### PR TITLE
Reduce layout shift by reserving space for dynamically loaded content

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -36,18 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
-function applyColorScheme() {
-    const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const htmlElement = document.documentElement;
-
-    if (isDarkMode) {
-        htmlElement.setAttribute('data-bs-theme', 'dark');
-    } else {
-        htmlElement.setAttribute('data-bs-theme', 'light');
-    }
-}
-applyColorScheme();
-
-window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
-    applyColorScheme();
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+    var d = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-bs-theme', d ? 'dark' : 'light');
 });

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -91,14 +91,6 @@
     }
 }
 
-@font-face {
-    font-family: "Nunito";
-    font-display: swap;
-    font-weight: 600;
-    font-style: normal;
-    src: url("https://fonts.googleapis.com/css2?family=Nunito:wght@600&display=swap");
-}
-
 .fira-code {
   font-family: "Fira Code", monospace;
   font-optical-sizing: auto;
@@ -15790,4 +15782,59 @@ fieldset:disabled .btn {
 
 .ql-toolbar .ql-picker {
     color: var(--bs-white);
+}
+
+/* ── Layout-shift reduction ── */
+
+/* HTMX placeholder: reserves space for content loaded via hx-trigger="load" */
+.hx-placeholder {
+    min-height: 120px;
+}
+
+/* Sidebar placeholder for dynamically loaded nav items */
+.sidebar-hx-placeholder {
+    min-height: 96px;
+}
+
+/* Subscribe button placeholder */
+.subscribe-placeholder {
+    min-height: 38px;
+    min-width: 110px;
+}
+
+/* Channel profile image container — prevent shift before image loads */
+.channel-picture-container {
+    aspect-ratio: 16 / 9;
+    max-height: 15vh;
+    overflow: hidden;
+}
+
+.channel-picture-container img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Medium page picture — maintain aspect ratio before load */
+.medium-picture {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: contain;
+}
+
+/* Media player container — reserve 16:9 space before player initializes */
+.player-container {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+}
+
+/* Limit reflow scope for cards that receive HTMX content */
+.card {
+    contain: layout style;
+}
+
+/* Prevent sidebar from shifting main content during HTMX load */
+.sidebar {
+    contain: layout style;
+    overflow: hidden;
 }

--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -22,7 +22,9 @@
                 <table>
                     <tr>
                         <td class="text-center">
-                            <img src="/source/{{ user.channel_picture.clone().unwrap() }}/picture.avif" style="max-height:15vh;">
+                            <div class="channel-picture-container d-inline-block">
+                                <img src="/source/{{ user.channel_picture.clone().unwrap() }}/picture.avif">
+                            </div>
                         </td>
                     </tr>
                     <tr>
@@ -38,7 +40,7 @@
             <div class="card py-3 px-3 text-white">
                 <h3 class="my-2 mx-3">Latest videos</h3>
                 <hr>
-                <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3" style="min-height:100vh;" preload="always">
+                <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:100vh;" preload="always">
                 </div>
             </div>
         </div>

--- a/templates/pages/component-dependencies.html
+++ b/templates/pages/component-dependencies.html
@@ -1,13 +1,17 @@
-<link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/fontawesome.min.css" rel="stylesheet">
-<link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/solid.min.css" rel="stylesheet">
+<script>
+(function(){var d=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;document.documentElement.setAttribute('data-bs-theme',d?'dark':'light');})();
+</script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/fontawesome.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/solid.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@600&family=Nunito:wght@600&family=Source+Serif+4:opsz,wght@8..60,600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <script src="https://cdn.jsdelivr.net/npm/htmx.org/dist/htmx.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/htmx-ext-preload/dist/preload.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets/highlight.min.js"></script>
 <link href="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets/styles/vs2015.min.css" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/quill@2/dist/quill.js" defer></script>
 <script src="/script.js" async></script>
-<link rel="stylesheet" href="/style.css" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/templates/pages/component-sidebar.html
+++ b/templates/pages/component-sidebar.html
@@ -18,7 +18,7 @@
                 Trending
             </a>
         </li>
-        <div hx-get="/hx/sidebar/{{ active_item }}" hx-swap="outerHTML" hx-trigger="load"></div>
+        <div hx-get="/hx/sidebar/{{ active_item }}" hx-swap="outerHTML" hx-trigger="load" class="sidebar-hx-placeholder"></div>
     </ul>
 </div>
 <div class="sidebarbackground" id="sidebarbackground"></div>

--- a/templates/pages/concepts.html
+++ b/templates/pages/concepts.html
@@ -19,7 +19,7 @@
             <div class="card py-3 px-3 text-white" style="min-height:100vh;">
                 <h3 class="my-2 mx-3">Concepts</h3>
                 <hr>
-                <div hx-get="/hx/studio/concepts" hx-trigger="load, every 30s" class="row mb-3" preload="always">
+                <div hx-get="/hx/studio/concepts" hx-trigger="load, every 30s" class="row mb-3 hx-placeholder" preload="always">
                 </div>
             </div>
         </div>

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -28,7 +28,7 @@
             <div class="card py-3 px-3 text-white" style="min-height:100vh;">
                 <h3 class="my-2 mx-3"><a href="/trending" class="text-decoration-none text-white" preload="mouseover">Trending</a></h3>
                 <hr>
-                <div hx-get="/hx/trending" hx-trigger="load" class="row mb-3" preload="always">
+                <div hx-get="/hx/trending" hx-trigger="load" class="row mb-3 hx-placeholder" preload="always">
                 </div>
             </div>
         </div>

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -87,7 +87,7 @@
         <div class="row maincontentrow g-3 py-2 ps-2" style="max-width: 99%">
             <div class="col-12 col-sm-12 col-md-12 col-lg-9">
                 <div class="card py-3 px-3 text-white" style="min-height: 85vh">
-                    <div class="d-flex justify-content-center">
+                    <div class="d-flex justify-content-center player-container">
                         {% if medium_type == "video" %}
                         <media-player
                             viewType="video"
@@ -157,7 +157,7 @@
                         {% else if medium_type == "picture" %}
                         <img
                             src="/source/{{ medium_id }}/picture.avif"
-                            style="width: 100%"
+                            class="medium-picture"
                         />
                         {% endif %}
                     </div>
@@ -189,7 +189,7 @@
                                     <div
                                         hx-get="/hx/subscribebutton/{{ medium_owner }}"
                                         hx-trigger="load"
-                                        class="col-sm"
+                                        class="col-sm subscribe-placeholder"
                                     ></div>
                                 </div>
                             </li>
@@ -321,6 +321,7 @@
                     <div
                         hx-get="/hx/comments/{{ medium_id }}"
                         hx-trigger="revealed"
+                        class="hx-placeholder"
                     ></div>
                 </div>
             </div>
@@ -331,6 +332,7 @@
                     <div
                         hx-get="/hx/reccomended/{{ medium_id }}"
                         hx-trigger="load"
+                        class="hx-placeholder"
                     ></div>
                 </div>
             </div>

--- a/templates/pages/studio.html
+++ b/templates/pages/studio.html
@@ -27,7 +27,7 @@
                     </div>
                 </div>
                 <hr>
-                <div hx-get="/hx/studio" hx-trigger="load" class="row mb-3" style="min-height:100vh;" preload="always">
+                <div hx-get="/hx/studio" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:100vh;" preload="always">
                 </div>
             </div>
         </div>

--- a/templates/pages/subscriptions.html
+++ b/templates/pages/subscriptions.html
@@ -29,7 +29,7 @@
                     <div
                         hx-get="/hx/subscriptions"
                         hx-trigger="load"
-                        class="row mb-3"
+                        class="row mb-3 hx-placeholder"
                         preload="always"
                     ></div>
                 </div>

--- a/templates/pages/trending.html
+++ b/templates/pages/trending.html
@@ -19,7 +19,7 @@
             <div class="card py-3 px-3 text-white" style="min-height:100vh;">
                 <h3 class="my-2 mx-3">Trending</h3>
                 <hr>
-                <div hx-get="/hx/trending" hx-trigger="load" class="row mb-3" preload="always">
+                <div hx-get="/hx/trending" hx-trigger="load" class="row mb-3 hx-placeholder" preload="always">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
This PR addresses cumulative layout shift (CLS) issues by reserving space for content that loads dynamically via HTMX and other asynchronous operations. The changes include adding placeholder styles, using CSS containment, and optimizing the color scheme initialization.

## Key Changes

- **Layout shift prevention**: Added CSS classes with `min-height` and `aspect-ratio` properties to reserve space for:
  - HTMX-loaded content (`.hx-placeholder`, `.sidebar-hx-placeholder`)
  - Subscribe buttons (`.subscribe-placeholder`)
  - Media players and images (`.player-container`, `.medium-picture`, `.channel-picture-container`)

- **CSS containment**: Applied `contain: layout style` to `.card` and `.sidebar` elements to limit reflow scope and prevent layout shifts in adjacent content

- **Removed unused font-face**: Deleted the `@font-face` rule for Nunito 600 weight (now loaded via Google Fonts link)

- **Simplified color scheme logic**: Refactored `applyColorScheme()` function to inline initialization in `component-dependencies.html` and simplified the media query listener in `script.js`

- **Improved resource loading order**: Reordered dependencies in `component-dependencies.html` to prioritize critical resources and added preconnect for CDN

- **Applied placeholder classes**: Updated all HTMX containers across templates (medium, channel, home, trending, studio, subscriptions, concepts) with appropriate placeholder classes

## Notable Implementation Details

- Color scheme is now initialized inline in the HTML head to prevent flash of unstyled content
- Media containers use `aspect-ratio` CSS property to maintain dimensions before content loads
- Sidebar and card containment prevents cascading layout shifts during HTMX updates
- All changes are CSS-based with minimal JavaScript modifications for better performance

https://claude.ai/code/session_01EFG81smADspGaFr1FWuUid