### PR TITLE
Consolidate page titles into navbar component

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16013,10 +16013,6 @@ body.sidebar-collapsed .sidebarbackground {
     margin-bottom: 1rem;
 }
 
-.search-header h3 {
-    margin: 0.5rem 0 1rem 0;
-}
-
 .search-bar-wrapper {
     max-width: 900px;
     margin: 0 auto;

--- a/templates/pages/component-navbar.html
+++ b/templates/pages/component-navbar.html
@@ -1,4 +1,9 @@
-<div class="d-flex justify-content-end mx-1">
+<div class="d-flex align-items-center mx-1">
+    {% if page_title is defined %}
+    <span class="ms-3 me-auto fs-5 fw-semibold text-white">{{ page_title }}</span>
+    {% else %}
+    <span class="me-auto"></span>
+    {% endif %}
     <form id="navSearchForm" onsubmit="return navbarSearch(event)">
         <div class="input-group m-2 text-white">
             <input id="searchInput" class="form-control searchinput" hx-post="/hx/searchsuggestions"

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -12,6 +12,7 @@
 </head>
 
 <body hx-ext="preload">
+    {% set page_title = "Search" %}
     {{ sidebar }}
     {% include "component-navbar.html" %}
     <div class="row maincontentrow g-3 py-2 ps-2 w-100">
@@ -19,7 +20,6 @@
             <div class="card py-3 px-3 text-white" style="min-height: 80vh;">
 
                 <div class="search-header">
-                    <h3><i class="fa-solid fa-magnifying-glass me-2"></i>Search</h3>
                     <div class="search-bar-wrapper">
                         <form id="searchForm" hx-post="/hx/search/0" hx-target="#searchresults" hx-trigger="submit"
                             hx-indicator="#search-loading">

--- a/templates/pages/studio.html
+++ b/templates/pages/studio.html
@@ -12,12 +12,12 @@
 </head>
 
 <body hx-ext="preload">
+    {% set page_title = "Studio" %}
     {{ sidebar }}
     {% include "component-navbar.html" %}
     <div class="row maincontentrow g-3 py-2 ps-2 w-100">
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <div class="card py-3 px-3 text-white" style="min-height:30vh;">
-                <h3 class="my-2 mx-1">Studio</h3>
                 <ul class="nav nav-tabs">
                     <li class="nav-item">
                         <button class="nav-link {% if active_tab == "media" %}active {% endif %}text-white"

--- a/templates/pages/subscriptions.html
+++ b/templates/pages/subscriptions.html
@@ -17,6 +17,7 @@
     </head>
 
     <body hx-ext="preload">
+        {% set page_title = "Subscriptions" %}
         {{ sidebar }} {% include "component-navbar.html" %}
         <div class="row maincontentrow g-3 py-2 ps-2 w-100">
             <div class="col-12 col-sm-12 col-md-12 col-lg-12">
@@ -24,8 +25,6 @@
                     class="card py-3 px-3 text-white"
                     style="min-height: 100vh"
                 >
-                    <h3 class="my-2 mx-3">Subscriptions</h3>
-                    <hr />
                     <div
                         hx-get="/hx/subscriptions"
                         hx-trigger="load"

--- a/templates/pages/trending.html
+++ b/templates/pages/trending.html
@@ -12,13 +12,12 @@
 </head>
 
 <body hx-ext="preload">
+    {% set page_title = "Trending" %}
     {{ sidebar }}
     {% include "component-navbar.html" %}
     <div class="row maincontentrow g-3 py-2 ps-2 w-100">
         <div class="col-12 col-sm-12 col-md-12 col-lg-12">
             <div class="card py-3 px-3 text-white" style="min-height:100vh;">
-                <h3 class="my-2 mx-3">Trending</h3>
-                <hr>
                 <div hx-get="/hx/trending" hx-trigger="load" class="row mb-3 hx-placeholder" preload="always">
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Refactored page title display by moving individual page heading elements into the navbar component. This eliminates duplicate title markup across pages and provides a consistent, centralized approach to displaying page titles.

## Key Changes
- **Navbar component enhancement**: Modified `component-navbar.html` to display a `page_title` variable when defined, with proper styling and alignment
- **Page template updates**: Removed individual `<h3>` heading elements from:
  - `subscriptions.html`
  - `trending.html`
  - `search.html`
  - `studio.html`
- **Page title injection**: Added `{% set page_title = "..." %}` to each page template to pass the title to the navbar
- **CSS cleanup**: Removed unused `.search-header h3` styling rules from `style.css`

## Implementation Details
- The navbar now uses flexbox with `align-items-center` to vertically center the page title alongside the search form
- The page title is displayed with Bootstrap utility classes (`fs-5 fw-semibold text-white`) for consistent styling
- A fallback empty `<span>` is rendered when `page_title` is not defined, maintaining layout integrity
- The `me-auto` class ensures proper spacing between the title and search form

https://claude.ai/code/session_01ToENYWDjLhU6BsAjqdhJ37