### PR TITLE
Replace CSS line-clamp with JS-based font sizing for medium title

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -105,3 +105,33 @@ document.addEventListener('webkitfullscreenchange', function () {
         icon.classList.add('fa-expand');
     }
 });
+
+function fitMediumTitle() {
+    const title = document.getElementById('medium-title');
+    if (!title || window.matchMedia('(min-width: 992px)').matches) return;
+
+    // Reset to CSS-specified font size to measure from the top
+    title.style.fontSize = '';
+
+    const style = window.getComputedStyle(title);
+    const lineHeight = parseFloat(style.lineHeight);
+    const maxHeight = lineHeight * 2;
+
+    if (title.scrollHeight <= maxHeight + 1) return;
+
+    // Binary search for the largest font size that fits in 2 lines
+    let lo = 10, hi = parseFloat(style.fontSize);
+    while (hi - lo > 0.5) {
+        const mid = (lo + hi) / 2;
+        title.style.fontSize = mid + 'px';
+        if (title.scrollHeight <= maxHeight + 1) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    title.style.fontSize = lo + 'px';
+}
+
+document.addEventListener('DOMContentLoaded', fitMediumTitle);
+window.addEventListener('resize', fitMediumTitle);

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16432,12 +16432,9 @@ body.sidebar-collapsed .sidebarbackground {
 
 /* ==================== Medium page title ==================== */
 
-/* Mobile: at most 2 lines, normal wrap */
+/* Mobile: shrink font to always fit 2 lines (JS handles sizing) */
 #medium-title {
     overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
     white-space: normal;
     font-size: clamp(1.25rem, 5vw, 2rem);
 }


### PR DESCRIPTION
## Summary
Replaced the CSS `-webkit-line-clamp` approach for the medium page title with a JavaScript-based solution that dynamically shrinks the font size to ensure the title always fits within 2 lines.

## Key Changes
- **JavaScript**: Added `fitMediumTitle()` function that uses binary search to find the largest font size that fits within 2 lines of the title element
- **Event Listeners**: Attached the function to `DOMContentLoaded` and `resize` events to handle initial layout and responsive resizing
- **CSS**: Removed `-webkit-line-clamp`, `-webkit-box-orient`, and `display: -webkit-box` properties; kept `overflow: hidden` and `white-space: normal` for layout control
- **Updated Comment**: Changed CSS comment to reflect that JavaScript now handles the sizing logic

## Implementation Details
- The binary search algorithm efficiently finds the optimal font size by testing values between 10px and the current computed font size
- Includes a 1px tolerance threshold (`maxHeight + 1`) to account for rounding differences
- Only applies on mobile devices (skips when viewport width ≥ 992px via media query check)
- Resets font size to CSS-specified value before measuring to ensure consistent baseline measurements

https://claude.ai/code/session_01Y8MSEMePQmptB4pSmwCcL4