### PR TITLE
Add comment creation and pagination to media pages

### DIFF
--- a/.sqlx/query-3b57eaec444de11f471b2fa1c2f52c8bebfd5977412ee5045d49361d5e4971ab.json
+++ b/.sqlx/query-3b57eaec444de11f471b2fa1c2f52c8bebfd5977412ee5045d49361d5e4971ab.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO comments (media, \"user\", text) VALUES ($1, $2, $3) RETURNING id, \"user\", text, time;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "user",
+        "type_info": "Name"
+      },
+      {
+        "ordinal": 2,
+        "name": "text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "time",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      false,
+      false
+    ]
+  },
+  "hash": "3b57eaec444de11f471b2fa1c2f52c8bebfd5977412ee5045d49361d5e4971ab"
+}

--- a/.sqlx/query-fae9d5b5477235c5567aba3b6624d63f811abb6fb9867c7e5cf68b8c5507135b.json
+++ b/.sqlx/query-fae9d5b5477235c5567aba3b6624d63f811abb6fb9867c7e5cf68b8c5507135b.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id,user,text,time FROM comments WHERE media=$1 ORDER BY time DESC LIMIT $2 OFFSET $3;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "user",
+        "type_info": "Name"
+      },
+      {
+        "ordinal": 2,
+        "name": "text",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "time",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      false,
+      false
+    ]
+  },
+  "hash": "fae9d5b5477235c5567aba3b6624d63f811abb6fb9867c7e5cf68b8c5507135b"
+}

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -5,24 +5,90 @@ struct Comment {
     text: String,
     time: i64,
 }
+
+#[derive(Deserialize)]
+struct CommentsQuery {
+    page: Option<i64>,
+}
+
 #[derive(Template)]
 #[template(path = "pages/hx-comments.html", escape = "none")]
 struct HXCommentsTemplate {
     comments: Vec<Comment>,
+    medium_id: String,
+    next_page: Option<i64>,
 }
+
+const COMMENTS_PER_PAGE: i64 = 20;
+
 async fn hx_comments(
     Extension(pool): Extension<PgPool>,
     Path(mediumid): Path<String>,
+    axum::extract::Query(query): axum::extract::Query<CommentsQuery>,
 ) -> axum::response::Html<Vec<u8>> {
+    let page = query.page.unwrap_or(0);
+    let offset = page * COMMENTS_PER_PAGE;
+
     let comments = sqlx::query_as!(
         Comment,
-        "SELECT id,user,text,time FROM comments WHERE media=$1;",
-        mediumid
+        "SELECT id,user,text,time FROM comments WHERE media=$1 ORDER BY time DESC LIMIT $2 OFFSET $3;",
+        mediumid,
+        COMMENTS_PER_PAGE + 1,
+        offset
     )
     .fetch_all(&pool)
     .await
     .expect("Database error");
 
-    let template = HXCommentsTemplate { comments };
+    let has_more = comments.len() as i64 > COMMENTS_PER_PAGE;
+    let comments: Vec<Comment> = comments.into_iter().take(COMMENTS_PER_PAGE as usize).collect();
+    let next_page = if has_more { Some(page + 1) } else { None };
+
+    let template = HXCommentsTemplate {
+        comments,
+        medium_id: mediumid,
+        next_page,
+    };
     Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Deserialize)]
