### PR TITLE
Add group-based visibility controls to media search

### DIFF
--- a/MEILISEARCH_SCHEMA.md
+++ b/MEILISEARCH_SCHEMA.md
@@ -28,20 +28,23 @@ Add these fields to `config.json`:
 
 Each document in the index must have the following fields:
 
-| Field       | Type    | Description                                     |
-|-------------|---------|------------------------------------------------|
-| `id`        | String  | Media ID (primary key)                          |
-| `name`      | String  | Media title/name                                |
-| `owner`     | String  | Creator's login username                        |
-| `views`     | Integer | View count                                      |
-| `likes`     | Integer | Like count                                      |
-| `dislikes`  | Integer | Dislike count                                   |
-| `type`      | String  | Media type: `"video"`, `"audio"`, or `"picture"`|
-| `upload`    | Integer | Upload timestamp (Unix epoch seconds)           |
-| `public`    | Boolean | Whether the media is publicly visible           |
+| Field                | Type           | Description                                          |
+|----------------------|----------------|------------------------------------------------------|
+| `id`                 | String         | Media ID (primary key)                               |
+| `name`               | String         | Media title/name                                     |
+| `owner`              | String         | Creator's login username                             |
+| `views`              | Integer        | View count                                           |
+| `likes`              | Integer        | Like count                                           |
+| `dislikes`           | Integer        | Dislike count                                        |
+| `type`               | String         | Media type: `"video"`, `"audio"`, or `"picture"`     |
+| `upload`             | Integer        | Upload timestamp (Unix epoch seconds)                |
+| `public`             | Boolean        | Whether the media is publicly visible (legacy)       |
+| `visibility`         | String         | Visibility state: `"public"`, `"hidden"`, `"restricted"` |
+| `restricted_to_group`| String or null | Group ID if visibility is `"restricted"`, else null  |
 
-### Example Document
+### Example Documents
 
+Public media:
 ```json
 {
     "id": "abc1234xyz",
@@ -52,7 +55,26 @@ Each document in the index must have the following fields:
     "dislikes": 3,
     "type": "video",
     "upload": 1708531200,
-    "public": true
+    "public": true,
+    "visibility": "public",
+    "restricted_to_group": null
+}
+```
+
+Group-restricted media:
+```json
+{
+    "id": "def5678uvw",
+    "name": "Members Only Tutorial",
+    "owner": "johndoe",
+    "views": 120,
+    "likes": 15,
+    "dislikes": 0,
+    "type": "video",
+    "upload": 1708617600,
+    "public": false,
+    "visibility": "restricted",
+    "restricted_to_group": "grp_abc123"
 }
 ```
 
@@ -71,15 +93,17 @@ The indexer must configure these settings on the `media` index:
 ### Filterable Attributes
 
 ```json
-["public", "type", "upload", "views", "likes"]
+["public", "type", "upload", "views", "likes", "visibility", "restricted_to_group"]
 ```
 
 These are used by the search filters:
-- `public` - Always filtered to `true` in search queries
+- `public` - Legacy boolean visibility flag
 - `type` - Filter by media type (video/audio/picture)
 - `upload` - Filter by upload date range (timestamp comparisons)
 - `views` - Used for sorting by most viewed
 - `likes` - Used for sorting by most liked
+- `visibility` - Filter by visibility state (`public`, `hidden`, `restricted`)
+- `restricted_to_group` - Filter restricted media by group ID membership
 
 ### Sortable Attributes
 
@@ -116,7 +140,7 @@ The indexer should:
 ### SQL Query for Full Sync
 
 ```sql
-SELECT id, name, owner, views, likes, dislikes, type, upload, public
+SELECT id, name, owner, views, likes, dislikes, type, upload, public, visibility, restricted_to_group
 FROM media;
 ```
 
