### PR TITLE
Refactor Studio page to use tabbed navigation with HTMX

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ async fn main() {
         .route("/studio/concept/{conceptid}/publish", post(publish))
         .route("/upload", get(upload))
         .route("/hx/upload", post(hx_upload))
+        .route("/hx/studio/upload", get(hx_studio_upload))
         .route("/list/{listid}", get(list_page))
         .route("/l/{listid}/{mediumid}", get(medium_in_list))
         .route("/hx/listitems/{listid}", get(hx_list_items))

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,4 +1,21 @@
 #[derive(Template)]
+#[template(path = "pages/hx-studio-upload.html", escape = "none")]
+struct HXStudioUploadTemplate {}
+async fn hx_studio_upload(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let template = HXStudioUploadTemplate {};
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Template)]
 #[template(path = "pages/upload.html", escape = "none")]
 struct UploadTemplate {
     sidebar: String,

--- a/templates/pages/hx-studio-upload.html
+++ b/templates/pages/hx-studio-upload.html
@@ -1,0 +1,60 @@
+<div class="d-flex justify-content-center mt-3">
+    <div class="w-100" style="max-width: 600px">
+        <h1 class="m-3 text-center">What do you want to upload today?</h1>
+        <div id="upload-container">
+            <form
+                id="upload-form"
+                hx-encoding="multipart/form-data"
+                hx-post="/hx/upload"
+                class="m-3"
+                onsubmit="beginupload()"
+                hx-target="#upload-result"
+            >
+                <div class="d-flex flex-column align-items-center">
+                    <input
+                        class="btn btn-primary m-3"
+                        type="file"
+                        name="file"
+                        style="width: 100%; max-width: 500px;"
+                    />
+                    <br />
+                    <button
+                        class="btn btn-primary text-center m-3"
+                        id="upload-submitbutton"
+                        style="width: 150px"
+                    >
+                        Upload
+                    </button>
+                    <progress
+                        id="upload-progress"
+                        value="0"
+                        max="100"
+                        class="m-3"
+                        style="display: none; width: 100%; max-width: 500px;"
+                    ></progress>
+                </div>
+            </form>
+            <div id="upload-result"></div>
+        </div>
+    </div>
+</div>
+<script>
+    function beginupload() {
+        window.isUploading = true;
+        document.getElementById("upload-submitbutton").disabled = true;
+        document.getElementById("upload-submitbutton").style.display = "none";
+        document.getElementById("upload-progress").style.display = "inline";
+        return true;
+    }
+
+    htmx.on("#upload-form", "htmx:xhr:progress", function(evt) {
+        htmx.find("#upload-progress").setAttribute(
+            "value",
+            (evt.detail.loaded / evt.detail.total) * 100
+        );
+    });
+
+    htmx.on("#upload-form", "htmx:afterRequest", function() {
+        window.isUploading = false;
+    });
+</script>

--- a/templates/pages/studio.html
+++ b/templates/pages/studio.html
@@ -17,25 +17,73 @@
     <div class="row maincontentrow g-3 py-2 ps-2 w-100">
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <div class="card py-3 px-3 text-white" style="min-height:30vh;">
-                <div class="row justify-content-between">
-                    <h3 class="my-2 mx-3" style="width:200px;">Studio</h3>
-                    <div style="width:760px;">
-                    <a href="/upload" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
-                            class="fa-solid fa-upload"></i>&nbsp;Upload</a>
-                    <a href="/studio/concepts" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
-                            class="fa-solid fa-wand-magic-sparkles"></i>&nbsp;Concepts</a>
-                    <a href="/studio/lists" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
-                            class="fa-solid fa-list"></i>&nbsp;Lists</a>
-                    <a href="/studio/groups" class="btn btn-primary mx-3" style="width:150px;height:40px;" preload="mouseover"><i
-                            class="fa-solid fa-users"></i>&nbsp;Groups</a>
+                <h3 class="my-2 mx-1">Studio</h3>
+                <ul class="nav nav-tabs">
+                    <li class="nav-item">
+                        <button class="nav-link active text-white"
+                                hx-get="/hx/studio"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/studio"
+                                hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
+                                hx-on::before-request="if(window.isUploading){event.preventDefault();}">
+                            <i class="fa-solid fa-photo-film me-2"></i>Media
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link text-white"
+                                hx-get="/hx/studio/upload"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/upload"
+                                hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                            <i class="fa-solid fa-upload me-2"></i>Upload
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link text-white"
+                                hx-get="/hx/studio/concepts"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/studio/concepts"
+                                hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
+                                hx-on::before-request="if(window.isUploading){event.preventDefault();}">
+                            <i class="fa-solid fa-wand-magic-sparkles me-2"></i>Concepts
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link text-white"
+                                hx-get="/hx/studio/lists"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/studio/lists"
+                                hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
+                                hx-on::before-request="if(window.isUploading){event.preventDefault();}">
+                            <i class="fa-solid fa-list me-2"></i>Lists
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link text-white"
+                                hx-get="/hx/studio/groups"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/studio/groups"
+                                hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
+                                hx-on::before-request="if(window.isUploading){event.preventDefault();}">
+                            <i class="fa-solid fa-users me-2"></i>Groups
+                        </button>
+                    </li>
+                </ul>
+                <div id="tab-content" class="row">
+                    <div hx-get="/hx/studio" hx-trigger="load" class="mb-3 hx-placeholder" preload="always">
                     </div>
-                </div>
-                <hr>
-                <div hx-get="/hx/studio" hx-trigger="load" class="row mb-3 hx-placeholder" preload="always">
                 </div>
             </div>
         </div>
     </div>
+    <script>
+        window.isUploading = false;
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
Refactored the Studio page to use a tabbed navigation interface powered by HTMX, replacing the previous button-based layout. This improves UX by consolidating all studio features under a single page with dynamic content loading.

## Key Changes
- **Navigation UI**: Converted horizontal button layout to Bootstrap nav-tabs component with 5 tabs (Media, Upload, Concepts, Lists, Groups)
- **Dynamic Content Loading**: Implemented HTMX-based tab switching that loads content into a `#tab-content` container without full page reloads
- **Upload State Management**: Added `window.isUploading` flag to prevent tab switching during active uploads, with user alerts and request prevention
- **New Upload Tab Template**: Created `hx-studio-upload.html` as a dedicated upload interface with progress tracking and upload state management
- **Backend Route**: Added `/hx/studio/upload` GET endpoint that serves the upload form template with authentication checks
- **Active Tab Styling**: Implemented client-side tab activation logic that manages the `active` class on nav-links
- **URL History**: Configured HTMX to push URLs to browser history for proper back/forward navigation

## Implementation Details
- Each tab button uses `hx-get` to fetch content from `/hx/studio/*` endpoints
- Upload prevention logic checks `window.isUploading` before allowing tab switches
- Progress bar and upload state are managed via HTMX lifecycle events (`htmx:xhr:progress`, `htmx:afterRequest`)
- All tab buttons include `text-white` class for consistent styling with the dark card background
- The initial Media tab is marked as active and loads on page load via `hx-trigger="load"`

https://claude.ai/code/session_01Xg4Twne6CRB5uoLQoLuakP