### PR TITLE
Add subtitle/caption management for video and audio media

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,9 @@ async fn main() {
         .route("/studio/edit/{mediumid}", post(studio_edit_save))
         .route("/studio/edit/{mediumid}/chapters.json", get(studio_chapters_get))
         .route("/studio/edit/{mediumid}/chapters", post(studio_chapters_save))
+        .route("/studio/edit/{mediumid}/subtitles.json", get(studio_subtitles_get))
+        .route("/studio/edit/{mediumid}/subtitles/add", post(studio_subtitles_add))
+        .route("/studio/edit/{mediumid}/subtitles/delete", post(studio_subtitles_delete))
         .route("/hx/studio/delete/{mediumid}", get(hx_delete_video))
         .route("/studio/lists", get(studio_lists))
         .route("/hx/studio/lists", get(hx_studio_lists))
@@ -141,6 +144,7 @@ include!("search.rs");
 include!("channel.rs");
 include!("studio.rs");
 include!("chapters.rs");
+include!("subtitles.rs");
 include!("upload.rs");
 include!("concept.rs");
 include!("serve.rs");

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -1,0 +1,253 @@
+async fn studio_subtitles_get(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> Json<serde_json::Value> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Json(serde_json::Value::Array(vec![]));
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Json(serde_json::Value::Array(vec![]));
+            }
+        }
+        Err(_) => {
+            return Json(serde_json::Value::Array(vec![]));
+        }
+    }
+
+    let list_path = format!("source/{}/captions/list.txt", mediumid);
+    if std::path::Path::new(&list_path).exists() {
+        let labels: Vec<serde_json::Value> = read_lines_to_vec(&list_path)
+            .into_iter()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::json!({ "label": l.trim() }))
+            .collect();
+        Json(serde_json::Value::Array(labels))
+    } else {
+        Json(serde_json::Value::Array(vec![]))
+    }
+}
+
+async fn studio_subtitles_add(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    mut multipart: Multipart,
+) -> Response<Body> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"not logged in\"}"))
+            .unwrap();
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"not authorized\"}"))
+                    .unwrap();
+            }
+        }
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"media not found\"}"))
+                .unwrap();
+        }
+    }
+
+    let mut label = String::new();
+    let mut vtt_content = Vec::new();
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let name = field.name().unwrap_or("").to_string();
+        match name.as_str() {
+            "label" => {
+                label = field.text().await.unwrap_or_default().trim().to_string();
+            }
+            "file" => {
+                vtt_content = field.bytes().await.unwrap_or_default().to_vec();
+            }
+            _ => {}
+        }
+    }
+
+    if label.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"label is required\"}"))
+            .unwrap();
+    }
+
+    // Sanitize label: only allow alphanumeric, hyphens, underscores, spaces
+    let sanitized_label: String = label
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_' || *c == ' ')
+        .collect();
+
+    if sanitized_label.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"invalid label\"}"))
+            .unwrap();
+    }
+
+    if vtt_content.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"VTT file is required\"}"))
+            .unwrap();
+    }
+
+    let captions_dir = format!("source/{}/captions", mediumid);
+    let _ = tokio::fs::create_dir_all(&captions_dir).await;
+
+    // Write the VTT file
+    let vtt_path = format!("{}/{}.vtt", captions_dir, sanitized_label);
+    if let Err(_) = tokio::fs::write(&vtt_path, &vtt_content).await {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"failed to write VTT file\"}"))
+            .unwrap();
+    }
+
+    // Update list.txt - read existing, add if not present, write back
+    let list_path = format!("{}/list.txt", captions_dir);
+    let mut existing: Vec<String> = if std::path::Path::new(&list_path).exists() {
+        read_lines_to_vec(&list_path)
+            .into_iter()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.trim().to_string())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if !existing.contains(&sanitized_label) {
+        existing.push(sanitized_label.clone());
+    }
+
+    let list_content = existing.join("\n") + "\n";
+    if let Err(_) = tokio::fs::write(&list_path, list_content).await {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"failed to update list\"}"))
+            .unwrap();
+    }
+
+    Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{\"ok\":true}"))
+        .unwrap()
+}
+
+#[derive(Deserialize)]
+struct SubtitleDeleteForm {
+    label: String,
+}
+
+async fn studio_subtitles_delete(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    Json(form): Json<SubtitleDeleteForm>,
+) -> Response<Body> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"not logged in\"}"))
+            .unwrap();
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"not authorized\"}"))
+                    .unwrap();
+            }
+        }
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"media not found\"}"))
+                .unwrap();
+        }
+    }
+
+    let label = form.label.trim().to_string();
+    if label.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"label is required\"}"))
+            .unwrap();
+    }
+
+    let captions_dir = format!("source/{}/captions", mediumid);
+    let list_path = format!("{}/list.txt", captions_dir);
+    let vtt_path = format!("{}/{}.vtt", captions_dir, label);
+
+    // Remove the VTT file
+    let _ = tokio::fs::remove_file(&vtt_path).await;
+
+    // Update list.txt
+    if std::path::Path::new(&list_path).exists() {
+        let existing: Vec<String> = read_lines_to_vec(&list_path)
+            .into_iter()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.trim().to_string())
+            .filter(|l| l != &label)
+            .collect();
+
+        if existing.is_empty() {
+            let _ = tokio::fs::remove_file(&list_path).await;
+        } else {
+            let list_content = existing.join("\n") + "\n";
+            let _ = tokio::fs::write(&list_path, list_content).await;
+        }
+    }
+
+    Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{\"ok\":true}"))
+        .unwrap()
+}

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -146,7 +146,16 @@
                             autoplay
                         >
                             <media-provider>
