### PR TITLE
Add media editing interface to studio

### DIFF
--- a/.sqlx/query-479af27bfb4fd6f0214e562edcb224b40c3d70d571becea5ee3177f775685d40.json
+++ b/.sqlx/query-479af27bfb4fd6f0214e562edcb224b40c3d70d571becea5ee3177f775685d40.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE media SET name=$1, description=$2, public=$3 WHERE id=$4;",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Jsonb",
+        "Bool",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "479af27bfb4fd6f0214e562edcb224b40c3d70d571becea5ee3177f775685d40"
+}

--- a/.sqlx/query-7445b68b52a7ef2f0f45bd2ee3c8f57f291d230df43025cf4c70966003544813.json
+++ b/.sqlx/query-7445b68b52a7ef2f0f45bd2ee3c8f57f291d230df43025cf4c70966003544813.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id,name,owner,public FROM media WHERE id=$1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "public",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7445b68b52a7ef2f0f45bd2ee3c8f57f291d230df43025cf4c70966003544813"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,8 @@ async fn main() {
         .route("/hx/usermedia/{userid}", get(hx_usermedia))
         .route("/studio", get(studio))
         .route("/hx/studio", get(hx_studio))
+        .route("/studio/edit/{mediumid}", get(studio_edit))
+        .route("/studio/edit/{mediumid}", post(studio_edit_save))
         .route("/hx/studio/delete/{mediumid}", get(hx_delete_video))
         .route("/studio/lists", get(studio_lists))
         .route("/hx/studio/lists", get(hx_studio_lists))

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -122,6 +122,130 @@ async fn hx_studio_lists(
     Html(minifi_html(template.render().unwrap()))
 }
 
