### PR TITLE
Refactor medium page layout to use CSS Grid for better responsiveness

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16456,3 +16456,45 @@ body.sidebar-collapsed .sidebarbackground {
         font-size: clamp(0.75rem, 3.5cqw, 2rem);
     }
 }
+
+/* ==================== Medium page info grid ==================== */
+
+/* Mobile-first: single column, stacked (title → channel → engagement bar) */
+.medium-info-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+}
+
+.medium-title-col {
+    min-width: 0;
+    overflow: hidden;
+}
+
+.medium-engagement-col {
+    margin-top: 0.25rem;
+}
+
+/* Desktop (md+): 2-column grid; engagement bar right-aligned, spanning both rows */
+@media (min-width: 768px) {
+    .medium-info-grid {
+        grid-template-columns: 1fr auto;
+        column-gap: 0.5rem;
+    }
+
+    .medium-title-col {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+    .medium-channel-col {
+        grid-column: 1;
+        grid-row: 2;
+    }
+
+    .medium-engagement-col {
+        grid-column: 2;
+        grid-row: 1 / 3;
+        margin-top: 0;
+        justify-content: flex-end;
+    }
+}

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -194,30 +194,29 @@
                         </div>
                         {% endif %}
                     </div>
-                    <!-- Outer flex: left column (title + channel/subscribe) and right column (bar) -->
-                    <div class="d-flex flex-wrap align-items-stretch gap-2 mt-2">
-                        <!-- Left: title on top, channel + subscribe below -->
-                        <div class="flex-grow-1" style="min-width: 0;">
-                            <div style="min-width: 0; overflow: hidden;">
-                                <h1 id="medium-title" class="mb-0 fw-bold">
-                                    {{ medium_name }}
-                                </h1>
-                            </div>
-                            <div class="d-flex align-items-center mt-1">
-                                <a
-                                    href="/channel/{{ medium_owner }}"
-                                    class="text-secondary text-decoration-none fs-5"
-                                    preload="mouseover"
-                                >{{ medium_owner }}</a>
-                                <div
-                                    hx-get="/hx/subscribebutton/{{ medium_owner }}"
-                                    hx-trigger="load"
-                                    class="subscribe-placeholder p-1 ms-2"
-                                ></div>
-                            </div>
+                    <!-- Info grid: title + channel/subscribe on left; engagement bar right-aligned on desktop -->
+                    <div class="medium-info-grid mt-2">
+                        <!-- Title (grid col 1, row 1) -->
+                        <div class="medium-title-col medium-title-wrapper">
+                            <h1 id="medium-title" class="mb-0 fw-bold">
+                                {{ medium_name }}
+                            </h1>
                         </div>
-                        <!-- Right: engagement bar, vertically centered between the two left rows -->
-                        <div class="d-flex align-items-center">
+                        <!-- Channel + subscribe (grid col 1, row 2) -->
+                        <div class="medium-channel-col d-flex align-items-center mt-1">
+                            <a
+                                href="/channel/{{ medium_owner }}"
+                                class="text-secondary text-decoration-none fs-5"
+                                preload="mouseover"
+                            >{{ medium_owner }}</a>
+                            <div
+                                hx-get="/hx/subscribebutton/{{ medium_owner }}"
+                                hx-trigger="load"
+                                class="subscribe-placeholder p-1 ms-2"
+                            ></div>
+                        </div>
+                        <!-- Engagement bar (grid col 2, rows 1-2 on desktop; stacks below on mobile) -->
+                        <div class="medium-engagement-col d-flex align-items-center">
                             <ul class="list-group list-unstyled list-group-horizontal py-2 px-2 mb-0" style="background-color: var(--bs-primary);">
                                 <li class="mx-2">
                                     <a


### PR DESCRIPTION
## Summary
Refactored the medium page header layout from flexbox to CSS Grid, improving responsive behavior and code maintainability. The engagement bar now properly spans multiple rows on desktop while maintaining a clean stacked layout on mobile.

## Key Changes
- **Layout restructuring**: Replaced flexbox-based layout with CSS Grid in `medium.html`
  - Removed nested flex containers and inline styles
  - Introduced semantic grid column classes (`medium-title-col`, `medium-channel-col`, `medium-engagement-col`)
  - Simplified HTML structure by eliminating wrapper divs

- **Responsive grid implementation** in `style.css`
  - Mobile-first: Single column layout with stacked elements (title → channel → engagement bar)
  - Desktop (768px+): Two-column grid where engagement bar spans both rows on the right
  - Proper gap and alignment handling for both breakpoints

- **Improved accessibility and overflow handling**
  - Maintained `min-width: 0` and `overflow: hidden` on title column to prevent text overflow
  - Cleaner separation of concerns with dedicated grid areas

## Implementation Details
- Grid uses `1fr auto` columns on desktop to allow the engagement bar to size naturally while title/channel takes remaining space
- Engagement bar positioned at `grid-row: 1 / 3` to span both rows vertically
- Mobile layout uses single column (`1fr`) for simplicity
- Preserved all existing styling and functionality while improving layout flexibility

https://claude.ai/code/session_01PAFvND65sG9Bp6XXcWtVrF