-                                {% if medium_chapters_exist %}
+                                {% if medium_captions_exist %} {% for
+                                caption_name in medium_captions_list %}
+                                <track
+                                    src="/source/{{ medium_id }}/captions/{{ caption_name }}.vtt"
+                                    kind="subtitles"
+                                    label="{{ caption_name }}"
+                                    lang="{{caption_name}}"
+                                />
+                                {% endfor %} {% endif %} {% if
+                                medium_chapters_exist %}
                                 <track
                                     src="/source/{{ medium_id }}/chapters.vtt"
                                     kind="chapters"

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -304,6 +304,167 @@
                     });
                     </script>
                     {% endif %}
+                    {% if medium.medium_type == "video" || medium.medium_type == "audio" %}
+                    <hr />
+                    <div class="mx-3">
+                        <h5><i class="fa-solid fa-closed-captioning"></i>&nbsp;Subtitles</h5>
+                        <p class="text-secondary">Upload WebVTT (.vtt) subtitle files. Each subtitle track needs a label (e.g. "English", "Spanish").</p>
+                        <div id="subtitles-editor">
+                            <div class="table-responsive">
+                                <table class="table table-dark table-hover" id="subtitles-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Label</th>
+                                            <th style="width: 80px"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="subtitles-tbody">
+                                    </tbody>
+                                </table>
+                            </div>
+                            <p class="text-secondary" id="no-subtitles-msg">No subtitles yet. Use the form below to add a subtitle track.</p>
+                            <div class="card p-3 mt-3" style="background-color: var(--bs-dark)">
+                                <h6>Add Subtitle Track</h6>
+                                <div class="row g-2 align-items-end">
+                                    <div class="col-sm-4">
+                                        <label for="subtitle-label-input" class="form-label">Label</label>
+                                        <input type="text" class="form-control form-control-sm" id="subtitle-label-input" placeholder="e.g. English" />
+                                    </div>
+                                    <div class="col-sm-5">
+                                        <label for="subtitle-file-input" class="form-label">VTT File</label>
+                                        <input type="file" class="form-control form-control-sm" id="subtitle-file-input" accept=".vtt" />
+                                    </div>
+                                    <div class="col-sm-3">
+                                        <button type="button" class="btn btn-primary btn-sm w-100" id="upload-subtitle-btn">
+                                            <i class="fa-solid fa-upload"></i>&nbsp;Upload
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="subtitles-status" class="mt-2"></div>
+                        </div>
+                    </div>
+                    <script>
+                    document.addEventListener('DOMContentLoaded', function() {
+                        var subtitles = [];
+
+                        function renderSubtitles() {
+                            var tbody = document.getElementById('subtitles-tbody');
+                            var noMsg = document.getElementById('no-subtitles-msg');
+                            tbody.innerHTML = '';
+
+                            if (subtitles.length === 0) {
+                                noMsg.style.display = '';
+                                document.getElementById('subtitles-table').style.display = 'none';
+                                return;
+                            }
+                            noMsg.style.display = 'none';
+                            document.getElementById('subtitles-table').style.display = '';
+
+                            subtitles.forEach(function(sub) {
+                                var tr = document.createElement('tr');
+
+                                var tdLabel = document.createElement('td');
+                                tdLabel.textContent = sub.label;
+                                tr.appendChild(tdLabel);
+
+                                var tdActions = document.createElement('td');
+                                var btnDelete = document.createElement('button');
+                                btnDelete.type = 'button';
+                                btnDelete.className = 'btn btn-sm btn-outline-danger';
+                                btnDelete.title = 'Remove subtitle';
+                                btnDelete.innerHTML = '<i class="fa-solid fa-trash"></i>';
+                                (function(label) {
+                                    btnDelete.addEventListener('click', function() {
+                                        if (!confirm('Delete subtitle track "' + label + '"?')) return;
+                                        fetch('/studio/edit/{{ medium.id }}/subtitles/delete', {
+                                            method: 'POST',
+                                            headers: { 'Content-Type': 'application/json' },
+                                            body: JSON.stringify({ label: label })
+                                        })
+                                        .then(function(r) { return r.json(); })
+                                        .then(function(data) {
+                                            if (data.ok) {
+                                                subtitles = subtitles.filter(function(s) { return s.label !== label; });
+                                                renderSubtitles();
+                                                showSubStatus('success', 'Subtitle track deleted.');
+                                            } else {
+                                                showSubStatus('danger', data.error || 'Failed to delete.');
+                                            }
+                                        })
+                                        .catch(function() { showSubStatus('danger', 'Failed to delete subtitle.'); });
+                                    });
+                                })(sub.label);
+                                tdActions.appendChild(btnDelete);
+                                tr.appendChild(tdActions);
+
+                                tbody.appendChild(tr);
+                            });
+                        }
+
+                        function showSubStatus(type, msg) {
+                            var el = document.getElementById('subtitles-status');
+                            var icon = type === 'success' ? 'fa-check' : 'fa-xmark';
+                            el.innerHTML = '<span class="text-' + type + '"><i class="fa-solid ' + icon + '"></i> ' + msg + '</span>';
+                            setTimeout(function() { el.innerHTML = ''; }, 4000);
+                        }
+
+                        fetch('/studio/edit/{{ medium.id }}/subtitles.json')
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                subtitles = data;
+                                renderSubtitles();
+                            })
+                            .catch(function(err) { console.error('Failed to load subtitles:', err); });
+
+                        document.getElementById('upload-subtitle-btn').addEventListener('click', function() {
+                            var btn = this;
+                            var labelInput = document.getElementById('subtitle-label-input');
+                            var fileInput = document.getElementById('subtitle-file-input');
+                            var label = labelInput.value.trim();
+
+                            if (!label) {
+                                showSubStatus('danger', 'Please enter a label.');
+                                return;
+                            }
+                            if (!fileInput.files || fileInput.files.length === 0) {
+                                showSubStatus('danger', 'Please select a VTT file.');
+                                return;
+                            }
+
+                            var formData = new FormData();
+                            formData.append('label', label);
+                            formData.append('file', fileInput.files[0]);
+
+                            btn.disabled = true;
+                            fetch('/studio/edit/{{ medium.id }}/subtitles/add', {
+                                method: 'POST',
+                                body: formData
+                            })
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                btn.disabled = false;
+                                if (data.ok) {
+                                    var exists = subtitles.some(function(s) { return s.label === label; });
+                                    if (!exists) {
+                                        subtitles.push({ label: label });
+                                    }
+                                    renderSubtitles();
+                                    labelInput.value = '';
+                                    fileInput.value = '';
+                                    showSubStatus('success', 'Subtitle track uploaded!');
+                                } else {
+                                    showSubStatus('danger', data.error || 'Upload failed.');
+                                }
+                            })
+                            .catch(function() {
+                                btn.disabled = false;
+                                showSubStatus('danger', 'Upload failed.');
+                            });
+                        });
+                    });
+                    </script>
+                    {% endif %}
                     <hr />
                     <div class="mx-3">
                         <h5 class="text-danger">Danger Zone</h5>