+#[derive(Serialize, Deserialize)]
+struct MediumEdit {
+    id: String,
+    name: String,
+    public: bool,
+}
+#[derive(Template)]
+#[template(path = "pages/studio-edit.html", escape = "none")]
+struct StudioEditTemplate {
+    sidebar: String,
+    config: Config,
+    medium: MediumEdit,
+    common_headers: CommonHeaders,
+}
+async fn studio_edit(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let user_info = user_info.unwrap();
+
+    let medium = sqlx::query!(
+        "SELECT id,name,owner,public FROM media WHERE id=$1;",
+        mediumid
+    )
+    .fetch_one(&pool)
+    .await;
+
+    match medium {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Html(minifi_html(
+                    "<script>window.location.replace(\"/studio\");</script>".to_owned(),
+                ));
+            }
+            let sidebar = generate_sidebar(&config, "studio".to_owned());
+            let common_headers = extract_common_headers(&headers).unwrap();
+            let template = StudioEditTemplate {
+                sidebar,
+                config,
+                medium: MediumEdit {
+                    id: record.id,
+                    name: record.name,
+                    public: record.public,
+                },
+                common_headers,
+            };
+            Html(minifi_html(template.render().unwrap()))
+        }
+        Err(_) => Html(minifi_html(
+            "<script>window.location.replace(\"/studio\");</script>".to_owned(),
+        )),
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct EditForm {
+    medium_name: String,
+    medium_description: String,
+    medium_visibility: String,
+}
+async fn studio_edit_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    Form(form): Form<EditForm>,
+) -> axum::response::Html<String> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
+            }
+        }
+        Err(_) => {
+            return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
+        }
+    }
+
+    let ispublic = form.medium_visibility == "public";
+    let description: serde_json::Value =
+        serde_json::from_str(&form.medium_description).unwrap_or(serde_json::Value::Null);
+
+    let update_result = sqlx::query!(
+        "UPDATE media SET name=$1, description=$2, public=$3 WHERE id=$4;",
+        form.medium_name,
+        description,
+        ispublic,
+        mediumid
+    )
+    .execute(&pool)
+    .await;
+
+    if update_result.is_err() {
+        return Html(format!(
+            "<b class=\"text-danger\">Failed to save changes.</b><script>setTimeout(function(){{window.location.replace(\"/studio/edit/{}\");}},2000);</script>",
+            mediumid
+        ));
+    }
+
+    Html(format!(
+        "<script>window.location.replace(\"/studio/edit/{}\");</script>",
+        mediumid
+    ))
+}
+
 async fn hx_delete_video(
     Extension(pool): Extension<PgPool>,
     Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,

--- a/templates/pages/hx-studio.html
+++ b/templates/pages/hx-studio.html
@@ -1,7 +1,7 @@
 {% for medium in media %}
 <div class="col-xl-2 col-lg-4 col-6 my-3 d-flex justify-content-center">
     <a
-        href="/m/{{ medium.id }}"
+        href="/studio/edit/{{ medium.id }}"
         class="text-decoration-none"
         preload="mouseover"
     >
@@ -29,6 +29,9 @@
                         <i class="fa-solid fa-image fa-sm ms-1"></i>
                         {% endif %}
                     </p>
+                    <span class="text-secondary" style="font-size: 0.8em;">
+                        <i class="fa-solid fa-pen-to-square fa-sm"></i> Edit
+                    </span>
                 </td>
             </tr>
         </table>

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html>
+    <head>
+        {% include "component-dependencies.html" %}
+
+        <title>Edit - {{ medium.name }}</title>
+
+        <meta property="og:title" content="{{ config.instancename }} Studio" />
+        <meta property="og:type" content="website" />
+        <meta
+            property="og:url"
+            content="https://{{ common_headers.host }}/studio/edit/{{ medium.id }}"
+        />
+    </head>
+
+    <body hx-ext="preload">
+        {{ sidebar }} {% include "component-navbar.html" %}
+        <div class="row maincontentrow g-3 py-2 ps-2" style="max-width: 99%">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+                <div class="card py-3 px-3 text-white" style="min-height: 80vh">
+                    <div class="row justify-content-between align-items-center">
+                        <h3 class="my-2 mx-3" style="width: auto">Edit Media</h3>
+                        <div style="width: auto">
+                            <a href="/studio" class="btn btn-secondary mx-1" preload="mouseover">
+                                <i class="fa-solid fa-arrow-left"></i>&nbsp;Back to Studio
+                            </a>
+                            <a href="/m/{{ medium.id }}" class="btn btn-primary mx-1" preload="mouseover">
+                                <i class="fa-solid fa-eye"></i>&nbsp;View
+                            </a>
+                        </div>
+                    </div>
+                    <hr />
+                    <form
+                        action="/studio/edit/{{ medium.id }}"
+                        method="post"
+                        class="mx-3"
+                        id="edit-form"
+                    >
+                        <div class="form-group row my-3">
+                            <label for="medium_id_display" class="col-4 col-form-label"
+                                >URL</label
+                            >
+                            <div class="col-8">
+                                <div class="input-group">
+                                    <input
+                                        id="medium_id_display"
+                                        type="text"
+                                        class="form-control"
+                                        value="{{ medium.id }}"
+                                        disabled
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group row my-3">
+                            <label
+                                for="medium_name"
+                                class="col-4 col-form-label"
+                                >Name</label
+                            >
+                            <div class="col-8">
+                                <input
+                                    id="medium_name"
+                                    name="medium_name"
+                                    type="text"
+                                    class="form-control"
+                                    required
+                                    value="{{ medium.name }}"
+                                />
+                            </div>
+                        </div>
+                        <div class="form-group row my-3">
+                            <label
+                                for="medium_description"
+                                class="col-4 col-form-label"
+                                >Description</label
+                            >
+                            <div class="col-8">
+                                <div
+                                    id="medium_description_editor"
+                                    style="height: 50vh"
+                                ></div>
+                                <input
+                                    type="hidden"
+                                    name="medium_description"
+                                    id="medium_description"
+                                />
+                            </div>
+                        </div>
+                        <script>
+                        document.addEventListener('DOMContentLoaded', function() {
+                            let quill = new Quill('#medium_description_editor', {
+                                theme: 'snow'
+                            });
+
+                            // Load existing description
+                            fetch('/m/{{ medium.id }}/description.json')
+                                .then(function(response) {
+                                    if (!response.ok) throw new Error('Failed to load description');
+                                    return response.json();
+                                })
+                                .then(function(data) {
+                                    quill.setContents(data);
+                                })
+                                .catch(function(err) {
+                                    console.error('Could not load existing description:', err);
+                                });
+
+                            const editForm = document.getElementById('edit-form');
+
+                            editForm.addEventListener('submit', function(e) {
+                                let descriptionInput = document.getElementById('medium_description');
+                                let delta = quill.getContents();
+                                descriptionInput.value = JSON.stringify(delta);
+                            });
+                        });
+                        </script>
+                        <div class="form-group row my-3">
+                            <label
+                                for="medium_visibility"
+                                class="col-4 col-form-label"
+                                >Visibility</label
+                            >
+                            <div class="col-8">
+                                <select
+                                    id="medium_visibility"
+                                    name="medium_visibility"
+                                    class="form-select"
+                                    required
+                                >
+                                    <option value="public" {% if medium.public %}selected{% endif %}>
+                                        Public
+                                    </option>
+                                    <option value="hidden" {% if !medium.public %}selected{% endif %}>
+                                        Hidden
+                                    </option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group row my-3">
+                            <div class="offset-4 col-8">
+                                <button
+                                    name="submit"
+                                    type="submit"
+                                    class="btn btn-primary"
+                                >
+                                    <i class="fa-solid fa-floppy-disk"></i>&nbsp;Save Changes
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    <hr />
+                    <div class="mx-3">
+                        <h5 class="text-danger">Danger Zone</h5>
+                        <button
+                            class="btn btn-outline-danger mt-2"
+                            data-bs-toggle="modal"
+                            data-bs-target="#deleteModal"
+                        >
+                            <i class="fa-solid fa-trash"></i>&nbsp;Delete Media
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete Confirmation Modal -->
+        <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="deleteModalLabel">Delete Media</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        Are you sure you want to delete <b>{{ medium.name }}</b>? This action cannot be undone. All comments and list entries associated with this media will also be removed.
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button
+                            class="btn btn-danger"
+                            hx-get="/hx/studio/delete/{{ medium.id }}"
+                            hx-target="body"
+                        >
+                            <i class="fa-solid fa-trash"></i>&nbsp;Delete
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
This PR adds a complete media editing interface to the studio, allowing users to edit their uploaded media's name, description, visibility, and delete media with confirmation.

## Key Changes
- **New edit page template** (`studio-edit.html`): Full-featured editing interface with:
  - Read-only URL/ID display
  - Editable name field
  - Rich text description editor using Quill.js
  - Visibility toggle (Public/Hidden)
  - Save changes button
  - Delete confirmation modal with safety warnings

- **Backend handlers** in `src/studio.rs`:
  - `studio_edit()`: GET handler that displays the edit form, with ownership verification
  - `studio_edit_save()`: POST handler that processes form submissions and updates the database
  - Proper authorization checks to ensure only media owners can edit their content

- **Database queries**: Added SQLx prepared statements for:
  - Fetching media details by ID
  - Updating media name, description, and visibility

- **UI/UX improvements**:
  - Updated studio media grid to link to edit pages instead of direct media view
  - Added visual "Edit" indicator on media cards
  - Navigation buttons to switch between edit view and media preview

- **Route registration** in `src/main.rs`:
  - `/studio/edit/{mediumid}` GET route
  - `/studio/edit/{mediumid}` POST route

## Implementation Details
- Description data is serialized as JSON (Quill Delta format) for rich text support
- Ownership verification prevents unauthorized edits
- Form submission redirects back to edit page on success or shows error message on failure
- Delete functionality uses HTSX for seamless modal interaction

https://claude.ai/code/session_01Le83rnb4vYfRViZhGiA2ab