### PR TITLE
Add studio lists management page

### DIFF
--- a/.sqlx/query-6b3a34befc6ef441ba20b17c560c8796d6978dd3ab79e8ff31f516c806c51a40.json
+++ b/.sqlx/query-6b3a34befc6ef441ba20b17c560c8796d6978dd3ab79e8ff31f516c806c51a40.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT l.id, l.name, l.owner, l.public, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
+  "describe": {
+    "columns": [{"ordinal":0,"name":"id","type_info":"Varchar"},{"ordinal":1,"name":"name","type_info":"Varchar"},{"ordinal":2,"name":"owner","type_info":"Varchar"},{"ordinal":3,"name":"public","type_info":"Bool"},{"ordinal":4,"name":"item_count","type_info":"Int8"}],
+    "parameters": {
+      "Left": ["Varchar"]
+    },
+    "nullable": [false,false,false,false,true]
+  },
+  "hash": "6b3a34befc6ef441ba20b17c560c8796d6978dd3ab79e8ff31f516c806c51a40"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,8 @@ async fn main() {
         .route("/studio", get(studio))
         .route("/hx/studio", get(hx_studio))
         .route("/hx/studio/delete/{mediumid}", get(hx_delete_video))
+        .route("/studio/lists", get(studio_lists))
+        .route("/hx/studio/lists", get(hx_studio_lists))
         .route("/studio/concepts", get(concepts))
         .route("/hx/studio/concepts", get(hx_concepts))
         .route("/studio/concept/{conceptid}", get(concept))

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -64,6 +64,64 @@ async fn hx_studio(
     Html(minifi_html(template.render().unwrap()))
 }
 
+#[derive(Template)]
+#[template(path = "pages/studio-lists.html", escape = "none")]
+struct StudioListsTemplate {
+    sidebar: String,
+    config: Config,
+    common_headers: CommonHeaders,
+}
+async fn studio_lists(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+
+    let sidebar = generate_sidebar(&config, "studio".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = StudioListsTemplate {
+        sidebar,
+        config,
+        common_headers,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-studio-lists.html", escape = "none")]
+struct HXStudioListsTemplate {
+    lists: Vec<ListWithCount>,
+}
+async fn hx_studio_lists(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let user_info = user_info.unwrap();
+    let lists = sqlx::query_as!(
+        ListWithCount,
+        "SELECT l.id, l.name, l.owner, l.public, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
+        user_info.login
+    )
+    .fetch_all(&pool)
+    .await
+    .expect("Database error");
+    let template = HXStudioListsTemplate { lists };
+    Html(minifi_html(template.render().unwrap()))
+}
+
 async fn hx_delete_video(
     Extension(pool): Extension<PgPool>,
     Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,

--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -38,17 +38,23 @@
         </div>
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <div class="card py-3 px-3 text-white">
-                <h3 class="my-2 mx-3">Latest videos</h3>
-                <hr>
-                <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:100vh;" preload="always">
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
-            <div class="card py-3 px-3 text-white">
-                <h3 class="my-2 mx-3"><i class="fa-solid fa-list me-2"></i>Lists</h3>
-                <hr>
-                <div hx-get="/hx/userlists/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder">
+                <ul class="nav nav-tabs" role="tablist">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link active text-white" id="media-tab" data-bs-toggle="tab" data-bs-target="#media-tab-pane" type="button" role="tab" aria-controls="media-tab-pane" aria-selected="true"><i class="fa-solid fa-photo-film me-2"></i>Media</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link text-white" id="lists-tab" data-bs-toggle="tab" data-bs-target="#lists-tab-pane" type="button" role="tab" aria-controls="lists-tab-pane" aria-selected="false"><i class="fa-solid fa-list me-2"></i>Lists</button>
+                    </li>
+                </ul>
+                <div class="tab-content pt-3">
+                    <div class="tab-pane fade show active" id="media-tab-pane" role="tabpanel" aria-labelledby="media-tab">
+                        <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:50vh;" preload="always">
+                        </div>
+                    </div>
+                    <div class="tab-pane fade" id="lists-tab-pane" role="tabpanel" aria-labelledby="lists-tab">
+                        <div hx-get="/hx/userlists/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder">
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/pages/hx-studio-lists.html
+++ b/templates/pages/hx-studio-lists.html
@@ -1,0 +1,22 @@
+{% for list in lists %}
+<div class="col-xl-3 col-lg-4 col-6 my-3">
+    <div class="card p-3" style="min-height: 80px;">
+        <div class="d-flex justify-content-between align-items-start">
+            <a href="/list/{{ list.id }}" class="text-decoration-none" preload="mouseover">
+                <b class="text-white"><i class="fa-solid fa-list me-2"></i>{{ list.name }}</b>
+            </a>
+            <span hx-get="/hx/deletelist/{{ list.id }}" hx-confirm="Are you sure you want to delete this list?" class="text-secondary" style="cursor:pointer;" title="Delete list"><i class="fa-solid fa-trash"></i></span>
+        </div>
+        <p class="text-secondary mb-0">{{ list.item_count.unwrap_or(0) }} items
+            {% if list.public %}
+            <i class="fa-solid fa-globe ms-1" title="Public"></i>
+            {% else %}
+            <i class="fa-solid fa-lock ms-1" title="Private"></i>
+            {% endif %}
+        </p>
+    </div>
+</div>
+{% endfor %}
+{% if lists.is_empty() %}
+<p class="text-secondary text-center">No lists yet.</p>
+{% endif %}

--- a/templates/pages/studio-lists.html
+++ b/templates/pages/studio-lists.html
@@ -4,11 +4,11 @@
 <head>
     {% include "component-dependencies.html" %}
 
-    <title>Studio</title>
+    <title>Studio - Lists</title>
 
-    <meta property="og:title" content="{{ config.instancename }} Studio" />
+    <meta property="og:title" content="{{ config.instancename }} Studio - Lists" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://{{ common_headers.host }}/studio" />
+    <meta property="og:url" content="https://{{ common_headers.host }}/studio/lists" />
 </head>
 
 <body hx-ext="preload">
@@ -18,18 +18,16 @@
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <div class="card py-3 px-3 text-white" style="min-height:30vh;">
                 <div class="row justify-content-between">
-                    <h3 class="my-2 mx-3" style="width:200px;">Studio</h3>
+                    <h3 class="my-2 mx-3" style="width:200px;">Lists</h3>
                     <div style="width:400px;">
-                    <a href="/upload" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
-                            class="fa-solid fa-upload"></i>&nbsp;Upload</a>
+                    <a href="/studio" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
+                            class="fa-solid fa-photo-film"></i>&nbsp;Media</a>
                     <a href="/studio/concepts" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
                             class="fa-solid fa-wand-magic-sparkles"></i>&nbsp;Concepts</a>
-                    <a href="/studio/lists" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
-                            class="fa-solid fa-list"></i>&nbsp;Lists</a>
                     </div>
                 </div>
                 <hr>
-                <div hx-get="/hx/studio" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:100vh;" preload="always">
+                <div hx-get="/hx/studio/lists" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:100vh;" preload="always">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
This PR adds a new "Lists" management page to the studio section, allowing users to view and manage their created lists alongside existing media and concepts management.

## Key Changes
- **New Routes**: Added `/studio/lists` and `/hx/studio/lists` endpoints for displaying and managing user lists
- **New Templates**: 
  - `studio-lists.html` - Main page template with studio navigation and sidebar
  - `hx-studio-lists.html` - HTMX partial template rendering list cards with item counts and delete functionality
- **New Handler Functions**:
  - `studio_lists()` - Renders the main lists management page with authentication check
  - `hx_studio_lists()` - Fetches user's lists from database and returns HTML partial
- **Database Query**: Added SQL query to fetch lists with item counts, ordered by creation date
- **UI Updates**:
  - Added "Lists" button to studio navigation in `studio.html`
  - Refactored channel page to use Bootstrap tabs for organizing media and lists sections
- **Route Registration**: Registered new routes in `main.rs`

## Implementation Details
- Lists are fetched with a subquery counting associated items (`list_items`)
- Authentication is enforced on both endpoints
- Lists display includes item count, public/private status indicator, and delete action
- Empty state message shown when user has no lists
- Consistent styling with existing studio pages using card-based layout

https://claude.ai/code/session_01HVwLhtZ8DQHk2Ktz6P4doq