### PR DESCRIPTION
## Summary
This PR adds comprehensive subtitle management functionality to the studio editor, allowing users to upload, view, and delete WebVTT subtitle tracks for video and audio media. Subtitles are now also displayed in the media player.

## Key Changes
- **New subtitle management API endpoints** (`src/subtitles.rs`):
  - `GET /studio/edit/{mediumid}/subtitles.json` - Retrieve list of available subtitle tracks
  - `POST /studio/edit/{mediumid}/subtitles/add` - Upload new WebVTT subtitle file with label
  - `POST /studio/edit/{mediumid}/subtitles/delete` - Remove a subtitle track

- **Studio editor UI** (`templates/pages/studio-edit.html`):
  - New "Subtitles" section for video/audio media types
  - Table displaying existing subtitle tracks with delete buttons
  - Form to upload new subtitle files with label input and VTT file picker
  - Real-time status messages for upload/delete operations
  - Client-side validation and error handling

- **Media player integration** (`templates/pages/medium.html`):
  - Dynamically loads and displays available subtitle tracks as `<track>` elements
  - Subtitles are rendered with proper labels and language attributes

- **Route registration** (`src/main.rs`):
  - Registered three new routes for subtitle management endpoints

## Implementation Details
- **Security**: All endpoints verify user authentication and ownership of the media before allowing operations
- **Label sanitization**: Subtitle labels are sanitized to allow only alphanumeric characters, hyphens, underscores, and spaces
- **File storage**: Subtitles are stored in `source/{mediumid}/captions/` directory with a `list.txt` index file
- **Error handling**: Comprehensive error responses with appropriate HTTP status codes (401, 403, 404, 400, 500)
- **Async operations**: Uses tokio for non-blocking file I/O operations

https://claude.ai/code/session_015GuZm1m4t7c6f1dWRnUGRH