### PR TITLE
Add user groups feature with restricted content access control

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -8,6 +8,8 @@ CREATE TABLE public.media (
 	dislikes int8 DEFAULT 0 NOT NULL,
 	"views" int8 DEFAULT 0 NOT NULL,
 	public bool DEFAULT false NOT NULL,
+	visibility varchar DEFAULT 'hidden' NOT NULL,
+	restricted_to_group varchar,
 	"type" varchar NOT NULL,
 	CONSTRAINT videos_pk PRIMARY KEY (id)
 );
@@ -44,6 +46,8 @@ CREATE TABLE public.lists (
 	"name" varchar NOT NULL,
 	"owner" varchar(40) NOT NULL,
 	public bool DEFAULT false NOT NULL,
+	visibility varchar DEFAULT 'hidden' NOT NULL,
+	restricted_to_group varchar,
 	created int8 DEFAULT EXTRACT(epoch FROM now()) NOT NULL,
 	CONSTRAINT lists_pk PRIMARY KEY (id)
 );
@@ -53,3 +57,19 @@ CREATE TABLE public.list_items (
 	"position" int4 DEFAULT 0 NOT NULL,
 	added int8 DEFAULT EXTRACT(epoch FROM now()) NOT NULL
 );
+CREATE TABLE public.user_groups (
+	id varchar NOT NULL,
+	"name" varchar NOT NULL,
+	"owner" varchar(40) NOT NULL,
+	created int8 DEFAULT EXTRACT(epoch FROM now()) NOT NULL,
+	CONSTRAINT user_groups_pk PRIMARY KEY (id)
+);
+CREATE TABLE public.user_group_members (
+	group_id varchar NOT NULL,
+	user_login varchar(40) NOT NULL,
+	CONSTRAINT user_group_members_pk PRIMARY KEY (group_id, user_login)
+);
+
+-- Migration for existing data:
+-- UPDATE public.media SET visibility = CASE WHEN public THEN 'public' ELSE 'hidden' END;
+-- UPDATE public.lists SET visibility = CASE WHEN public THEN 'public' ELSE 'hidden' END;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -63,14 +63,32 @@ WHERE
 async fn hx_usermedia(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let media = sqlx::query_as!(Medium,
-        "SELECT id,name,owner,views,type FROM media WHERE public=true AND owner=$1 ORDER BY upload DESC;",userid
+    let user = get_user_login(headers, &pool, session_store).await;
+    let user_login = user.map(|u| u.login).unwrap_or_default();
+
+    let media: Vec<Medium> = sqlx::query(
+        "SELECT id,name,owner,views,type FROM media WHERE owner=$1 AND (visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY upload DESC;"
     )
+    .bind(&userid)
+    .bind(&user_login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        Medium {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            views: row.get("views"),
+            r#type: row.get("type"),
+        }
+    })
     .fetch_all(&pool)
     .await
     .expect("Database error");
+
     let template = HXMediumCardTemplate { media, config };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/concept.rs
+++ b/src/concept.rs
@@ -66,6 +66,7 @@ struct ConceptTemplate {
     config: Config,
     concept: MediumConcept,
     common_headers: CommonHeaders,
+    owner_groups: Vec<UserGroup>,
 }
 async fn concept(
     Extension(pool): Extension<PgPool>,
@@ -89,6 +90,21 @@ async fn concept(
     .await
     .expect("Database error");
 
+    // Fetch user's groups for the dropdown
+    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+        .bind(&user_info.login)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
     let sidebar = generate_sidebar(&config, "studio".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
     let template = ConceptTemplate {
@@ -96,6 +112,7 @@ async fn concept(
         config,
         concept,
         common_headers,
+        owner_groups,
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -106,6 +123,7 @@ struct PublishForm {
     medium_name: String,
     medium_description: String,
     medium_visibility: String,
+    medium_restricted_group: Option<String>,
 }
 async fn publish(
     Extension(pool): Extension<PgPool>,
@@ -133,23 +151,29 @@ async fn publish(
     )
     .await;
     if concept_move.is_ok() {
-        let ispublic: bool;
-        if form.medium_visibility == "public".to_owned() {
-            ispublic = true;
+        let visibility = match form.medium_visibility.as_str() {
+            "public" | "hidden" | "restricted" => form.medium_visibility.clone(),
+            _ => "hidden".to_owned(),
+        };
+        let ispublic = visibility == "public";
+        let restricted_to_group = if visibility == "restricted" {
+            form.medium_restricted_group.clone().filter(|g| !g.is_empty())
         } else {
-            ispublic = false;
-        }
+            None
+        };
         let description: serde_json::Value =
             serde_json::from_str(&form.medium_description).unwrap();
-        let _ = sqlx::query!(
-            "INSERT INTO media (id,name,description,owner,public,type) VALUES ($1,$2,$3,$4,$5,$6);",
-            form.medium_id.to_ascii_lowercase(),
-            form.medium_name,
-            description,
-            user_info.login,
-            ispublic,
-            concept.r#type
+        let _ = sqlx::query(
+            "INSERT INTO media (id,name,description,owner,public,visibility,restricted_to_group,type) VALUES ($1,$2,$3,$4,$5,$6,$7,$8);"
         )
+        .bind(form.medium_id.to_ascii_lowercase())
+        .bind(&form.medium_name)
+        .bind(&description)
+        .bind(&user_info.login)
+        .bind(ispublic)
+        .bind(&visibility)
+        .bind(&restricted_to_group)
+        .bind(&concept.r#type)
         .execute(&pool)
         .await;
         let _ = sqlx::query!("DELETE FROM media_concepts WHERE id=$1;", concept.id)

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,0 +1,444 @@
+#[derive(Serialize, Deserialize, Clone)]
+struct UserGroup {
+    id: String,
+    name: String,
+    owner: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct UserGroupWithCount {
+    id: String,
+    name: String,
+    owner: String,
+    member_count: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct GroupMember {
+    user_login: String,
+}
+
+#[derive(Deserialize)]
+struct CreateGroupForm {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct AddMemberForm {
+    user_login: String,
+}
+
+#[derive(Template)]
+#[template(path = "pages/studio-groups.html", escape = "none")]
+struct StudioGroupsTemplate {
+    sidebar: String,
+    config: Config,
+    common_headers: CommonHeaders,
+}
+
+async fn studio_groups(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+
+    let sidebar = generate_sidebar(&config, "studio".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = StudioGroupsTemplate {
+        sidebar,
+        config,
+        common_headers,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-studio-groups.html", escape = "none")]
+struct HXStudioGroupsTemplate {
+    groups: Vec<UserGroupWithCount>,
+}
+
+async fn hx_studio_groups(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let user_info = user_info.unwrap();
+
+    let groups: Vec<UserGroupWithCount> = sqlx::query(
+        "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
+    )
+    .bind(&user_info.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        UserGroupWithCount {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            member_count: row.get("member_count"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .expect("Database error");
+
+    let template = HXStudioGroupsTemplate { groups };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn hx_create_group(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Form(form): Form<CreateGroupForm>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("".as_bytes().to_vec());
+    }
+    let user_info = user_info.unwrap();
+
+    let group_id = generate_medium_id();
+
+    sqlx::query("INSERT INTO user_groups (id, name, owner) VALUES ($1, $2, $3);")
+        .bind(&group_id)
+        .bind(&form.name)
+        .bind(&user_info.login)
+        .execute(&pool)
+        .await
+        .expect("Database error");
+
+    // Return updated groups list
+    let groups: Vec<UserGroupWithCount> = sqlx::query(
+        "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
+    )
+    .bind(&user_info.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        UserGroupWithCount {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            member_count: row.get("member_count"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .expect("Database error");
+
+    let template = HXStudioGroupsTemplate { groups };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn hx_delete_group(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(groupid): Path<String>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("".as_bytes().to_vec());
+    }
+    let user_info = user_info.unwrap();
+
+    // Verify ownership
+    let owner_check: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT owner FROM user_groups WHERE id = $1;")
+        .bind(&groupid)
+        .fetch_optional(&pool)
+        .await
+        .expect("Database error");
+
+    if let Some(row) = owner_check {
+        use sqlx::Row;
+        let owner: String = row.get("owner");
+        if owner != user_info.login {
+            return Html("".as_bytes().to_vec());
+        }
+    } else {
+        return Html("".as_bytes().to_vec());
+    }
+
+    // Clear group references from media and lists
+    sqlx::query("UPDATE media SET visibility = 'hidden', restricted_to_group = NULL WHERE restricted_to_group = $1;")
+        .bind(&groupid)
+        .execute(&pool)
+        .await
+        .expect("Database error");
+
+    sqlx::query("UPDATE lists SET visibility = 'hidden', restricted_to_group = NULL WHERE restricted_to_group = $1;")
+        .bind(&groupid)
+        .execute(&pool)
+        .await
+        .expect("Database error");
+
+    // Delete members and group
+    sqlx::query("DELETE FROM user_group_members WHERE group_id = $1;")
+        .bind(&groupid)
+        .execute(&pool)
+        .await
+        .expect("Database error");
+
+    sqlx::query("DELETE FROM user_groups WHERE id = $1;")
+        .bind(&groupid)
+        .execute(&pool)
+        .await
+        .expect("Database error");
+
+    // Return updated groups list
+    let groups: Vec<UserGroupWithCount> = sqlx::query(
+        "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
+    )
+    .bind(&user_info.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        UserGroupWithCount {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            member_count: row.get("member_count"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .expect("Database error");
+
+    let template = HXStudioGroupsTemplate { groups };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-group-members.html", escape = "none")]
+struct HXGroupMembersTemplate {
+    group: UserGroup,
+    members: Vec<GroupMember>,
+    is_owner: bool,
+}
+
+async fn hx_group_members(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(groupid): Path<String>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("".as_bytes().to_vec());
+    }
+    let user_info = user_info.unwrap();
+
+    let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
+        .bind(&groupid)
+        .fetch_optional(&pool)
+        .await
+        .expect("Database error");
+
+    let group = match group_row {
+        Some(row) => {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        }
+        None => return Html("".as_bytes().to_vec()),
+    };
+
+    let is_owner = group.owner == user_info.login;
+
+    let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
+        .bind(&groupid)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            GroupMember {
+                user_login: row.get("user_login"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .expect("Database error");
+
+    let template = HXGroupMembersTemplate {
+        group,
+        members,
+        is_owner,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn hx_add_group_member(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path(groupid): Path<String>,
+    Form(form): Form<AddMemberForm>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("".as_bytes().to_vec());
+    }
+    let user_info = user_info.unwrap();
+
+    // Verify group ownership
+    let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
+        .bind(&groupid)
+        .fetch_optional(&pool)
+        .await
+        .expect("Database error");
+
+    let group = match group_row {
+        Some(row) => {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        }
+        None => return Html("".as_bytes().to_vec()),
+    };
+
+    if group.owner != user_info.login {
+        return Html("".as_bytes().to_vec());
+    }
+
+    // Check that the user exists
+    let user_exists: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT login FROM users WHERE login = $1;")
+        .bind(&form.user_login)
+        .fetch_optional(&pool)
+        .await
+        .expect("Database error");
+
+    if user_exists.is_some() {
+        // Insert member (ignore if already exists)
+        let _ = sqlx::query("INSERT INTO user_group_members (group_id, user_login) VALUES ($1, $2) ON CONFLICT DO NOTHING;")
+            .bind(&groupid)
+            .bind(&form.user_login)
+            .execute(&pool)
+            .await;
+    }
+
+    // Return updated members list
+    let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
+        .bind(&groupid)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            GroupMember {
+                user_login: row.get("user_login"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .expect("Database error");
+
+    let template = HXGroupMembersTemplate {
+        group,
+        members,
+        is_owner: true,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn hx_remove_group_member(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+    Path((groupid, login)): Path<(String, String)>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("".as_bytes().to_vec());
+    }
+    let user_info = user_info.unwrap();
+
+    // Verify group ownership
+    let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
+        .bind(&groupid)
+        .fetch_optional(&pool)
+        .await
+        .expect("Database error");
+
+    let group = match group_row {
+        Some(row) => {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        }
+        None => return Html("".as_bytes().to_vec()),
+    };
+
+    if group.owner != user_info.login {
+        return Html("".as_bytes().to_vec());
+    }
+
+    sqlx::query("DELETE FROM user_group_members WHERE group_id = $1 AND user_login = $2;")
+        .bind(&groupid)
+        .bind(&login)
+        .execute(&pool)
+        .await
+        .expect("Database error");
+
+    // Return updated members list
+    let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
+        .bind(&groupid)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            GroupMember {
+                user_login: row.get("user_login"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .expect("Database error");
+
+    let template = HXGroupMembersTemplate {
+        group,
+        members,
+        is_owner: true,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn hx_user_groups_json(
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+) -> Json<Vec<UserGroup>> {
+    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    if !is_logged(user_info.clone()).await {
+        return Json(vec![]);
+    }
+    let user_info = user_info.unwrap();
+
+    let groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+        .bind(&user_info.login)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
+    Json(groups)
+}

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -286,3 +286,32 @@ async fn move_dir(src: &str, dest: &str) -> io::Result<()> {
     fs::remove_dir_all(src).await?;
     Ok(())
 }
+
+async fn is_group_member(pool: &PgPool, group_id: &str, user_login: &str) -> bool {
+    sqlx::query("SELECT 1 FROM user_group_members WHERE group_id = $1 AND user_login = $2")
+        .bind(group_id)
+        .bind(user_login)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_group: Option<&str>, owner: &str, user: &Option<User>) -> bool {
+    match visibility {
+        "public" => true,
+        "restricted" => {
+            if let Some(u) = user {
+                if u.login == owner {
+                    return true;
+                }
+                if let Some(group_id) = restricted_to_group {
+                    return is_group_member(pool, group_id, &u.login).await;
+                }
+            }
+            false
+        }
+        _ => true // "hidden" - accessible via direct link (existing behavior)
+    }
+}

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -3,7 +3,8 @@ struct List {
     id: String,
     name: String,
     owner: String,
-    public: bool,
+    visibility: String,
+    restricted_to_group: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -11,7 +12,8 @@ struct ListWithCount {
     id: String,
     name: String,
     owner: String,
-    public: bool,
+    visibility: String,
+    restricted_to_group: Option<String>,
     item_count: Option<i64>,
 }
 
@@ -25,7 +27,8 @@ struct ListModalEntry {
 #[derive(Deserialize)]
 struct CreateListForm {
     name: String,
-    public: Option<String>,
+    visibility: Option<String>,
+    restricted_group: Option<String>,
 }
 
 #[derive(Template)]
@@ -50,6 +53,7 @@ struct HXListItemsTemplate {
 struct HXListModalTemplate {
     lists: Vec<ListModalEntry>,
     medium_id: String,
+    owner_groups: Vec<UserGroup>,
 }
 
 #[derive(Template)]
@@ -65,16 +69,24 @@ async fn list_page(
     headers: HeaderMap,
     Path(listid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let list = sqlx::query_as!(
-        List,
-        "SELECT id, name, owner, public FROM lists WHERE id=$1;",
-        listid
+    let list_row = sqlx::query(
+        "SELECT id, name, owner, visibility, restricted_to_group FROM lists WHERE id=$1;"
     )
+    .bind(&listid)
     .fetch_one(&pool)
     .await;
 
-    let list = match list {
-        Ok(l) => l,
+    let list = match list_row {
+        Ok(row) => {
+            use sqlx::Row;
+            List {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+                visibility: row.get("visibility"),
+                restricted_to_group: row.get("restricted_to_group"),
+            }
+        }
         Err(_) => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),
@@ -87,6 +99,13 @@ async fn list_page(
         .as_ref()
         .map(|u| u.login == list.owner)
         .unwrap_or(false);
+
+    // Access control for restricted lists
+    if !is_owner && !can_access_restricted(&pool, &list.visibility, list.restricted_to_group.as_deref(), &list.owner, &user_info).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/\");</script>".to_owned(),
+        ));
+    }
 
     let sidebar = generate_sidebar(&config, "list".to_owned());
     let template = ListPageTemplate {
@@ -105,15 +124,24 @@ async fn medium_in_list(
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let list = sqlx::query!(
-        "SELECT id, public, owner, name FROM lists WHERE id=$1;",
-        listid
+    let list_row = sqlx::query(
+        "SELECT id, visibility, restricted_to_group, owner, name FROM lists WHERE id=$1;"
     )
+    .bind(&listid)
     .fetch_one(&pool)
     .await;
 
-    let list = match list {
-        Ok(l) => l,
+    let list = match list_row {
+        Ok(row) => {
+            use sqlx::Row;
+            (
+                row.get::<String, _>("id"),
+                row.get::<String, _>("visibility"),
+                row.get::<Option<String>, _>("restricted_to_group"),
+                row.get::<String, _>("owner"),
+                row.get::<String, _>("name"),
+            )
+        }
         Err(_) => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),
@@ -124,20 +152,50 @@ async fn medium_in_list(
     let user_info = get_user_login(headers.clone(), &pool, session_store).await;
     let is_logged_in = user_info.is_some();
 
-    let common_headers = extract_common_headers(&headers).unwrap();
-    let medium = sqlx::query!(
-        "SELECT id,name,description,upload,owner,likes,dislikes,views,type FROM media WHERE id=$1;",
-        mediumid.to_ascii_lowercase()
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
+    // Access control for restricted lists
+    let is_owner = user_info.as_ref().map(|u| u.login == list.3).unwrap_or(false);
+    if !is_owner && !can_access_restricted(&pool, &list.1, list.2.as_deref(), &list.3, &user_info).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/\");</script>".to_owned(),
+        ));
+    }
 
+    let common_headers = extract_common_headers(&headers).unwrap();
+
+    // Also check media access
+    let medium_row = sqlx::query(
+        "SELECT id,name,description,upload,owner,likes,dislikes,views,type,visibility,restricted_to_group FROM media WHERE id=$1;"
+    )
+    .bind(mediumid.to_ascii_lowercase())
+    .fetch_one(&pool)
+    .await;
+
+    let medium = match medium_row {
+        Ok(row) => row,
+        Err(_) => {
+            return Html(minifi_html(
+                "<script>window.location.replace(\"/\");</script>".to_owned(),
+            ));
+        }
+    };
+
+    use sqlx::Row;
+    let m_visibility: String = medium.get("visibility");
+    let m_restricted: Option<String> = medium.get("restricted_to_group");
+    let m_owner: String = medium.get("owner");
+
+    if !can_access_restricted(&pool, &m_visibility, m_restricted.as_deref(), &m_owner, &user_info).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/\");</script>".to_owned(),
+        ));
+    }
+
+    let medium_id: String = medium.get("id");
     let medium_captions_exist: bool;
     let mut medium_captions_list: Vec<String> = Vec::new();
-    if std::path::Path::new(&format!("source/{}/captions/list.txt", medium.id)).exists() {
+    if std::path::Path::new(&format!("source/{}/captions/list.txt", medium_id)).exists() {
         medium_captions_exist = true;
-        for caption_name in read_lines_to_vec(&format!("source/{}/captions/list.txt", medium.id)) {
+        for caption_name in read_lines_to_vec(&format!("source/{}/captions/list.txt", medium_id)) {
             medium_captions_list.push(caption_name);
         }
     } else {
@@ -145,14 +203,14 @@ async fn medium_in_list(
     }
 
     let medium_chapters_exist: bool;
-    if std::path::Path::new(&format!("source/{}/chapters.vtt", medium.id)).exists() {
+    if std::path::Path::new(&format!("source/{}/chapters.vtt", medium_id)).exists() {
         medium_chapters_exist = true;
     } else {
         medium_chapters_exist = false;
     }
 
     let medium_previews_exist: bool;
-    if std::path::Path::new(&format!("source/{}/previews/previews.vtt", medium.id)).exists() {
+    if std::path::Path::new(&format!("source/{}/previews/previews.vtt", medium_id)).exists() {
         medium_previews_exist = true;
     } else {
         medium_previews_exist = false;
@@ -161,14 +219,14 @@ async fn medium_in_list(
     let sidebar = generate_sidebar(&config, "medium".to_owned());
     let template = MediumTemplate {
         sidebar,
-        medium_id: medium.id,
-        medium_name: medium.name,
-        medium_owner: medium.owner,
-        medium_likes: medium.likes,
-        medium_dislikes: medium.dislikes,
-        medium_upload: prettyunixtime(medium.upload).await,
-        medium_views: medium.views,
-        medium_type: medium.r#type,
+        medium_id,
+        medium_name: medium.get("name"),
+        medium_owner: medium.get("owner"),
+        medium_likes: medium.get("likes"),
+        medium_dislikes: medium.get("dislikes"),
+        medium_upload: prettyunixtime(medium.get("upload")).await,
+        medium_views: medium.get("views"),
+        medium_type: medium.get("type"),
         medium_captions_exist,
         medium_captions_list,
         medium_chapters_exist,
@@ -177,7 +235,7 @@ async fn medium_in_list(
         common_headers,
         is_logged_in,
         list_id: listid,
-        list_name: list.name,
+        list_name: list.4,
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -248,9 +306,25 @@ async fn hx_list_modal(
     .await
     .expect("Database error");
 
+    // Fetch user's groups for visibility selection in create form
+    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+        .bind(&user_info.login)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
     let template = HXListModalTemplate {
         lists,
         medium_id: mediumid,
+        owner_groups,
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -269,15 +343,27 @@ async fn hx_create_list(
     let user_info = user_info.unwrap();
 
     let list_id = generate_medium_id();
-    let is_public = form.public.is_some();
+    let visibility = match form.visibility.as_deref() {
+        Some("public") => "public",
+        Some("restricted") => "restricted",
+        _ => "hidden",
+    };
+    let is_public = visibility == "public";
+    let restricted_to_group = if visibility == "restricted" {
+        form.restricted_group.clone().filter(|g| !g.is_empty())
+    } else {
+        None
+    };
 
-    sqlx::query!(
-        "INSERT INTO lists (id, name, owner, public) VALUES ($1, $2, $3, $4);",
-        list_id,
-        form.name,
-        user_info.login,
-        is_public
+    sqlx::query(
+        "INSERT INTO lists (id, name, owner, public, visibility, restricted_to_group) VALUES ($1, $2, $3, $4, $5, $6);"
     )
+    .bind(&list_id)
+    .bind(&form.name)
+    .bind(&user_info.login)
+    .bind(is_public)
+    .bind(visibility)
+    .bind(&restricted_to_group)
     .execute(&pool)
     .await
     .expect("Database error");
@@ -301,9 +387,25 @@ async fn hx_create_list(
     .await
     .expect("Database error");
 
+    // Fetch user's groups for visibility selection in create form
+    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+        .bind(&user_info.login)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
     let template = HXListModalTemplate {
         lists,
         medium_id: mediumid,
+        owner_groups,
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -358,9 +460,24 @@ async fn hx_add_to_list(
     .await
     .expect("Database error");
 
+    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+        .bind(&user_info.login)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
     let template = HXListModalTemplate {
         lists,
         medium_id: mediumid,
+        owner_groups,
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -404,9 +521,24 @@ async fn hx_remove_from_list(
     .await
     .expect("Database error");
 
+    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+        .bind(&user_info.login)
+        .map(|row: sqlx::postgres::PgRow| {
+            use sqlx::Row;
+            UserGroup {
+                id: row.get("id"),
+                name: row.get("name"),
+                owner: row.get("owner"),
+            }
+        })
+        .fetch_all(&pool)
+        .await
+        .unwrap_or_default();
+
     let template = HXListModalTemplate {
         lists,
         medium_id: mediumid,
+        owner_groups,
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -455,13 +587,29 @@ async fn hx_delete_list(
 
 async fn hx_user_lists(
     Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let lists = sqlx::query_as!(
-        ListWithCount,
-        "SELECT l.id, l.name, l.owner, l.public, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND l.public = true ORDER BY l.created DESC;",
-        userid
+    let user = get_user_login(headers, &pool, session_store).await;
+    let user_login = user.map(|u| u.login).unwrap_or_default();
+
+    let lists: Vec<ListWithCount> = sqlx::query(
+        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND (l.visibility = 'public' OR (l.visibility = 'restricted' AND l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY l.created DESC;"
     )
+    .bind(&userid)
+    .bind(&user_login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        ListWithCount {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            visibility: row.get("visibility"),
+            restricted_to_group: row.get("restricted_to_group"),
+            item_count: row.get("item_count"),
+        }
+    })
     .fetch_all(&pool)
     .await
     .expect("Database error");

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,15 @@ async fn main() {
         .route("/hx/removefromlist/{listid}/{mediumid}", get(hx_remove_from_list))
         .route("/hx/deletelist/{listid}", get(hx_delete_list))
         .route("/hx/userlists/{userid}", get(hx_user_lists))
+        // Group management routes
+        .route("/studio/groups", get(studio_groups))
+        .route("/hx/studio/groups", get(hx_studio_groups))
+        .route("/hx/creategroup", post(hx_create_group))
+        .route("/hx/deletegroup/{groupid}", get(hx_delete_group))
+        .route("/hx/group/{groupid}/members", get(hx_group_members))
+        .route("/hx/group/{groupid}/addmember", post(hx_add_group_member))
+        .route("/hx/group/{groupid}/removemember/{login}", get(hx_remove_group_member))
+        .route("/hx/usergroups.json", get(hx_user_groups_json))
         .nest("/source", static_router("source"))
         .layer(Extension(pool))
         .layer(Extension(config))
@@ -191,3 +200,4 @@ include!("upload.rs");
 include!("concept.rs");
 include!("serve.rs");
 include!("lists.rs");
+include!("groups.rs");

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -37,21 +37,46 @@ async fn medium(
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let is_logged_in = is_logged(get_user_login(headers.clone(), &pool, session_store).await).await;
-    let common_headers = extract_common_headers(&headers).unwrap();
-    let medium = sqlx::query!(
-        "SELECT id,name,description,upload,owner,likes,dislikes,views,type FROM media WHERE id=$1;",
-        mediumid.to_ascii_lowercase()
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
+    let user = get_user_login(headers.clone(), &pool, session_store).await;
+    let is_logged_in = user.is_some();
 
+    // Fetch media with visibility info
+    let medium_row = sqlx::query(
+        "SELECT id,name,description,upload,owner,likes,dislikes,views,type,visibility,restricted_to_group FROM media WHERE id=$1;"
+    )
+    .bind(mediumid.to_ascii_lowercase())
+    .fetch_one(&pool)
+    .await;
+
+    let medium = match medium_row {
+        Ok(row) => row,
+        Err(_) => {
+            return Html(minifi_html(
+                "<script>window.location.replace(\"/\");</script>".to_owned(),
+            ));
+        }
+    };
+
+    use sqlx::Row;
+    let visibility: String = medium.get("visibility");
+    let restricted_to_group: Option<String> = medium.get("restricted_to_group");
+    let owner: String = medium.get("owner");
+
+    // Access control for restricted content
+    if !can_access_restricted(&pool, &visibility, restricted_to_group.as_deref(), &owner, &user).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/\");</script>".to_owned(),
+        ));
+    }
+
+    let common_headers = extract_common_headers(&headers).unwrap();
+
+    let medium_id: String = medium.get("id");
     let medium_captions_exist: bool;
     let mut medium_captions_list: Vec<String> = Vec::new();
-    if std::path::Path::new(&format!("source/{}/captions/list.txt", medium.id)).exists() {
+    if std::path::Path::new(&format!("source/{}/captions/list.txt", medium_id)).exists() {
         medium_captions_exist = true;
-        for caption_name in read_lines_to_vec(&format!("source/{}/captions/list.txt", medium.id)) {
+        for caption_name in read_lines_to_vec(&format!("source/{}/captions/list.txt", medium_id)) {
             medium_captions_list.push(caption_name);
         }
     } else {
@@ -59,14 +84,14 @@ async fn medium(
     }
 
     let medium_chapters_exist: bool;
-    if std::path::Path::new(&format!("source/{}/chapters.vtt", medium.id)).exists() {
+    if std::path::Path::new(&format!("source/{}/chapters.vtt", medium_id)).exists() {
         medium_chapters_exist = true;
     } else {
         medium_chapters_exist = false;
     }
 
     let medium_previews_exist: bool;
-    if std::path::Path::new(&format!("source/{}/previews/previews.vtt", medium.id)).exists() {
+    if std::path::Path::new(&format!("source/{}/previews/previews.vtt", medium_id)).exists() {
         medium_previews_exist = true;
     } else {
         medium_previews_exist = false;
@@ -75,14 +100,14 @@ async fn medium(
     let sidebar = generate_sidebar(&config, "medium".to_owned());
     let template = MediumTemplate {
         sidebar,
-        medium_id: medium.id,
-        medium_name: medium.name,
-        medium_owner: medium.owner,
-        medium_likes: medium.likes,
-        medium_dislikes: medium.dislikes,
-        medium_upload: prettyunixtime(medium.upload).await,
-        medium_views: medium.views,
-        medium_type: medium.r#type,
+        medium_id,
+        medium_name: medium.get("name"),
+        medium_owner: medium.get("owner"),
+        medium_likes: medium.get("likes"),
+        medium_dislikes: medium.get("dislikes"),
+        medium_upload: prettyunixtime(medium.get("upload")).await,
+        medium_views: medium.get("views"),
+        medium_type: medium.get("type"),
         medium_captions_exist,
         medium_captions_list,
         medium_chapters_exist,

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -1,12 +1,27 @@
 async fn hx_recommended(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Result<Html<Vec<u8>>, axum::response::Response> {
-    let media: Vec<Medium> = sqlx::query_as!(
-        Medium,
-        "SELECT id, name, owner, views, type FROM media WHERE public = true LIMIT 20;"
+    let user = get_user_login(headers, &pool, session_store).await;
+    let user_login = user.map(|u| u.login).unwrap_or_default();
+
+    let media: Vec<Medium> = sqlx::query(
+        "SELECT id, name, owner, views, type FROM media WHERE visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)) LIMIT 20;"
     )
+    .bind(&user_login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        Medium {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            views: row.get("views"),
+            r#type: row.get("type"),
+        }
+    })
     .fetch_all(&pool)
     .await
     .map_err(|_| {

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -112,11 +112,21 @@ async fn hx_studio_lists(
         ));
     }
     let user_info = user_info.unwrap();
-    let lists = sqlx::query_as!(
-        ListWithCount,
-        "SELECT l.id, l.name, l.owner, l.public, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
-        user_info.login
+    let lists: Vec<ListWithCount> = sqlx::query(
+        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;"
     )
+    .bind(&user_info.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        ListWithCount {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            visibility: row.get("visibility"),
+            restricted_to_group: row.get("restricted_to_group"),
+            item_count: row.get("item_count"),
+        }
+    })
     .fetch_all(&pool)
     .await
     .expect("Database error");
@@ -128,7 +138,8 @@ async fn hx_studio_lists(
 struct MediumEdit {
     id: String,
     name: String,
-    public: bool,
+    visibility: String,
+    restricted_to_group: String,
     medium_type: String,
 }
 #[derive(Template)]
@@ -138,6 +149,7 @@ struct StudioEditTemplate {
     config: Config,
     medium: MediumEdit,
     common_headers: CommonHeaders,
+    owner_groups: Vec<UserGroup>,
 }
 async fn studio_edit(
     Extension(config): Extension<Config>,
@@ -154,32 +166,51 @@ async fn studio_edit(
     }
     let user_info = user_info.unwrap();
 
-    let medium = sqlx::query!(
-        "SELECT id,name,owner,public,type FROM media WHERE id=$1;",
-        mediumid
+    let medium = sqlx::query(
+        "SELECT id,name,owner,visibility,restricted_to_group,type FROM media WHERE id=$1;"
     )
+    .bind(&mediumid)
     .fetch_one(&pool)
     .await;
 
     match medium {
         Ok(record) => {
-            if record.owner != user_info.login {
+            use sqlx::Row;
+            let owner: String = record.get("owner");
+            if owner != user_info.login {
                 return Html(minifi_html(
                     "<script>window.location.replace(\"/studio\");</script>".to_owned(),
                 ));
             }
+
+            // Fetch user's groups for the dropdown
+            let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+                .bind(&user_info.login)
+                .map(|row: sqlx::postgres::PgRow| {
+                    UserGroup {
+                        id: row.get("id"),
+                        name: row.get("name"),
+                        owner: row.get("owner"),
+                    }
+                })
+                .fetch_all(&pool)
+                .await
+                .unwrap_or_default();
+
             let sidebar = generate_sidebar(&config, "studio".to_owned());
             let common_headers = extract_common_headers(&headers).unwrap();
             let template = StudioEditTemplate {
                 sidebar,
                 config,
                 medium: MediumEdit {
-                    id: record.id,
-                    name: record.name,
-                    public: record.public,
-                    medium_type: record.r#type,
+                    id: record.get("id"),
+                    name: record.get("name"),
+                    visibility: record.get("visibility"),
+                    restricted_to_group: record.get::<Option<String>, _>("restricted_to_group").unwrap_or_default(),
+                    medium_type: record.get("type"),
                 },
                 common_headers,
+                owner_groups,
             };
             Html(minifi_html(template.render().unwrap()))
         }
@@ -194,6 +225,7 @@ struct EditForm {
     medium_name: String,
     medium_description: String,
     medium_visibility: String,
+    medium_restricted_group: Option<String>,
 }
 async fn studio_edit_save(
     Extension(pool): Extension<PgPool>,
@@ -223,17 +255,28 @@ async fn studio_edit_save(
         }
     }
 
-    let ispublic = form.medium_visibility == "public";
+    let visibility = match form.medium_visibility.as_str() {
+        "public" | "hidden" | "restricted" => form.medium_visibility.clone(),
+        _ => "hidden".to_owned(),
+    };
+    let ispublic = visibility == "public";
+    let restricted_to_group = if visibility == "restricted" {
+        form.medium_restricted_group.clone().filter(|g| !g.is_empty())
+    } else {
+        None
+    };
     let description: serde_json::Value =
         serde_json::from_str(&form.medium_description).unwrap_or(serde_json::Value::Null);
 
-    let update_result = sqlx::query!(
-        "UPDATE media SET name=$1, description=$2, public=$3 WHERE id=$4;",
-        form.medium_name,
-        description,
-        ispublic,
-        mediumid
+    let update_result = sqlx::query(
+        "UPDATE media SET name=$1, description=$2, public=$3, visibility=$4, restricted_to_group=$5 WHERE id=$6;"
     )
+    .bind(&form.medium_name)
+    .bind(&description)
+    .bind(ispublic)
+    .bind(&visibility)
+    .bind(&restricted_to_group)
+    .bind(&mediumid)
     .execute(&pool)
     .await;
 

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -37,16 +37,25 @@ async fn hx_subscriptions(
         }
     };
 
-    let media = sqlx::query_as!(
-        Medium,
+    let media: Vec<Medium> = sqlx::query(
         "SELECT m.id, m.name, m.owner, m.views, m.type
          FROM media m
          INNER JOIN subscriptions s ON m.owner = s.target
-         WHERE s.subscriber = $1 AND m.public = true
+         WHERE s.subscriber = $1 AND (m.visibility = 'public' OR (m.visibility = 'restricted' AND m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)))
          ORDER BY m.upload DESC
-         LIMIT 100;",
-        user.login
+         LIMIT 100;"
     )
+    .bind(&user.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        Medium {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            views: row.get("views"),
+            r#type: row.get("type"),
+        }
+    })
     .fetch_all(&pool)
     .await
     .expect("Database error");

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -19,10 +19,29 @@ async fn trending(
     Html(minifi_html(template.render().unwrap()))
 }
 
-async fn hx_trending(Extension(config): Extension<Config>, Extension(pool): Extension<PgPool>) -> axum::response::Html<Vec<u8>> {
-    let media = sqlx::query_as!(Medium,
-        "SELECT id,name,owner,views,type FROM media WHERE public=true ORDER BY likes DESC LIMIT 100;"
+async fn hx_trending(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user = get_user_login(headers, &pool, session_store).await;
+    let user_login = user.map(|u| u.login).unwrap_or_default();
+
+    let media: Vec<Medium> = sqlx::query(
+        "SELECT id,name,owner,views,type FROM media WHERE visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)) ORDER BY likes DESC LIMIT 100;"
     )
+    .bind(&user_login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        Medium {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            views: row.get("views"),
+            r#type: row.get("type"),
+        }
+    })
     .fetch_all(&pool)
     .await
     .expect("Database error");

--- a/templates/pages/concept.html
+++ b/templates/pages/concept.html
@@ -123,9 +123,39 @@
                                         Public
                                     </option>
                                     <option value="hidden">Hidden</option>
+                                    <option value="restricted">Restricted to Group</option>
                                 </select>
+                                <select
+                                    id="medium_restricted_group"
+                                    name="medium_restricted_group"
+                                    class="form-select mt-2"
+                                    style="display:none"
+                                >
+                                    <option value="">-- Select a group --</option>
+                                    {% for group in owner_groups %}
+                                    <option value="{{ group.id }}">{{ group.name }}</option>
+                                    {% endfor %}
+                                </select>
+                                {% if owner_groups.is_empty() %}
+                                <small class="text-secondary mt-1" id="no-groups-hint" style="display:none">
+                                    You have no groups yet. <a href="/studio/groups" class="text-primary">Create one</a> to use restricted visibility.
+                                </small>
+                                {% endif %}
                             </div>
                         </div>
+                        <script>
+                        document.getElementById('medium_visibility').addEventListener('change', function() {
+                            var groupSelect = document.getElementById('medium_restricted_group');
+                            var noGroupsHint = document.getElementById('no-groups-hint');
+                            if (this.value === 'restricted') {
+                                groupSelect.style.display = '';
+                                if (noGroupsHint) noGroupsHint.style.display = '';
+                            } else {
+                                groupSelect.style.display = 'none';
+                                if (noGroupsHint) noGroupsHint.style.display = 'none';
+                            }
+                        });
+                        </script>
                         <div class="form-group row my-3">
                             <div class="offset-4 col-8">
                                 <button

--- a/templates/pages/hx-group-members.html
+++ b/templates/pages/hx-group-members.html
@@ -1,0 +1,53 @@
+<div class="card border p-3 mt-3">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h5 class="text-white m-0"><i class="fa-solid fa-users me-2"></i>{{ group.name }} - Members</h5>
+    </div>
+    <hr class="mt-0">
+    {% if is_owner %}
+    <form hx-post="/hx/group/{{ group.id }}/addmember" hx-target="#group-members-panel" class="mb-3">
+        <div class="input-group" style="max-width:400px;">
+            <input type="text" name="user_login" class="form-control" placeholder="Username to add..." required>
+            <button type="submit" class="btn btn-primary">
+                <i class="fa-solid fa-user-plus"></i>&nbsp;Add
+            </button>
+        </div>
+    </form>
+    {% endif %}
+    {% if members.is_empty() %}
+    <p class="text-secondary">No members yet. Add users by their username above.</p>
+    {% else %}
+    <div class="table-responsive">
+        <table class="table table-dark table-hover">
+            <thead>
+                <tr>
+                    <th>Username</th>
+                    {% if is_owner %}
+                    <th style="width:80px;"></th>
+                    {% endif %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for member in members %}
+                <tr>
+                    <td>
+                        <a href="/channel/{{ member.user_login }}" class="text-white text-decoration-none">
+                            <i class="fa-solid fa-user me-1"></i>{{ member.user_login }}
+                        </a>
+                    </td>
+                    {% if is_owner %}
+                    <td>
+                        <a hx-get="/hx/group/{{ group.id }}/removemember/{{ member.user_login }}"
+                           hx-target="#group-members-panel"
+                           hx-confirm="Remove {{ member.user_login }} from this group?"
+                           class="btn btn-sm btn-outline-danger" title="Remove member">
+                            <i class="fa-solid fa-user-minus"></i>
+                        </a>
+                    </td>
+                    {% endif %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+</div>

--- a/templates/pages/hx-listmodal.html
+++ b/templates/pages/hx-listmodal.html
@@ -38,9 +38,18 @@
                     <i class="fa-solid fa-plus"></i> Create
                 </button>
             </div>
-            <div class="form-check mx-2">
-                <input type="checkbox" name="public" class="form-check-input" id="listPublicCheck">
-                <label class="form-check-label text-secondary" for="listPublicCheck">Public</label>
+            <div class="d-flex align-items-center gap-2 mx-2">
+                <select name="visibility" class="form-select form-select-sm" style="width:auto;" id="listmodal-visibility" onchange="document.getElementById('listmodal-group-select').style.display = this.value === 'restricted' ? '' : 'none'">
+                    <option value="hidden">Private</option>
+                    <option value="public">Public</option>
+                    <option value="restricted">Restricted to Group</option>
+                </select>
+                <select name="restricted_group" class="form-select form-select-sm" style="width:auto;display:none;" id="listmodal-group-select">
+                    <option value="">-- Group --</option>
+                    {% for group in owner_groups %}
+                    <option value="{{ group.id }}">{{ group.name }}</option>
+                    {% endfor %}
+                </select>
             </div>
         </form>
     </div>

--- a/templates/pages/hx-studio-groups.html
+++ b/templates/pages/hx-studio-groups.html
@@ -1,0 +1,26 @@
+{% for group in groups %}
+<div class="col-xl-4 col-lg-6 col-12 my-3">
+    <div class="bg-hover rounded border p-3" style="min-height: 80px;">
+        <div class="d-flex justify-content-between align-items-start">
+            <div>
+                <b class="text-white"><i class="fa-solid fa-users me-2"></i>{{ group.name }}</b>
+                <p class="text-secondary mb-0">{{ group.member_count.unwrap_or(0) }} members</p>
+            </div>
+            <div class="d-flex gap-2">
+                <span hx-get="/hx/group/{{ group.id }}/members" hx-target="#group-members-panel" class="text-primary" style="cursor:pointer;" title="Manage members">
+                    <i class="fa-solid fa-user-gear"></i>
+                </span>
+                <span hx-get="/hx/deletegroup/{{ group.id }}" hx-target="#groups-list" hx-confirm="Are you sure you want to delete this group? Media and lists restricted to this group will become hidden." class="text-secondary" style="cursor:pointer;" title="Delete group">
+                    <i class="fa-solid fa-trash"></i>
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+{% endfor %}
+{% if groups.is_empty() %}
+<p class="text-secondary text-center">No groups yet. Create one above to restrict media and lists to specific users.</p>
+{% endif %}
+<div class="col-12">
+    <div id="group-members-panel"></div>
+</div>

--- a/templates/pages/hx-studio-lists.html
+++ b/templates/pages/hx-studio-lists.html
@@ -8,8 +8,10 @@
             <span hx-get="/hx/deletelist/{{ list.id }}" hx-confirm="Are you sure you want to delete this list?" class="text-secondary" style="cursor:pointer;" title="Delete list"><i class="fa-solid fa-trash"></i></span>
         </div>
         <p class="text-secondary mb-0">{{ list.item_count.unwrap_or(0) }} items
-            {% if list.public %}
+            {% if list.visibility == "public" %}
             <i class="fa-solid fa-globe ms-1" title="Public"></i>
+            {% else if list.visibility == "restricted" %}
+            <i class="fa-solid fa-users ms-1" title="Restricted to Group"></i>
             {% else %}
             <i class="fa-solid fa-lock ms-1" title="Private"></i>
             {% endif %}

--- a/templates/pages/hx-userlists.html
+++ b/templates/pages/hx-userlists.html
@@ -3,7 +3,11 @@
     <a href="/list/{{ list.id }}" class="text-decoration-none" preload="mouseover">
         <div class="bg-hover rounded border p-3" style="min-height: 80px;">
             <b class="text-white"><i class="fa-solid fa-list me-2"></i>{{ list.name }}</b>
-            <p class="text-secondary mb-0">{{ list.item_count.unwrap_or(0) }} items</p>
+            <p class="text-secondary mb-0">{{ list.item_count.unwrap_or(0) }} items
+                {% if list.visibility == "restricted" %}
+                <i class="fa-solid fa-users ms-1" title="Restricted"></i>
+                {% endif %}
+            </p>
         </div>
     </a>
 </div>

--- a/templates/pages/list.html
+++ b/templates/pages/list.html
@@ -24,8 +24,10 @@
                     </div>
                     <p class="text-secondary">
                         by <a href="/channel/{{ list.owner }}" class="text-secondary text-decoration-none">{{ list.owner }}</a>
-                        {% if list.public %}
+                        {% if list.visibility == "public" %}
                         <i class="fa-solid fa-globe fa-sm ms-2"></i> Public
+                        {% else if list.visibility == "restricted" %}
+                        <i class="fa-solid fa-users fa-sm ms-2"></i> Restricted
                         {% else %}
                         <i class="fa-solid fa-lock fa-sm ms-2"></i> Private
                         {% endif %}

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -128,15 +128,62 @@
                                     class="form-select"
                                     required
                                 >
-                                    <option value="public" {% if medium.public %}selected{% endif %}>
+                                    <option value="public" {% if medium.visibility == "public" %}selected{% endif %}>
                                         Public
                                     </option>
-                                    <option value="hidden" {% if !medium.public %}selected{% endif %}>
+                                    <option value="hidden" {% if medium.visibility == "hidden" %}selected{% endif %}>
                                         Hidden
                                     </option>
+                                    <option value="restricted" {% if medium.visibility == "restricted" %}selected{% endif %}>
+                                        Restricted to Group
+                                    </option>
                                 </select>
+                                <select
+                                    id="medium_restricted_group"
+                                    name="medium_restricted_group"
+                                    class="form-select mt-2"
+                                    style="display:none"
+                                >
+                                    <option value="">-- Select a group --</option>
+                                    {% for group in owner_groups %}
+                                    <option value="{{ group.id }}">
+                                        {{ group.name }}
+                                    </option>
+                                    {% endfor %}
+                                </select>
+                                {% if owner_groups.is_empty() %}
+                                <small class="text-secondary mt-1" id="no-groups-hint" style="display:none">
+                                    You have no groups yet. <a href="/studio/groups" class="text-primary">Create one</a> to use restricted visibility.
+                                </small>
+                                {% endif %}
                             </div>
                         </div>
+                        <script>
+                        document.addEventListener('DOMContentLoaded', function() {
+                            var visSelect = document.getElementById('medium_visibility');
+                            var groupSelect = document.getElementById('medium_restricted_group');
+                            var noGroupsHint = document.getElementById('no-groups-hint');
+
+                            // Set initial selected group value
+                            var currentGroup = '{{ medium.restricted_to_group }}';
+                            if (currentGroup) {
+                                groupSelect.value = currentGroup;
+                            }
+
+                            // Show/hide group selector based on visibility
+                            function updateGroupVisibility() {
+                                if (visSelect.value === 'restricted') {
+                                    groupSelect.style.display = '';
+                                    if (noGroupsHint) noGroupsHint.style.display = '';
+                                } else {
+                                    groupSelect.style.display = 'none';
+                                    if (noGroupsHint) noGroupsHint.style.display = 'none';
+                                }
+                            }
+                            updateGroupVisibility();
+                            visSelect.addEventListener('change', updateGroupVisibility);
+                        });
+                        </script>
                         <div class="form-group row my-3">
                             <div class="offset-4 col-8">
                                 <button

--- a/templates/pages/studio-groups.html
+++ b/templates/pages/studio-groups.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    {% include "component-dependencies.html" %}
+
+    <title>Groups</title>
+
+    <meta property="og:title" content="{{ config.instancename }} Groups" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://{{ common_headers.host }}/studio/groups" />
+</head>
+
+<body hx-ext="preload">
+    {{ sidebar }}
+    {% include "component-navbar.html" %}
+    <div class="row maincontentrow g-3 py-2 ps-2 w-100">
+        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="card py-3 px-3 text-white" style="min-height:30vh;">
+                <div class="row justify-content-between align-items-center">
+                    <h3 class="my-2 mx-3" style="width:auto;"><i class="fa-solid fa-users"></i>&nbsp;Groups</h3>
+                    <div style="width:auto;">
+                        <a href="/studio" class="btn btn-secondary mx-1" preload="mouseover">
+                            <i class="fa-solid fa-arrow-left"></i>&nbsp;Back to Studio
+                        </a>
+                    </div>
+                </div>
+                <hr>
+                <div class="mx-3 mb-3">
+                    <form hx-post="/hx/creategroup" hx-target="#groups-list">
+                        <div class="input-group" style="max-width:500px;">
+                            <input type="text" name="name" class="form-control" placeholder="New group name..." required>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fa-solid fa-plus"></i>&nbsp;Create Group
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                <div id="groups-list" hx-get="/hx/studio/groups" hx-trigger="load" class="row mb-3 hx-placeholder">
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/templates/pages/studio.html
+++ b/templates/pages/studio.html
@@ -19,13 +19,15 @@
             <div class="card py-3 px-3 text-white" style="min-height:30vh;">
                 <div class="row justify-content-between">
                     <h3 class="my-2 mx-3" style="width:200px;">Studio</h3>
-                    <div style="width:600px;">
+                    <div style="width:750px;">
                     <a href="/upload" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
                             class="fa-solid fa-upload"></i>&nbsp;Upload</a>
                     <a href="/studio/concepts" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
                             class="fa-solid fa-wand-magic-sparkles"></i>&nbsp;Concepts</a>
                     <a href="/studio/lists" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
                             class="fa-solid fa-list"></i>&nbsp;Lists</a>
+                    <a href="/studio/groups" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
+                            class="fa-solid fa-users"></i>&nbsp;Groups</a>
                     </div>
                 </div>
                 <hr>


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive user groups system that allows content creators to manage access to their media and lists through group-based restrictions. Users can create groups, manage members, and restrict content visibility to specific groups.

## Key Changes

### New Features
- **User Groups Management** (`src/groups.rs`): Complete CRUD operations for user groups including:
  - Create, read, and delete groups
  - Add/remove group members
  - Member count tracking
  - Group ownership verification
  
- **Restricted Content Access**: Extended visibility model from boolean `public` to three-tier system:
  - `public`: Accessible to all users
  - `hidden`: Only accessible via direct link
  - `restricted`: Only accessible to group members and owner
  
- **Access Control**: New `can_access_restricted()` helper function that validates user access based on visibility settings and group membership

### Database Schema Updates
- Added `visibility` and `restricted_to_group` columns to `media` and `lists` tables
- Created new `user_groups` and `user_group_members` tables
- Maintained backward compatibility with existing `public` boolean column

### Modified Endpoints
- **Media/Lists**: Updated all queries to filter by visibility and group membership:
  - `trending`: Shows public content and restricted content user has access to
  - `channel`: Filters user media by visibility
  - `subscriptions`: Respects visibility restrictions
  - `medium_in_list`: Validates access before displaying
  
- **Studio**: Added group management UI and visibility controls:
  - Group creation and deletion interface
  - Member management panel
  - Visibility dropdown with group selection for media/lists

### UI Templates
- New `studio-groups.html`: Main groups management page
- New `hx-studio-groups.html`: Groups list with HTMX integration
- New `hx-group-members.html`: Member management interface
- Updated `studio-edit.html` and `concept.html`: Added restricted group selection dropdown
- Updated `hx-listmodal.html`: Changed from checkbox to dropdown for visibility selection

### Implementation Details
- All database queries updated to use parameterized queries with `.bind()` instead of macros for flexibility
- Group ownership verification on all modification endpoints
- Cascade deletion: Deleting a group reverts restricted media/lists to hidden
- Member existence validation before adding to groups
- HTMX-based UI for seamless group and member management

https://claude.ai/code/session_01UuTqSwhLKEF48Aix8DMNVY