### PR TITLE
Replace in-memory session store with Redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ ahash = "*"
 argon2 = "0.5"
 rand = "0.9"
 meilisearch-sdk = "0.32"
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }

--- a/example-deployment/config.json
+++ b/example-deployment/config.json
@@ -1,5 +1,6 @@
 {
   "dbconnection": "postgresql://vids:YOURPASSWORD@postgres:5432/vids",
+  "redis_url": "redis://redis:6379",
   "instancename": "vids.cz",
   "welcome": "Welcome to our experimental open-source multimedia sharing platform! Dive into a vibrant community where creativity knows no bounds. Whether you're a photographer, musician, filmmaker, or digital artist, our site offers the perfect space to showcase your work, connect with like-minded individuals, and explore an endless stream of inspiration. Join us today and start sharing your creativity with the world!",
   "custom_session_domain": ".vids.cz"

--- a/example-deployment/docker-compose.yml
+++ b/example-deployment/docker-compose.yml
@@ -13,6 +13,13 @@ services:
      - ./config.json:/config.json
    depends_on:
      - postgres
+     - redis
+ redis:
+    image: redis:7-alpine
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - ./redis-data:/data
  postgres:
     image: postgres:18-alpine
     ports:

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -63,11 +63,11 @@ WHERE
 async fn hx_usermedia(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, session_store).await;
+    let user = get_user_login(headers, &pool, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
 
     let media: Vec<Medium> = sqlx::query(

--- a/src/chapters.rs
+++ b/src/chapters.rs
@@ -6,11 +6,11 @@ struct ChapterData {
 
 async fn studio_chapters_get(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::Value::Array(vec![]));
     }
@@ -43,12 +43,12 @@ async fn studio_chapters_get(
 
 async fn studio_chapters_save(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Json(chapters): Json<Vec<ChapterData>>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -80,12 +80,12 @@ struct HXCommentSingleTemplate {
 
 async fn hx_add_comment(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<CommentForm>,
 ) -> impl IntoResponse {
-    let user = get_user_login(headers, &pool, session_store).await;
+    let user = get_user_login(headers, &pool, redis.clone()).await;
 
     if user.is_none() {
         return (StatusCode::UNAUTHORIZED, Html(Vec::new()));

--- a/src/concept.rs
+++ b/src/concept.rs
@@ -16,10 +16,10 @@ struct ConceptsTemplate {
 async fn concepts(
     Extension(pool): Extension<PgPool>,
     Extension(config): Extension<Config>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -42,10 +42,10 @@ struct HXConceptsTemplate {
 }
 async fn hx_concepts(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let userinfo = get_user_login(headers, &pool, session_store).await.unwrap();
+    let userinfo = get_user_login(headers, &pool, redis.clone()).await.unwrap();
 
     let concepts = sqlx::query_as!(
         MediumConcept,
@@ -71,11 +71,11 @@ struct ConceptTemplate {
 async fn concept(
     Extension(pool): Extension<PgPool>,
     Extension(config): Extension<Config>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     Path(conceptid): Path<String>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -127,12 +127,12 @@ struct PublishForm {
 }
 async fn publish(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(conceptid): Path<String>,
     Form(form): Form<PublishForm>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -39,10 +39,10 @@ struct StudioGroupsTemplate {
 async fn studio_groups(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -66,10 +66,10 @@ struct HXStudioGroupsTemplate {
 
 async fn hx_studio_groups(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -100,11 +100,11 @@ async fn hx_studio_groups(
 
 async fn hx_create_group(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<CreateGroupForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -144,11 +144,11 @@ async fn hx_create_group(
 
 async fn hx_delete_group(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(groupid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -197,6 +197,9 @@ async fn hx_delete_group(
         .await
         .expect("Database error");
 
+    // Invalidate Redis group membership cache
+    let _: Result<(), _> = redis.clone().del(format!("group:{}:members", groupid)).await;
+
     // Return updated groups list
     let groups: Vec<UserGroupWithCount> = sqlx::query(
         "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
@@ -229,11 +232,11 @@ struct HXGroupMembersTemplate {
 
 async fn hx_group_members(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(groupid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -281,12 +284,12 @@ async fn hx_group_members(
 
 async fn hx_add_group_member(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(groupid): Path<String>,
     Form(form): Form<AddMemberForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -329,6 +332,9 @@ async fn hx_add_group_member(
             .bind(&form.user_login)
             .execute(&pool)
             .await;
+
+        // Invalidate Redis group membership cache
+        let _: Result<(), _> = redis.clone().del(format!("group:{}:members", groupid)).await;
     }
 
     // Return updated members list
@@ -354,11 +360,11 @@ async fn hx_add_group_member(
 
 async fn hx_remove_group_member(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((groupid, login)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -394,6 +400,9 @@ async fn hx_remove_group_member(
         .await
         .expect("Database error");
 
+    // Invalidate Redis group membership cache
+    let _: Result<(), _> = redis.clone().del(format!("group:{}:members", groupid)).await;
+
     // Return updated members list
     let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
         .bind(&groupid)
@@ -417,10 +426,10 @@ async fn hx_remove_group_member(
 
 async fn hx_user_groups_json(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> Json<Vec<UserGroup>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(vec![]);
     }

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -96,14 +96,16 @@ fn extract_common_headers(headers: &HeaderMap) -> Result<CommonHeaders, &'static
 async fn get_user_login(
     headers: HeaderMap,
     pool: &PgPool,
-    session_store: Arc<Mutex<AHashMap<String, String>>>,
+    mut redis: RedisConn,
 ) -> Option<User> {
     let session_cookie = parse_cookie_header(headers.get("Cookie")?.to_str().ok()?)
         .get("session")?
         .to_owned();
 
-    let session_store_guard = session_store.lock().await;
-    let login = session_store_guard.get(&session_cookie)?;
+    let login: String = redis
+        .get(format!("session:{}", session_cookie))
+        .await
+        .ok()?;
 
     let name = sqlx::query!("SELECT name FROM users WHERE login=$1;", login)
         .fetch_one(pool)
@@ -112,7 +114,7 @@ async fn get_user_login(
         .name;
 
     Some(User {
-        login: login.to_owned(),
+        login,
         name,
     })
 }
@@ -287,18 +289,34 @@ async fn move_dir(src: &str, dest: &str) -> io::Result<()> {
     Ok(())
 }
 
-async fn is_group_member(pool: &PgPool, group_id: &str, user_login: &str) -> bool {
-    sqlx::query("SELECT 1 FROM user_group_members WHERE group_id = $1 AND user_login = $2")
+async fn is_group_member(pool: &PgPool, group_id: &str, user_login: &str, mut redis: RedisConn) -> bool {
+    let redis_key = format!("group:{}:members", group_id);
+
+    // Check if membership set is cached in Redis
+    let key_exists: bool = redis.exists(&redis_key).await.unwrap_or(false);
+
+    if key_exists {
+        return redis.sismember(&redis_key, user_login).await.unwrap_or(false);
+    }
+
+    // Cache miss - load all members from DB and cache in Redis
+    let members: Vec<String> = sqlx::query_scalar("SELECT user_login FROM user_group_members WHERE group_id = $1")
         .bind(group_id)
-        .bind(user_login)
-        .fetch_optional(pool)
+        .fetch_all(pool)
         .await
-        .ok()
-        .flatten()
-        .is_some()
+        .unwrap_or_default();
+
+    let is_member = members.contains(&user_login.to_owned());
+
+    if !members.is_empty() {
+        let _: Result<(), _> = redis.sadd(&redis_key, &members).await;
+        let _: Result<(), _> = redis.expire(&redis_key, 3600).await;
+    }
+
+    is_member
 }
 
-async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_group: Option<&str>, owner: &str, user: &Option<User>) -> bool {
+async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_group: Option<&str>, owner: &str, user: &Option<User>, redis: RedisConn) -> bool {
     match visibility {
         "public" => true,
         "restricted" => {
@@ -307,7 +325,7 @@ async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_gr
                     return true;
                 }
                 if let Some(group_id) = restricted_to_group {
-                    return is_group_member(pool, group_id, &u.login).await;
+                    return is_group_member(pool, group_id, &u.login, redis).await;
                 }
             }
             false

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -65,7 +65,7 @@ struct HXUserListsTemplate {
 async fn list_page(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(listid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
@@ -94,14 +94,14 @@ async fn list_page(
         }
     };
 
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     let is_owner = user_info
         .as_ref()
         .map(|u| u.login == list.owner)
         .unwrap_or(false);
 
     // Access control for restricted lists
-    if !is_owner && !can_access_restricted(&pool, &list.visibility, list.restricted_to_group.as_deref(), &list.owner, &user_info).await {
+    if !is_owner && !can_access_restricted(&pool, &list.visibility, list.restricted_to_group.as_deref(), &list.owner, &user_info, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
@@ -120,7 +120,7 @@ async fn list_page(
 async fn medium_in_list(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
@@ -149,12 +149,12 @@ async fn medium_in_list(
         }
     };
 
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     let is_logged_in = user_info.is_some();
 
     // Access control for restricted lists
     let is_owner = user_info.as_ref().map(|u| u.login == list.3).unwrap_or(false);
-    if !is_owner && !can_access_restricted(&pool, &list.1, list.2.as_deref(), &list.3, &user_info).await {
+    if !is_owner && !can_access_restricted(&pool, &list.1, list.2.as_deref(), &list.3, &user_info, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
@@ -184,7 +184,7 @@ async fn medium_in_list(
     let m_restricted: Option<String> = medium.get("restricted_to_group");
     let m_owner: String = medium.get("owner");
 
-    if !can_access_restricted(&pool, &m_visibility, m_restricted.as_deref(), &m_owner, &user_info).await {
+    if !can_access_restricted(&pool, &m_visibility, m_restricted.as_deref(), &m_owner, &user_info, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
@@ -286,11 +286,11 @@ async fn hx_list_sidebar(
 
 async fn hx_list_modal(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -331,12 +331,12 @@ async fn hx_list_modal(
 
 async fn hx_create_list(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<CreateListForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -412,11 +412,11 @@ async fn hx_create_list(
 
 async fn hx_add_to_list(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -484,11 +484,11 @@ async fn hx_add_to_list(
 
 async fn hx_remove_from_list(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -545,11 +545,11 @@ async fn hx_remove_from_list(
 
 async fn hx_delete_list(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(listid): Path<String>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
@@ -587,11 +587,11 @@ async fn hx_delete_list(
 
 async fn hx_user_lists(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, session_store).await;
+    let user = get_user_login(headers, &pool, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
 
     let lists: Vec<ListWithCount> = sqlx::query(

--- a/src/login_handler.rs
+++ b/src/login_handler.rs
@@ -23,7 +23,7 @@ struct User {
 async fn hx_login(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(mut redis): Extension<RedisConn>,
     Form(form): Form<LoginForm>,
 ) -> impl IntoResponse {
     let password_hash_get = sqlx::query!(
@@ -58,10 +58,10 @@ async fn hx_login(
             session_restriction = "Path=/".to_owned()
         }
         let session_cookie_set = format!("session={}; {}", session_cookie_value, session_restriction);
-        session_store
-            .lock()
+        let _: () = redis
+            .set(format!("session:{}", session_cookie_value), &form.login)
             .await
-            .insert(session_cookie_value.clone(), form.login);
+            .unwrap();
 
         let mut response_headers = HeaderMap::new();
         response_headers.insert("Set-Cookie", session_cookie_set.parse().unwrap());
@@ -77,12 +77,12 @@ async fn hx_login(
 
 async fn hx_logout(
     headers: HeaderMap,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(mut redis): Extension<RedisConn>,
 ) -> axum::response::Html<String> {
     let session_cookie = parse_cookie_header(headers.get("Cookie").unwrap().to_str().unwrap())
         .get("session")
         .unwrap()
         .to_owned();
-    session_store.lock().await.remove_entry(&session_cookie);
+    let _: () = redis.del(format!("session:{}", session_cookie)).await.unwrap();
     Html("<h1>LOGOUT SUCESS</h1><script>window.location.replace(\"/\");</script>".to_owned())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,18 +25,22 @@ use chrono::{DateTime, Datelike, Local, Timelike};
 use memory_serve::{load_assets, MemoryServe};
 use rand::{rng, Rng};
 use meilisearch_sdk::client::Client as MeilisearchClient;
+use redis::AsyncCommands;
 use serde::Deserialize;
 use serde::Serialize;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use std::io::BufRead;
 use std::sync::Arc;
-use tokio::{fs, io, io::AsyncWriteExt, sync::Mutex};
+use tokio::{fs, io, io::AsyncWriteExt};
 use tower_http::services::ServeDir;
+
+type RedisConn = redis::aio::ConnectionManager;
 
 #[derive(Deserialize, Clone)]
 struct Config {
     dbconnection: String,
+    redis_url: String,
     instancename: String,
     welcome: String,
     custom_session_domain: Option<String>,
@@ -92,10 +96,11 @@ async fn main() {
         }
     }
 
-    let memory_router = MemoryServe::new(load_assets!("assets/static")).into_router();
+    let redis_client = redis::Client::open(config.redis_url.as_str()).unwrap();
+    let redis_conn = redis_client.get_connection_manager().await.unwrap();
+    println!("Redis connected: url={}", &config.redis_url);
 
-    let session_store: Arc<Mutex<AHashMap<String, String>>> =
-        Arc::new(Mutex::new(AHashMap::default()));
+    let memory_router = MemoryServe::new(load_assets!("assets/static")).into_router();
 
     let app = Router::new()
         .route("/", get(home))
@@ -169,7 +174,7 @@ async fn main() {
         .nest("/source", static_router("source"))
         .layer(Extension(pool))
         .layer(Extension(config))
-        .layer(Extension(session_store))
+        .layer(Extension(redis_conn))
         .layer(Extension(Arc::new(meilisearch_client)))
         .layer(DefaultBodyLimit::disable())
         .merge(memory_router);

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -33,11 +33,11 @@ struct Medium {
 async fn medium(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers.clone(), &pool, session_store).await;
+    let user = get_user_login(headers.clone(), &pool, redis.clone()).await;
     let is_logged_in = user.is_some();
 
     // Fetch media with visibility info
@@ -63,7 +63,7 @@ async fn medium(
     let owner: String = medium.get("owner");
 
     // Access control for restricted content
-    if !can_access_restricted(&pool, &visibility, restricted_to_group.as_deref(), &owner, &user).await {
+    if !can_access_restricted(&pool, &visibility, restricted_to_group.as_deref(), &owner, &user, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -1,11 +1,11 @@
 async fn hx_recommended(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Result<Html<Vec<u8>>, axum::response::Response> {
-    let user = get_user_login(headers, &pool, session_store).await;
+    let user = get_user_login(headers, &pool, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
 
     let media: Vec<Medium> = sqlx::query(

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -18,12 +18,12 @@ struct HXSidebarTemplate {
     active_item: String,
 }
 async fn hx_sidebar(
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     Extension(pool): Extension<PgPool>,
     Path(active_item): Path<String>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, session_store).await;
+    let user = get_user_login(headers, &pool, redis.clone()).await;
     if user.is_some() {
         let template = HXSidebarTemplate {
             active_item,

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -8,10 +8,10 @@ struct StudioTemplate {
 async fn studio(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -44,10 +44,10 @@ struct HXStudioTemplate {
 async fn hx_studio(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -76,10 +76,10 @@ struct StudioListsTemplate {
 async fn studio_lists(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -102,10 +102,10 @@ struct HXStudioListsTemplate {
 }
 async fn hx_studio_lists(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -154,11 +154,11 @@ struct StudioEditTemplate {
 async fn studio_edit(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -229,12 +229,12 @@ struct EditForm {
 }
 async fn studio_edit_save(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<EditForm>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
@@ -295,11 +295,11 @@ async fn studio_edit_save(
 
 async fn hx_delete_video(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> impl IntoResponse {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return ([("HX-Redirect", "/login")], "");
     }

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -24,9 +24,9 @@ async fn hx_subscriptions(
     Extension(config): Extension<Config>,
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = match get_user_login(headers, &pool, session_store).await {
+    let user = match get_user_login(headers, &pool, redis.clone()).await {
         Some(user) => user,
         None => {
             return Html(
@@ -67,10 +67,10 @@ async fn hx_subscriptions(
 async fn hx_subscribe(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     Path(userid): Path<String>,
 ) -> axum::response::Html<String> {
-    let user = get_user_login(headers, &pool, session_store).await.unwrap();
+    let user = get_user_login(headers, &pool, redis.clone()).await.unwrap();
     sqlx::query!(
         "INSERT INTO subscriptions (subscriber, target) VALUES ($1,$2);",
         user.login,
@@ -84,10 +84,10 @@ async fn hx_subscribe(
 async fn hx_unsubscribe(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     Path(userid): Path<String>,
 ) -> axum::response::Html<String> {
-    let user = get_user_login(headers, &pool, session_store).await.unwrap();
+    let user = get_user_login(headers, &pool, redis.clone()).await.unwrap();
     sqlx::query!(
         "DELETE FROM subscriptions WHERE subscriber=$1 AND target=$2;",
         user.login,
@@ -101,10 +101,10 @@ async fn hx_unsubscribe(
 async fn hx_subscribebutton(
     headers: HeaderMap,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     Path(userid): Path<String>,
 ) -> axum::response::Html<String> {
-    if let Some(user) = get_user_login(headers, &pool, session_store).await {
+    if let Some(user) = get_user_login(headers, &pool, redis.clone()).await {
         let issubscribed = sqlx::query!(
             "SELECT EXISTS(SELECT FROM subscriptions WHERE subscriber=$1 AND target=$2) AS issubscribed;",
             user.login,

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -1,10 +1,10 @@
 async fn studio_subtitles_get(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::Value::Array(vec![]));
     }
@@ -40,12 +40,12 @@ async fn studio_subtitles_get(
 
 async fn studio_subtitles_add(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     mut multipart: Multipart,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -175,12 +175,12 @@ struct SubtitleDeleteForm {
 
 async fn studio_subtitles_delete(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Json(form): Json<SubtitleDeleteForm>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -22,10 +22,10 @@ async fn trending(
 async fn hx_trending(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, session_store).await;
+    let user = get_user_login(headers, &pool, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
 
     let media: Vec<Medium> = sqlx::query(

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -8,10 +8,10 @@ struct UploadTemplate {
 async fn upload(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, session_store).await).await {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -29,12 +29,12 @@ async fn upload(
 
 async fn hx_upload(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     mut multipart: Multipart,
 ) -> Html<String> {
     // Step 1: Authenticate User
-    let user_info = get_user_login(headers.clone(), &pool, session_store).await;
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }

--- a/src/usernav.rs
+++ b/src/usernav.rs
@@ -5,10 +5,10 @@ struct HXUsernavTemplate {
 }
 async fn hx_usernav(
     Extension(pool): Extension<PgPool>,
-    Extension(session_store): Extension<Arc<Mutex<AHashMap<String, String>>>>,
+    Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let try_user = get_user_login(headers, &pool, session_store).await;
+    let try_user = get_user_login(headers, &pool, redis.clone()).await;
     if try_user.is_some() {
         let user = try_user.unwrap();
         let template = HXUsernavTemplate { user };


### PR DESCRIPTION
## Summary
Migrate session management and group membership caching from an in-memory `AHashMap` to Redis, improving scalability and enabling distributed session sharing across multiple instances.

## Key Changes

- **Session Storage**: Replaced `Arc<Mutex<AHashMap<String, String>>>` with Redis-backed session storage
  - Sessions now stored with key format `session:{cookie_value}` in Redis
  - Login handler stores session in Redis instead of in-memory map
  - Logout handler deletes session from Redis
  - `get_user_login()` retrieves sessions from Redis

- **Group Membership Caching**: Implemented Redis-based caching for group membership checks
  - `is_group_member()` now checks Redis first before querying database
  - Cache key format: `group:{group_id}:members` (Redis set)
  - Cache invalidation on group member add/remove/delete operations (1-hour TTL)
  - Reduces database queries for repeated membership checks

- **Configuration**: Added `redis_url` configuration parameter to `Config` struct

- **Dependencies**: Added `redis` crate with `tokio-comp` and `connection-manager` features

- **Infrastructure**: Updated Docker Compose to include Redis 7 Alpine service with persistent volume

## Implementation Details

- Uses `redis::aio::ConnectionManager` for async connection pooling
- Session keys are prefixed with `session:` to avoid collisions
- Group membership sets use Redis SADD/SISMEMBER operations for efficient membership testing
- Cache invalidation is explicit (not automatic) when group membership changes
- All Redis operations use `.await` for async/await compatibility
- Graceful error handling with `.unwrap_or()` for cache misses

https://claude.ai/code/session_01L6fTcWXeiJUCUCjaCTrHcA