@@ -134,6 +158,8 @@ struct MeiliMedia {
     r#type: String,
     upload: i64,
     public: bool,
+    visibility: String,
+    restricted_to_group: Option<String>,
 }
 ```
 
@@ -152,7 +178,7 @@ async fn setup_media_index(client: &Client) {
     media.set_searchable_attributes(["name", "owner"]).await.unwrap();
 
     // Configure filterable attributes
-    media.set_filterable_attributes(["public", "type", "upload", "views", "likes"]).await.unwrap();
+    media.set_filterable_attributes(["public", "type", "upload", "views", "likes", "visibility", "restricted_to_group"]).await.unwrap();
 
     // Configure sortable attributes
     media.set_sortable_attributes(["upload", "views", "likes"]).await.unwrap();

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,6 +11,10 @@ struct MeiliMedia {
     upload: i64,
     #[serde(default)]
     public: bool,
+    #[serde(default)]
+    visibility: String,
+    #[serde(default)]
+    restricted_to_group: Option<String>,
 }
 
 impl From<MeiliMedia> for Medium {
@@ -25,6 +29,40 @@ impl From<MeiliMedia> for Medium {
     }
 }
 
+// --- Visibility filter helpers ---
+
+/// Build a Meilisearch filter string that respects group-based visibility.
+/// For logged-in users, shows public media + restricted media in their groups.
+/// For anonymous users, shows only public media.
+async fn build_visibility_filter(pool: &PgPool, user: &Option<User>) -> String {
+    if let Some(u) = user {
+        let group_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT group_id FROM user_group_members WHERE user_login = $1"
+        )
+        .bind(&u.login)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
+
+        if group_ids.is_empty() {
+            return "visibility = 'public'".to_owned();
+        }
+
+        let group_list = group_ids
+            .iter()
+            .map(|g| format!("'{}'", g.replace('\'', "")))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!(
+            "visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN [{}])",
+            group_list
+        )
+    } else {
+        "visibility = 'public'".to_owned()
+    }
+}
+
 // --- Search suggestions (navbar autocomplete) ---
 
 #[derive(Serialize, Deserialize)]
@@ -34,18 +72,24 @@ struct HXSearch {
 
 async fn hx_search_suggestions(
     Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
     Extension(meili): Extension<Arc<MeilisearchClient>>,
+    headers: HeaderMap,
     Form(form): Form<HXSearch>,
 ) -> axum::response::Html<String> {
     if form.search.trim().is_empty() {
         return Html("".to_owned());
     }
 
+    let user = get_user_login(headers, &pool, redis).await;
+    let visibility_filter = build_visibility_filter(&pool, &user).await;
+
     let index = meili.index("media");
     let results = index
         .search()
         .with_query(&form.search)
-        .with_filter("public = true")
+        .with_filter(&visibility_filter)
         .with_limit(6)
         .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
         .with_highlight_pre_tag("<mark>")
@@ -131,7 +175,10 @@ struct MeiliSearchHit {
 
 async fn hx_search(
     Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
     Extension(meili): Extension<Arc<MeilisearchClient>>,
+    headers: HeaderMap,
     Path(pageid): Path<usize>,
     Form(form): Form<HXSearchForm>,
 ) -> axum::response::Html<String> {
@@ -147,8 +194,10 @@ async fn hx_search(
     let sort_by = form.sort_by.clone().unwrap_or_default();
     let date_range = form.date_range.clone().unwrap_or_default();
 
-    // Build filter string
-    let mut filters: Vec<String> = vec!["public = true".to_owned()];
+    // Build filter string with visibility-aware access control
+    let user = get_user_login(headers, &pool, redis).await;
+    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let mut filters: Vec<String> = vec![format!("({})", visibility_filter)];
 
     // Media type filter
     match media_type.as_str() {


### PR DESCRIPTION
## Summary
This PR implements group-based visibility controls for media content, allowing media to be restricted to specific user groups while maintaining backward compatibility with the existing public/private boolean flag.

## Key Changes

- **Schema Updates**: Added two new fields to the media index:
  - `visibility`: String field with states `"public"`, `"hidden"`, or `"restricted"`
  - `restricted_to_group`: Optional string field storing the group ID for restricted media
  - Kept `public` boolean field for backward compatibility (marked as legacy)

- **Search Filter Logic**: Implemented `build_visibility_filter()` helper function that:
  - Returns only public media for anonymous users
  - For authenticated users, returns public media plus restricted media they have access to (based on group membership)
  - Queries the `user_group_members` table to determine user's group memberships

- **Search Endpoints Updated**:
  - `hx_search_suggestions()`: Now respects visibility filters instead of hardcoded `public = true`
  - `hx_search()`: Replaced hardcoded public filter with dynamic visibility-aware filter that includes user context

- **Documentation**: Updated schema documentation with:
  - New field descriptions and example documents
  - Filterable and sortable attributes lists
  - SQL query and Rust struct examples

## Implementation Details

The visibility filter uses Meilisearch's filter syntax to construct queries like:
- Anonymous: `visibility = 'public'`
- Authenticated: `visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN [group1, group2, ...])`

Both search endpoints now require `PgPool`, `RedisConn`, and `HeaderMap` extensions to authenticate users and build appropriate filters.

https://claude.ai/code/session_01Y5W48SaRbcNRfykL8Cb9mU