### PR TITLE
Add chapter management for video and audio media

### DIFF
--- a/.sqlx/query-a183b0e4e447dee8eb11a5ff1670eeb5a724e98d8f147d34a4439a4da8d53ae3.json
+++ b/.sqlx/query-a183b0e4e447dee8eb11a5ff1670eeb5a724e98d8f147d34a4439a4da8d53ae3.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id,name,owner,public,type FROM media WHERE id=$1;",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "owner",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "type",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a183b0e4e447dee8eb11a5ff1670eeb5a724e98d8f147d34a4439a4da8d53ae3"
+}

--- a/src/chapters.rs
+++ b/src/chapters.rs
@@ -1,0 +1,235 @@
+#[derive(Serialize, Deserialize, Clone)]
+struct ChapterData {
+    start: String,
+    title: String,
+}
+
+async fn studio_chapters_get(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> Json<serde_json::Value> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Json(serde_json::Value::Array(vec![]));
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Json(serde_json::Value::Array(vec![]));
+            }
+        }
+        Err(_) => {
+            return Json(serde_json::Value::Array(vec![]));
+        }
+    }
+
+    let vtt_path = format!("source/{}/chapters.vtt", mediumid);
+    match tokio::fs::read_to_string(&vtt_path).await {
+        Ok(content) => {
+            let chapters = parse_webvtt_chapters(&content);
+            Json(serde_json::to_value(chapters).unwrap_or(serde_json::Value::Array(vec![])))
+        }
+        Err(_) => Json(serde_json::Value::Array(vec![])),
+    }
+}
+
+async fn studio_chapters_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    Json(chapters): Json<Vec<ChapterData>>,
+) -> Response<Body> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"not logged in\"}"))
+            .unwrap();
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"not authorized\"}"))
+                    .unwrap();
+            }
+        }
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"media not found\"}"))
+                .unwrap();
+        }
+    }
+
+    let vtt_path = format!("source/{}/chapters.vtt", mediumid);
+
+    if chapters.is_empty() {
+        let _ = tokio::fs::remove_file(&vtt_path).await;
+        return Response::builder()
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"ok\":true}"))
+            .unwrap();
+    }
+
+    let vtt_content = generate_webvtt_from_chapters(&chapters);
+    match tokio::fs::write(&vtt_path, vtt_content).await {
+        Ok(_) => Response::builder()
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"ok\":true}"))
+            .unwrap(),
+        Err(_) => Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"failed to save\"}"))
+            .unwrap(),
+    }
+}
+
+fn parse_webvtt_chapters(content: &str) -> Vec<ChapterData> {
+    let mut chapters = Vec::new();
+    let mut lines = content.lines().peekable();
+
+    // Skip until WEBVTT header
+    let mut found_header = false;
+    while let Some(line) = lines.next() {
+        if line.trim().starts_with("WEBVTT") {
+            found_header = true;
+            break;
+        }
+    }
+    if !found_header {
+        return chapters;
+    }
+
+    loop {
+        // Find next timestamp line, skipping empty lines and cue identifiers
+        let mut timestamp_line = None;
+        while let Some(line) = lines.next() {
+            let trimmed = line.trim();
+            if trimmed.contains("-->") {
+                timestamp_line = Some(trimmed.to_string());
+                break;
+            }
+        }
+
+        let Some(ts_line) = timestamp_line else {
+            break;
+        };
+
+        let parts: Vec<&str> = ts_line.split("-->").collect();
+        if parts.len() != 2 {
+            continue;
+        }
+
+        let start = parts[0].trim().to_string();
+
+        // Collect title lines until empty line or end
+        let mut title = String::new();
+        while let Some(line) = lines.peek() {
+            if line.trim().is_empty() {
+                break;
+            }
+            if !title.is_empty() {
+                title.push(' ');
+            }
+            title.push_str(lines.next().unwrap().trim());
+        }
+
+        if !title.is_empty() {
+            chapters.push(ChapterData { start, title });
+        }
+    }
+
+    chapters
+}
+
+fn timestamp_to_seconds(ts: &str) -> f64 {
+    let ts = ts.trim();
+    let (time_part, ms_str) = if let Some(dot_pos) = ts.rfind('.') {
+        (&ts[..dot_pos], &ts[dot_pos + 1..])
+    } else {
+        (ts, "0")
+    };
+
+    let parts: Vec<&str> = time_part.split(':').collect();
+    let (h, m, s) = match parts.len() {
+        3 => (
+            parts[0].parse::<f64>().unwrap_or(0.0),
+            parts[1].parse::<f64>().unwrap_or(0.0),
+            parts[2].parse::<f64>().unwrap_or(0.0),
+        ),
+        2 => (
+            0.0,
+            parts[0].parse::<f64>().unwrap_or(0.0),
+            parts[1].parse::<f64>().unwrap_or(0.0),
+        ),
+        1 => (
+            0.0,
+            0.0,
+            parts[0].parse::<f64>().unwrap_or(0.0),
+        ),
+        _ => (0.0, 0.0, 0.0),
+    };
+
+    let ms = ms_str.parse::<f64>().unwrap_or(0.0)
+        / 10f64.powi(ms_str.len() as i32);
+
+    h * 3600.0 + m * 60.0 + s + ms
+}
+
+fn normalize_vtt_timestamp(ts: &str) -> String {
+    let seconds = timestamp_to_seconds(ts);
+    let total_secs = seconds.floor() as u64;
+    let ms = ((seconds - seconds.floor()) * 1000.0).round() as u64;
+    let h = total_secs / 3600;
+    let m = (total_secs % 3600) / 60;
+    let s = total_secs % 60;
+    format!("{:02}:{:02}:{:02}.{:03}", h, m, s, ms)
+}
+
+fn generate_webvtt_from_chapters(chapters: &[ChapterData]) -> String {
+    let mut sorted: Vec<ChapterData> = chapters.to_vec();
+    sorted.sort_by(|a, b| {
+        timestamp_to_seconds(&a.start)
+            .partial_cmp(&timestamp_to_seconds(&b.start))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let mut vtt = String::from("WEBVTT\n\n");
+
+    for i in 0..sorted.len() {
+        let start = normalize_vtt_timestamp(&sorted[i].start);
+        let end = if i + 1 < sorted.len() {
+            normalize_vtt_timestamp(&sorted[i + 1].start)
+        } else {
+            "99:59:59.000".to_string()
+        };
+
+        vtt.push_str(&format!(
+            "{} --> {}\n{}\n\n",
+            start, end, sorted[i].title
+        ));
+    }
+
+    vtt
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,8 @@ async fn main() {
         .route("/hx/studio", get(hx_studio))
         .route("/studio/edit/{mediumid}", get(studio_edit))
         .route("/studio/edit/{mediumid}", post(studio_edit_save))
+        .route("/studio/edit/{mediumid}/chapters.json", get(studio_chapters_get))
+        .route("/studio/edit/{mediumid}/chapters", post(studio_chapters_save))
         .route("/hx/studio/delete/{mediumid}", get(hx_delete_video))
         .route("/studio/lists", get(studio_lists))
         .route("/hx/studio/lists", get(hx_studio_lists))
@@ -138,6 +140,7 @@ include!("home.rs");
 include!("search.rs");
 include!("channel.rs");
 include!("studio.rs");
+include!("chapters.rs");
 include!("upload.rs");
 include!("concept.rs");
 include!("serve.rs");

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -127,6 +127,7 @@ struct MediumEdit {
     id: String,
     name: String,
     public: bool,
+    medium_type: String,
 }
 #[derive(Template)]
 #[template(path = "pages/studio-edit.html", escape = "none")]
@@ -152,7 +153,7 @@ async fn studio_edit(
     let user_info = user_info.unwrap();
 
     let medium = sqlx::query!(
-        "SELECT id,name,owner,public FROM media WHERE id=$1;",
+        "SELECT id,name,owner,public,type FROM media WHERE id=$1;",
         mediumid
     )
     .fetch_one(&pool)
@@ -174,6 +175,7 @@ async fn studio_edit(
                     id: record.id,
                     name: record.name,
                     public: record.public,
+                    medium_type: record.r#type,
                 },
                 common_headers,
             };

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -146,6 +146,13 @@
                             autoplay
                         >
                             <media-provider>
+                                {% if medium_chapters_exist %}
+                                <track
+                                    src="/source/{{ medium_id }}/chapters.vtt"
+                                    kind="chapters"
+                                    default
+                                />
+                                {% endif %}
                                 <media-poster
                                     class="vds-poster"
                                     src="/source/{{ medium_id }}/thumbnail.avif"

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -149,6 +149,162 @@
                             </div>
                         </div>
                     </form>
+                    {% if medium.medium_type == "video" || medium.medium_type == "audio" %}
+                    <hr />
+                    <div class="mx-3">
+                        <h5><i class="fa-solid fa-list-ol"></i>&nbsp;Chapters</h5>
+                        <p class="text-secondary">Add chapters to help viewers navigate your media. Enter a start time and title for each chapter.</p>
+                        <div id="chapters-editor">
+                            <div class="table-responsive">
+                                <table class="table table-dark table-hover" id="chapters-table">
+                                    <thead>
+                                        <tr>
+                                            <th style="width: 180px">Start Time</th>
+                                            <th>Title</th>
+                                            <th style="width: 80px"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="chapters-tbody">
+                                    </tbody>
+                                </table>
+                            </div>
+                            <p class="text-secondary" id="no-chapters-msg">No chapters yet. Click "Add Chapter" to get started.</p>
+                            <div class="d-flex gap-2">
+                                <button type="button" class="btn btn-secondary" id="add-chapter-btn">
+                                    <i class="fa-solid fa-plus"></i>&nbsp;Add Chapter
+                                </button>
+                                <button type="button" class="btn btn-primary" id="save-chapters-btn">
+                                    <i class="fa-solid fa-floppy-disk"></i>&nbsp;Save Chapters
+                                </button>
+                            </div>
+                            <div id="chapters-status" class="mt-2"></div>
+                        </div>
+                    </div>
+                    <script>
+                    document.addEventListener('DOMContentLoaded', function() {
+                        var chapters = [];
+
+                        function renderChapters() {
+                            var tbody = document.getElementById('chapters-tbody');
+                            var noMsg = document.getElementById('no-chapters-msg');
+                            tbody.innerHTML = '';
+
+                            if (chapters.length === 0) {
+                                noMsg.style.display = '';
+                                document.getElementById('chapters-table').style.display = 'none';
+                                return;
+                            }
+                            noMsg.style.display = 'none';
+                            document.getElementById('chapters-table').style.display = '';
+
+                            chapters.forEach(function(ch, idx) {
+                                var tr = document.createElement('tr');
+
+                                var tdStart = document.createElement('td');
+                                var inputStart = document.createElement('input');
+                                inputStart.type = 'text';
+                                inputStart.className = 'form-control form-control-sm';
+                                inputStart.value = ch.start;
+                                inputStart.placeholder = '00:00:00';
+                                tdStart.appendChild(inputStart);
+
+                                var tdTitle = document.createElement('td');
+                                var inputTitle = document.createElement('input');
+                                inputTitle.type = 'text';
+                                inputTitle.className = 'form-control form-control-sm';
+                                inputTitle.value = ch.title;
+                                inputTitle.placeholder = 'Chapter title';
+                                tdTitle.appendChild(inputTitle);
+
+                                var tdActions = document.createElement('td');
+                                var btnDelete = document.createElement('button');
+                                btnDelete.type = 'button';
+                                btnDelete.className = 'btn btn-sm btn-outline-danger';
+                                btnDelete.title = 'Remove chapter';
+                                btnDelete.innerHTML = '<i class="fa-solid fa-trash"></i>';
+                                (function(removeIdx) {
+                                    btnDelete.addEventListener('click', function() {
+                                        chapters = getChaptersFromDOM();
+                                        chapters.splice(removeIdx, 1);
+                                        renderChapters();
+                                    });
+                                })(idx);
+                                tdActions.appendChild(btnDelete);
+
+                                tr.appendChild(tdStart);
+                                tr.appendChild(tdTitle);
+                                tr.appendChild(tdActions);
+                                tbody.appendChild(tr);
+                            });
+                        }
+
+                        function getChaptersFromDOM() {
+                            var rows = document.getElementById('chapters-tbody').querySelectorAll('tr');
+                            var result = [];
+                            rows.forEach(function(row) {
+                                var inputs = row.querySelectorAll('input');
+                                if (inputs.length >= 2) {
+                                    result.push({
+                                        start: inputs[0].value.trim(),
+                                        title: inputs[1].value.trim()
+                                    });
+                                }
+                            });
+                            return result;
+                        }
+
+                        fetch('/studio/edit/{{ medium.id }}/chapters.json')
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                chapters = data;
+                                renderChapters();
+                            })
+                            .catch(function(err) { console.error('Failed to load chapters:', err); });
+
+                        document.getElementById('add-chapter-btn').addEventListener('click', function() {
+                            chapters = getChaptersFromDOM();
+                            chapters.push({ start: '00:00:00.000', title: '' });
+                            renderChapters();
+                            var lastRow = document.getElementById('chapters-tbody').lastElementChild;
+                            if (lastRow) {
+                                var titleInput = lastRow.querySelectorAll('input')[1];
+                                if (titleInput) titleInput.focus();
+                            }
+                        });
+
+                        document.getElementById('save-chapters-btn').addEventListener('click', function() {
+                            var btn = this;
+                            btn.disabled = true;
+                            var chaptersToSave = getChaptersFromDOM().filter(function(ch) {
+                                return ch.title !== '';
+                            });
+
+                            fetch('/studio/edit/{{ medium.id }}/chapters', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(chaptersToSave)
+                            })
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                btn.disabled = false;
+                                var statusEl = document.getElementById('chapters-status');
+                                if (data.ok) {
+                                    statusEl.innerHTML = '<span class="text-success"><i class="fa-solid fa-check"></i> Chapters saved successfully!</span>';
+                                    chapters = chaptersToSave;
+                                } else {
+                                    statusEl.innerHTML = '<span class="text-danger"><i class="fa-solid fa-xmark"></i> Failed to save chapters.</span>';
+                                }
+                                setTimeout(function() { statusEl.innerHTML = ''; }, 4000);
+                            })
+                            .catch(function(err) {
+                                console.error(err);
+                                btn.disabled = false;
+                                document.getElementById('chapters-status').innerHTML = '<span class="text-danger"><i class="fa-solid fa-xmark"></i> Failed to save chapters.</span>';
+                            });
+                        });
+                    });
+                    </script>
+                    {% endif %}
                     <hr />
                     <div class="mx-3">
                         <h5 class="text-danger">Danger Zone</h5>


