### PR TITLE
Fix audio track switching by preserving playback position

### DIFF
--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -90,6 +90,7 @@
                     <div class="d-flex justify-content-center player-container">
                         {% if medium_type == "video" %}
                         <media-player
+                            id="vds-player"
                             viewType="video"
                             src="/source/{{ medium_id }}/video/video.mpd"
                             aspectRatio="16/9"
@@ -133,6 +134,17 @@
                                 %}
                             ></media-video-layout>
                         </media-player>
+                        <script>
+                            document.addEventListener("DOMContentLoaded", function () {
+                                var player = document.getElementById("vds-player");
+                                player.addEventListener("audio-track-change", function () {
+                                    var ct = player.currentTime;
+                                    if (ct > 0) {
+                                        player.currentTime = ct;
+                                    }
+                                });
+                            });
+                        </script>
                         {% else if medium_type == "audio" %}
                         <media-player
                             src="/source/{{ medium_id }}/audio.ogg"


### PR DESCRIPTION
## Summary
Added functionality to preserve the current playback position when switching audio tracks in the video player.

## Key Changes
- Added `id="vds-player"` to the media-player element to enable JavaScript access
- Implemented an event listener for the `audio-track-change` event that maintains the playback position by resetting `currentTime` to its current value after a track switch

## Implementation Details
The solution addresses an issue where switching audio tracks would reset the playback position. By listening to the `audio-track-change` event and immediately restoring the `currentTime` property, the player maintains its position in the video when users switch between available audio tracks. The check `if (ct > 0)` ensures the operation only occurs when playback has actually started.

https://claude.ai/code/session_01HbSF756jNMKeyEppSmJkFV