### PR TITLE
Add PDF document viewer with fullscreen support

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -63,3 +63,45 @@ function closeListModal(event) {
         event.target.style.display = 'none';
     }
 }
+
+function togglePdfFullscreen() {
+    var wrapper = document.getElementById('pdfViewerWrapper');
+    var icon = document.getElementById('pdfFullscreenIcon');
+    if (!document.fullscreenElement && !document.webkitFullscreenElement) {
+        if (wrapper.requestFullscreen) {
+            wrapper.requestFullscreen();
+        } else if (wrapper.webkitRequestFullscreen) {
+            wrapper.webkitRequestFullscreen();
+        }
+    } else {
+        if (document.exitFullscreen) {
+            document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) {
+            document.webkitExitFullscreen();
+        }
+    }
+}
+
+document.addEventListener('fullscreenchange', function () {
+    var icon = document.getElementById('pdfFullscreenIcon');
+    if (!icon) return;
+    if (document.fullscreenElement) {
+        icon.classList.remove('fa-expand');
+        icon.classList.add('fa-compress');
+    } else {
+        icon.classList.remove('fa-compress');
+        icon.classList.add('fa-expand');
+    }
+});
+
+document.addEventListener('webkitfullscreenchange', function () {
+    var icon = document.getElementById('pdfFullscreenIcon');
+    if (!icon) return;
+    if (document.webkitFullscreenElement) {
+        icon.classList.remove('fa-expand');
+        icon.classList.add('fa-compress');
+    } else {
+        icon.classList.remove('fa-compress');
+        icon.classList.add('fa-expand');
+    }
+});

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -15878,6 +15878,59 @@ body.sidebar-collapsed .sidebarbackground {
     aspect-ratio: 16 / 9;
 }
 
+/* PDF viewer */
+.pdf-viewer-wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+
+.medium-pdf {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.pdf-fullscreen-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    width: 36px;
+    height: 36px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+    transition: background 0.2s;
+}
+
+.pdf-fullscreen-btn:hover {
+    background: rgba(0, 0, 0, 0.85);
+}
+
+.pdf-viewer-wrapper:fullscreen {
+    background: #1a1a1a;
+}
+
+.pdf-viewer-wrapper:fullscreen .medium-pdf {
+    height: 100vh;
+    width: 100vw;
+}
+
+.pdf-viewer-wrapper:-webkit-full-screen {
+    background: #1a1a1a;
+}
+
+.pdf-viewer-wrapper:-webkit-full-screen .medium-pdf {
+    height: 100vh;
+    width: 100vw;
+}
+
 /* Limit reflow scope for cards that receive HTMX content */
 .card {
     contain: layout style;

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -79,6 +79,8 @@
             content="https://{{ config.source_server_url }}/source/{{ medium_id }}/picture.avif"
         />
         <meta property="og:image:type" content="image/avif" />
+        {% else if medium_type == "document_pdf" %}
+        <meta property="og:type" content="article" />
         {% endif %}
     </head>
 
@@ -175,6 +177,21 @@
                             src="{{ config.source_server_url }}/source/{{ medium_id }}/picture.avif"
                             class="medium-picture"
                         />
+                        {% else if medium_type == "document_pdf" %}
+                        <div class="pdf-viewer-wrapper" id="pdfViewerWrapper">
+                            <embed
+                                src="{{ config.source_server_url }}/source/{{ medium_id }}/document.pdf"
+                                type="application/pdf"
+                                class="medium-pdf"
+                            />
+                            <button
+                                class="pdf-fullscreen-btn"
+                                onclick="togglePdfFullscreen()"
+                                title="Toggle fullscreen"
+                            >
+                                <i class="fa-solid fa-expand" id="pdfFullscreenIcon"></i>
+                            </button>
+                        </div>
                         {% endif %}
                     </div>
                     <div>
@@ -191,6 +208,8 @@
                                     <i class="fa-solid fa-music fa-sm ms-4"></i>
                                     {% else if medium_type == "picture" %}
                                     <i class="fa-solid fa-image fa-sm ms-4"></i>
+                                    {% else if medium_type == "document_pdf" %}
+                                    <i class="fa-solid fa-file-pdf fa-sm ms-4"></i>
                                     {% endif %}
                                 </h1>
                             </li>
@@ -266,6 +285,13 @@
                                     href="{{ config.source_server_url }}/source/{{ medium_id }}/picture.avif"
                                     class="text-white text-decoration-none"
                                     download="{{ medium_id }}.avif"
+                                    ><i class="fa-solid fa-download fa-xl"></i
+                                ></a>
+                                {% else if medium_type == "document_pdf" %}
+                                <a
+                                    href="{{ config.source_server_url }}/source/{{ medium_id }}/document.pdf"
+                                    class="text-white text-decoration-none"
+                                    download="{{ medium_id }}.pdf"
                                     ><i class="fa-solid fa-download fa-xl"></i
                                 ></a>
                                 {% endif %}


### PR DESCRIPTION
## Summary
This PR adds support for displaying PDF documents in the medium viewer with a fullscreen toggle feature.

## Key Changes
- **CSS Styling** (`assets/static/style.css`):
  - Added `.pdf-viewer-wrapper` for container positioning
  - Added `.medium-pdf` for the embedded PDF element
  - Added `.pdf-fullscreen-btn` with hover effects for the fullscreen toggle button
  - Added fullscreen and webkit fullscreen pseudo-class styles for proper fullscreen display

- **JavaScript Functionality** (`assets/static/script.js`):
  - Implemented `togglePdfFullscreen()` function to handle entering/exiting fullscreen mode with cross-browser support (standard and webkit APIs)
  - Added `fullscreenchange` event listener to update the fullscreen button icon when entering/exiting fullscreen
  - Added `webkitfullscreenchange` event listener for webkit browser compatibility
  - Icon toggles between expand (`fa-expand`) and compress (`fa-compress`) states

- **Template Updates** (`templates/pages/medium.html`):
  - Added PDF document type detection and rendering with `<embed>` element
  - Added fullscreen toggle button with Font Awesome icon
  - Added PDF icon display in the medium type indicator
  - Added PDF download link in the actions menu
  - Added Open Graph meta tag for PDF documents (article type)

## Implementation Details
- The PDF viewer uses the native `<embed>` element for broad browser compatibility
- Fullscreen functionality supports both standard and webkit-prefixed APIs for maximum browser support
- The fullscreen button is positioned absolutely in the top-right corner with semi-transparent dark background
- Icon state is synchronized with actual fullscreen state via event listeners
- Download functionality allows users to save the PDF with the medium ID as filename

https://claude.ai/code/session_0165fGVHKhTXLQLoewET3awF