### PR DESCRIPTION
## Summary
This PR adds chapter management functionality to video and audio media, allowing users to create, edit, and save chapters through the studio editor interface. Chapters are stored in WebVTT format and displayed as navigation tracks in the media player.

## Key Changes
- **New chapters module** (`src/chapters.rs`): Implements chapter parsing and generation with WebVTT format support
  - `parse_webvtt_chapters()`: Parses WebVTT files into chapter data structures
  - `generate_webvtt_from_chapters()`: Converts chapter data back to WebVTT format with automatic sorting and timestamp normalization
  - `studio_chapters_get()`: API endpoint to retrieve chapters for a media item (with ownership verification)
  - `studio_chapters_save()`: API endpoint to save/update chapters with proper authorization checks

- **Studio editor UI enhancements** (`templates/pages/studio-edit.html`):
  - Added chapters editor section (only visible for video/audio media types)
  - Interactive table for managing chapter start times and titles
  - Add/remove chapter functionality with real-time DOM updates
  - Save button with status feedback
  - Client-side validation and error handling

- **Media player integration** (`templates/pages/medium.html`):
  - Added WebVTT track element for chapters display when available
  - Conditional rendering based on chapter file existence

- **Backend routing** (`src/main.rs`):
  - Added GET route for retrieving chapters: `/studio/edit/{mediumid}/chapters.json`
  - Added POST route for saving chapters: `/studio/edit/{mediumid}/chapters`

- **Data model updates** (`src/studio.rs`):
  - Extended `MediumEdit` struct to include `medium_type` field for conditional UI rendering

## Implementation Details
- Chapters are stored as `.vtt` files in `source/{mediumid}/chapters.vtt`
- Timestamp normalization ensures consistent WebVTT format (HH:MM:SS.mmm)
- Chapters are automatically sorted by start time before saving
- Authorization checks verify media ownership before allowing chapter modifications
- Empty chapters are filtered out before saving; empty chapter list removes the VTT file
- Graceful error handling returns appropriate HTTP status codes (401, 403, 404, 500)

https://claude.ai/code/session_01KkrfAmKDC9T6Jiswf86zTx