### PR TITLE
Replace HTML redirects with HX-Redirect headers in video deletion

### DIFF
--- a/src/studio.rs
+++ b/src/studio.rs
@@ -253,10 +253,10 @@ async fn hx_delete_video(
     Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
-) -> axum::response::Html<String> {
+) -> impl IntoResponse {
     let user_info = get_user_login(headers.clone(), &pool, session_store).await;
     if !is_logged(user_info.clone()).await {
-        return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
+        return ([("HX-Redirect", "/login")], "");
     }
     let user_info = user_info.unwrap();
 
@@ -267,13 +267,11 @@ async fn hx_delete_video(
     match media_owner {
         Ok(record) => {
             if record.owner != user_info.login {
-                let result = "<b class=\"text-sucess\">MEDIA REMOVAL SUCESS</b><script>window.location.replace(\"/studio\");</script>".to_string();
-                return Html(result);
+                return ([("HX-Redirect", "/studio")], "");
             }
         }
         Err(_) => {
-            let result = "<b class=\"text-sucess\">MEDIA REMOVAL FAILED</b><script>window.location.replace(\"/studio\");</script>".to_string();
-            return Html(result);
+            return ([("HX-Redirect", "/studio")], "");
         }
     }
 
@@ -293,14 +291,12 @@ async fn hx_delete_video(
         .await;
 
     if delete_result.is_err() {
-        let result = "<b class=\"text-sucess\">MEDIA REMOVAL FAILED</b><script>window.location.replace(\"/studio\");</script>".to_string();
-        return Html(result);
+        return ([("HX-Redirect", "/studio")], "");
     }
 
     // Delete the source directory
     let source_path = format!("source/{}", mediumid);
     let _ = fs::remove_dir_all(&source_path).await;
 
-    let result = "<b class=\"text-sucess\">MEDIA REMOVAL SUCESS</b><script>window.location.replace(\"/studio\");</script>".to_string();
-    return Html(result);
+    ([("HX-Redirect", "/studio")], "")
 }


### PR DESCRIPTION
## Summary
Refactored the `hx_delete_video` endpoint to use HTMX-compatible `HX-Redirect` headers instead of returning HTML with embedded JavaScript redirects. This improves the separation of concerns and leverages HTMX's built-in redirect handling.

## Key Changes
- Changed return type from `axum::response::Html<String>` to `impl IntoResponse` for more flexible response handling
- Replaced all HTML redirect responses (`<script>window.location.replace(...)</script>`) with proper `HX-Redirect` headers
- Removed unnecessary HTML string construction and error message markup throughout the function
- Simplified response returns to use header tuples with empty string bodies

## Implementation Details
- All redirect scenarios now consistently use the `HX-Redirect` header approach:
  - Unauthenticated users redirected to `/login`
  - Authorization failures and deletion errors redirected to `/studio`
  - Successful deletions redirected to `/studio`
- This approach allows HTMX to handle redirects natively on the client side, reducing the need for JavaScript in responses
- The change maintains the same user-facing behavior while improving code clarity and following HTMX best practices

https://claude.ai/code/session_01Q5Daq2SiNoDN8NU5DzKMPo