### PR TITLE
Refactor channel tabs to use HTMX instead of Bootstrap tabs

### DIFF
--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -38,22 +38,16 @@
         </div>
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <div class="card py-3 px-3 text-white">
-                <ul class="nav nav-tabs" role="tablist">
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link active text-white" id="media-tab" data-bs-toggle="tab" data-bs-target="#media-tab-pane" type="button" role="tab" aria-controls="media-tab-pane" aria-selected="true"><i class="fa-solid fa-photo-film me-2"></i>Media</button>
+                <ul class="nav nav-tabs">
+                    <li class="nav-item">
+                        <button class="nav-link active text-white" hx-get="/hx/usermedia/{{ user.login }}" hx-target="#tab-content" hx-swap="innerHTML" hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active')"><i class="fa-solid fa-photo-film me-2"></i>Media</button>
                     </li>
-                    <li class="nav-item" role="presentation">
-                        <button class="nav-link text-white" id="lists-tab" data-bs-toggle="tab" data-bs-target="#lists-tab-pane" type="button" role="tab" aria-controls="lists-tab-pane" aria-selected="false"><i class="fa-solid fa-list me-2"></i>Lists</button>
+                    <li class="nav-item">
+                        <button class="nav-link text-white" hx-get="/hx/userlists/{{ user.login }}" hx-target="#tab-content" hx-swap="innerHTML" hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active')"><i class="fa-solid fa-list me-2"></i>Lists</button>
                     </li>
                 </ul>
-                <div class="tab-content pt-3">
-                    <div class="tab-pane fade show active" id="media-tab-pane" role="tabpanel" aria-labelledby="media-tab">
-                        <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:50vh;" preload="always">
-                        </div>
-                    </div>
-                    <div class="tab-pane fade" id="lists-tab-pane" role="tabpanel" aria-labelledby="lists-tab">
-                        <div hx-get="/hx/userlists/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder">
-                        </div>
+                <div id="tab-content" class="pt-3">
+                    <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:50vh;" preload="always">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Replaced Bootstrap's native tab component with HTMX-based dynamic content loading for the channel media and lists tabs. This simplifies the tab implementation and enables server-driven content updates.

## Key Changes
- Removed Bootstrap tab markup (`role="tablist"`, `role="presentation"`, `role="tab"`, `aria-controls`, `aria-selected`, `data-bs-toggle`, `data-bs-target`)
- Replaced static tab panes with a single dynamic content container (`#tab-content`)
- Converted tab buttons to use HTMX attributes:
  - `hx-get` to fetch content from `/hx/usermedia/` and `/hx/userlists/` endpoints
  - `hx-target="#tab-content"` to render responses into the shared container
  - `hx-swap="innerHTML"` to replace container contents
  - `hx-on:click` to handle active tab styling (removes active class from all tabs, adds to clicked tab)
- Removed nested tab pane divs and consolidated to a single content area
- Moved the initial media load trigger (`hx-trigger="load"`) to the container div

## Implementation Details
- Active tab state is now managed via JavaScript click handlers rather than Bootstrap's tab plugin
- Content is loaded on-demand when tabs are clicked, with the media tab pre-loading on page load
- The solution reduces HTML boilerplate and leverages HTMX for progressive enhancement

https://claude.ai/code/session_01Fif7raWN9UkQRScFwPaTuB