+struct CommentForm {
+    text: String,
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-comment-single.html", escape = "none")]
+struct HXCommentSingleTemplate {
+    comment: Comment,
+}
+
+async fn hx_add_comment(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    Form(form): Form<CommentForm>,
+) -> impl IntoResponse {
+    let user = get_user_login(headers, &pool, session_store).await;
+
+    if user.is_none() {
+        return (StatusCode::UNAUTHORIZED, Html(Vec::new()));
+    }
+
+    let user = user.unwrap();
+
+    let comment = sqlx::query_as!(
+        Comment,
+        r#"INSERT INTO comments (media, "user", text) VALUES ($1, $2, $3) RETURNING id, "user", text, time;"#,
+        mediumid,
+        user.login,
+        form.text
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("Database error");
+
+    let template = HXCommentSingleTemplate { comment };
+    (StatusCode::OK, Html(minifi_html(template.render().unwrap())))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ async fn main() {
             get(medium_description_prepare),
         )
         .route("/hx/comments/{mediumid}", get(hx_comments))
+        .route("/hx/comments/{mediumid}/add", post(hx_add_comment))
         .route("/hx/reccomended/{mediumid}", get(hx_recommended))
         .route("/hx/new_view/{mediumid}", get(hx_new_view))
         .route("/hx/like/{mediumid}", get(hx_like))

--- a/templates/pages/hx-comment-single.html
+++ b/templates/pages/hx-comment-single.html
@@ -1,4 +1,3 @@
-{% for comment in comments %}
 <div class="comment-item my-3 p-3" style="border-left: 3px solid var(--bs-secondary); border-radius: 4px;">
     <div class="d-flex align-items-center mb-2">
         <a href="/channel/{{ comment.user.clone().unwrap() }}" class="text-decoration-none">
@@ -7,14 +6,3 @@
     </div>
     <div class="comment-content ql-editor p-0" style="min-height: auto;">{{ comment.text }}</div>
 </div>
-{% endfor %}
-{% match next_page %}
-{% when Some with (page) %}
-<div
-    hx-get="/hx/comments/{{ medium_id }}?page={{ page }}"
-    hx-trigger="revealed"
-    hx-swap="outerHTML"
-    class="hx-placeholder"
-></div>
-{% when None %}
-{% endmatch %}

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -328,7 +328,67 @@
                 >
                     <h3 class="my-2">Comments</h3>
                     <hr />
+                    {% if is_logged_in %}
+                    <div class="mb-3">
+                        <div id="comment_editor" style="height: 120px;"></div>
+                        <input type="hidden" id="comment_text" />
+                        <button
+                            id="comment_submit_btn"
+                            class="btn btn-primary mt-2"
+                            type="button"
+                        >
+                            Comment
+                        </button>
+                    </div>
+                    <hr />
+                    <script>
+                        document.addEventListener("DOMContentLoaded", function () {
+                            const commentQuill = new Quill("#comment_editor", {
+                                theme: "snow",
+                                placeholder: "Write a comment...",
+                                modules: {
+                                    toolbar: [
+                                        ["bold", "italic", "underline", "strike"],
+                                        ["link", "code-block"],
+                                        [{ list: "ordered" }, { list: "bullet" }],
+                                    ],
+                                },
+                            });
+
+                            const submitBtn = document.getElementById("comment_submit_btn");
+                            submitBtn.addEventListener("click", function () {
+                                const text = commentQuill.getText().trim();
+                                if (text.length === 0) return;
+
+                                const html = commentQuill.getSemanticHTML();
+                                const formData = new FormData();
+                                formData.append("text", html);
+
+                                submitBtn.disabled = true;
+                                fetch("/hx/comments/{{ medium_id }}/add", {
+                                    method: "POST",
+                                    body: new URLSearchParams(formData),
+                                })
+                                    .then((response) => {
+                                        if (!response.ok) throw new Error("Failed to post comment");
+                                        return response.text();
+                                    })
+                                    .then((html) => {
+                                        const commentsList = document.getElementById("comments-list");
+                                        commentsList.insertAdjacentHTML("afterbegin", html);
+                                        commentQuill.setText("");
+                                        submitBtn.disabled = false;
+                                    })
+                                    .catch((err) => {
+                                        console.error(err);
+                                        submitBtn.disabled = false;
+                                    });
+                            });
+                        });
+                    </script>
+                    {% endif %}
                     <div
+                        id="comments-list"
                         hx-get="/hx/comments/{{ medium_id }}"
                         hx-trigger="revealed"
                         class="hx-placeholder"


### PR DESCRIPTION
## Summary
This PR adds the ability for logged-in users to create comments on media pages and implements pagination for the comments section. Comments are now displayed in reverse chronological order with a "load more" mechanism.

## Key Changes
- **Comment Creation**: Added `hx_add_comment` endpoint that allows authenticated users to submit comments using a rich text editor (Quill.js)
- **Comment Pagination**: Implemented pagination with 20 comments per page, including a "load more" trigger that appears when additional comments exist
- **UI Improvements**: 
  - Enhanced comment display with styled containers and user profile links
  - Added rich text editor for comment composition with formatting options (bold, italic, links, lists, etc.)
  - Comments now render with proper HTML formatting using Quill's semantic HTML output
- **Database Queries**: Updated comment retrieval to include ordering by time (DESC) and limit/offset for pagination
- **Authentication**: Comment submission requires user authentication, returning 401 Unauthorized if user is not logged in

## Implementation Details
- Comments are fetched with `LIMIT COMMENTS_PER_PAGE + 1` to detect if more comments exist beyond the current page
- New comments are inserted at the top of the comments list via JavaScript fetch
- The comment form is only displayed to logged-in users via template conditional
- Comment text is stored as HTML from the Quill editor, allowing rich formatting preservation
- Pagination uses HTMX's `hx-trigger="revealed"` for lazy loading additional comments

https://claude.ai/code/session_011JiDvzw4XEJRjydbXbEojZ