### PR TITLE
Consolidate studio tab templates into single reusable template

### DIFF
--- a/src/concept.rs
+++ b/src/concept.rs
@@ -6,13 +6,6 @@ struct MediumConcept {
     r#type: String,
 }
 
-#[derive(Template)]
-#[template(path = "pages/concepts.html", escape = "none")]
-struct ConceptsTemplate {
-    sidebar: String,
-    config: Config,
-    common_headers: CommonHeaders,
-}
 async fn concepts(
     Extension(pool): Extension<PgPool>,
     Extension(config): Extension<Config>,
@@ -27,10 +20,11 @@ async fn concepts(
 
     let sidebar = generate_sidebar(&config, "studio".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
-    let template = ConceptsTemplate {
+    let template = StudioTemplate {
         sidebar,
         config,
         common_headers,
+        active_tab: "concepts".to_owned(),
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -28,14 +28,6 @@ struct AddMemberForm {
     user_login: String,
 }
 
-#[derive(Template)]
-#[template(path = "pages/studio-groups.html", escape = "none")]
-struct StudioGroupsTemplate {
-    sidebar: String,
-    config: Config,
-    common_headers: CommonHeaders,
-}
-
 async fn studio_groups(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
@@ -50,10 +42,11 @@ async fn studio_groups(
 
     let sidebar = generate_sidebar(&config, "studio".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
-    let template = StudioGroupsTemplate {
+    let template = StudioTemplate {
         sidebar,
         config,
         common_headers,
+        active_tab: "groups".to_owned(),
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -4,6 +4,7 @@ struct StudioTemplate {
     sidebar: String,
     config: Config,
     common_headers: CommonHeaders,
+    active_tab: String,
 }
 async fn studio(
     Extension(config): Extension<Config>,
@@ -23,6 +24,7 @@ async fn studio(
         sidebar,
         config,
         common_headers,
+        active_tab: "media".to_owned(),
     };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -66,13 +68,6 @@ async fn hx_studio(
     Html(minifi_html(template.render().unwrap()))
 }
 
-#[derive(Template)]
-#[template(path = "pages/studio-lists.html", escape = "none")]
-struct StudioListsTemplate {
-    sidebar: String,
-    config: Config,
-    common_headers: CommonHeaders,
-}
 async fn studio_lists(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
@@ -87,10 +82,11 @@ async fn studio_lists(
 
     let sidebar = generate_sidebar(&config, "studio".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
-    let template = StudioListsTemplate {
+    let template = StudioTemplate {
         sidebar,
         config,
         common_headers,
+        active_tab: "lists".to_owned(),
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -15,13 +15,6 @@ async fn hx_studio_upload(
     Html(minifi_html(template.render().unwrap()))
 }
 
-#[derive(Template)]
-#[template(path = "pages/upload.html", escape = "none")]
-struct UploadTemplate {
-    sidebar: String,
-    config: Config,
-    common_headers: CommonHeaders,
-}
 async fn upload(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
@@ -36,10 +29,11 @@ async fn upload(
 
     let sidebar = generate_sidebar(&config, "studio".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
-    let template = UploadTemplate {
+    let template = StudioTemplate {
         sidebar,
         config,
         common_headers,
+        active_tab: "upload".to_owned(),
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/templates/pages/studio.html
+++ b/templates/pages/studio.html
@@ -20,7 +20,7 @@
                 <h3 class="my-2 mx-1">Studio</h3>
                 <ul class="nav nav-tabs">
                     <li class="nav-item">
-                        <button class="nav-link active text-white"
+                        <button class="nav-link {% if active_tab == "media" %}active {% endif %}text-white"
                                 hx-get="/hx/studio"
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
@@ -31,7 +31,7 @@
                         </button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link text-white"
+                        <button class="nav-link {% if active_tab == "upload" %}active {% endif %}text-white"
                                 hx-get="/hx/studio/upload"
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
@@ -41,7 +41,7 @@
                         </button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link text-white"
+                        <button class="nav-link {% if active_tab == "concepts" %}active {% endif %}text-white"
                                 hx-get="/hx/studio/concepts"
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
@@ -52,7 +52,7 @@
                         </button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link text-white"
+                        <button class="nav-link {% if active_tab == "lists" %}active {% endif %}text-white"
                                 hx-get="/hx/studio/lists"
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
@@ -63,7 +63,7 @@
                         </button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link text-white"
+                        <button class="nav-link {% if active_tab == "groups" %}active {% endif %}text-white"
                                 hx-get="/hx/studio/groups"
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
@@ -75,8 +75,22 @@
                     </li>
                 </ul>
                 <div id="tab-content" class="row">
+                    {% if active_tab == "upload" %}
+                    <div hx-get="/hx/studio/upload" hx-trigger="load" class="mb-3 hx-placeholder" preload="always">
+                    </div>
+                    {% else if active_tab == "concepts" %}
+                    <div hx-get="/hx/studio/concepts" hx-trigger="load" class="mb-3 hx-placeholder" preload="always">
+                    </div>
+                    {% else if active_tab == "lists" %}
+                    <div hx-get="/hx/studio/lists" hx-trigger="load" class="mb-3 hx-placeholder" preload="always">
+                    </div>
+                    {% else if active_tab == "groups" %}
+                    <div hx-get="/hx/studio/groups" hx-trigger="load" class="mb-3 hx-placeholder" preload="always">
+                    </div>
+                    {% else %}
                     <div hx-get="/hx/studio" hx-trigger="load" class="mb-3 hx-placeholder" preload="always">
                     </div>
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
Refactored the studio page to use a single `StudioTemplate` struct across all tab views instead of maintaining separate template structs for each tab. This reduces code duplication and improves maintainability.

## Key Changes
- **Template consolidation**: Removed `StudioListsTemplate`, `StudioGroupsTemplate`, `ConceptsTemplate`, and `UploadTemplate` structs, replacing them all with the unified `StudioTemplate`
- **Active tab tracking**: Added `active_tab: String` field to `StudioTemplate` to track which tab should be displayed
- **Dynamic tab styling**: Updated all tab buttons in `studio.html` to conditionally apply the `active` class based on the `active_tab` value
- **Content loading**: Modified the tab content section to conditionally load the appropriate content based on `active_tab` using HTMX `hx-trigger="load"`
- **Handler updates**: Updated all studio-related route handlers (`studio_lists`, `studio_groups`, `concepts`, `upload`) to use `StudioTemplate` with the appropriate `active_tab` value

## Implementation Details
- The template now uses Jinja2 conditional logic (`{% if active_tab == "..." %}`) to determine which tab button receives the `active` class and which content div loads on page render
- Each tab's content is loaded via HTMX with `preload="always"` to ensure content is fetched when the page loads
- The default tab is "media" when the main studio page is accessed

https://claude.ai/code/session_01F3rgEBWyJR67wXWLRsCmoi