### PR TITLE
Wrap media and list grids with row container for proper layout

### DIFF
--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -47,7 +47,7 @@
                     </li>
                 </ul>
                 <div id="tab-content" class="pt-3">
-                    <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="row mb-3 hx-placeholder" style="min-height:50vh;" preload="always">
+                    <div hx-get="/hx/usermedia/{{ user.login }}" hx-trigger="load" class="mb-3 hx-placeholder" style="min-height:50vh;" preload="always">
                     </div>
                 </div>
             </div>

--- a/templates/pages/hx-userlists.html
+++ b/templates/pages/hx-userlists.html
@@ -1,3 +1,4 @@
+<div class="row">
 {% for list in lists %}
 <div class="col-xl-3 col-lg-4 col-6 my-3">
     <a href="/list/{{ list.id }}" class="text-decoration-none" preload="mouseover">
@@ -8,6 +9,7 @@
     </a>
 </div>
 {% endfor %}
+</div>
 {% if lists.is_empty() %}
 <p class="text-secondary text-center">No public lists.</p>
 {% endif %}

--- a/templates/pages/hx-usermedia.html
+++ b/templates/pages/hx-usermedia.html
@@ -1,3 +1,4 @@
+<div class="row">
 {% for medium in usermedia %}
 <div class="col-xl-2 col-lg-4 col-6 my-3 d-flex justify-content-center">
     <a href="/m/{{ medium.id }}" class="text-decoration-none" preload="mouseover">
@@ -28,3 +29,4 @@
     </a>
 </div>
 {% endfor %}
+</div>


### PR DESCRIPTION
## Summary
This PR fixes the grid layout structure by wrapping media and list items with Bootstrap's `row` class container, and removes the redundant `row` class from the parent container that loads the media grid.

## Key Changes
- **hx-usermedia.html**: Wrapped the media grid items with a `<div class="row">` container to properly structure the Bootstrap grid layout
- **hx-userlists.html**: Wrapped the list items with a `<div class="row">` container for consistent grid structure
- **channel.html**: Removed the `row` class from the parent container that dynamically loads the user media, since the row wrapper is now included in the loaded template itself

## Implementation Details
The changes follow Bootstrap grid best practices by ensuring that column elements (`col-*` classes) are always direct children of a `row` container. Previously, the `row` class was applied to the parent container that received the HTMX-loaded content, but now it's properly defined within the loaded templates themselves. This provides better separation of concerns and ensures the grid structure is self-contained within each template.

https://claude.ai/code/session_01KRNZkWVhpZLqsqj7s8LMK1