### PR TITLE
Replace delete confirmation modal with inline confirm dialog

### DIFF
--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -309,35 +309,9 @@
                         <h5 class="text-danger">Danger Zone</h5>
                         <button
                             class="btn btn-outline-danger mt-2"
-                            data-bs-toggle="modal"
-                            data-bs-target="#deleteModal"
+                            onclick="if(confirm('Are you sure you want to delete &quot;{{ medium.name }}&quot;? This action cannot be undone. All comments and list entries will also be removed.')) { window.location.href='/hx/studio/delete/{{ medium.id }}'; }"
                         >
                             <i class="fa-solid fa-trash"></i>&nbsp;Delete Media
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Delete Confirmation Modal -->
-        <div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="deleteModalLabel">Delete Media</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        Are you sure you want to delete <b>{{ medium.name }}</b>? This action cannot be undone. All comments and list entries associated with this media will also be removed.
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                        <button
-                            class="btn btn-danger"
-                            hx-get="/hx/studio/delete/{{ medium.id }}"
-                            hx-target="body"
-                        >
-                            <i class="fa-solid fa-trash"></i>&nbsp;Delete
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Simplified the media deletion confirmation flow by replacing a Bootstrap modal with a native browser `confirm()` dialog.

## Key Changes
- Removed the dedicated delete confirmation modal component (`#deleteModal`) from the template
- Replaced the modal trigger button with an inline `onclick` handler that:
  - Shows a native browser confirmation dialog with the deletion warning message
  - Directly navigates to the delete endpoint on confirmation
  - Includes the media name in the confirmation message for clarity
- Removed the associated modal HTML markup (modal structure, header, body, and footer)

## Implementation Details
- The confirmation message now includes the media name and warns about cascading deletions (comments and list entries)
- Uses standard browser `confirm()` for a simpler UX without external dependencies
- Direct navigation via `window.location.href` replaces the previous HTMX-based deletion approach
- Reduces template complexity by eliminating modal-specific markup and Bootstrap modal attributes

https://claude.ai/code/session_01BXDdQFbMfSGE4UXqMPB347