### PR TITLE
Improve infinite scroll sentinel cleanup in pagination templates

### DIFF
--- a/templates/pages/hx-listitems.html
+++ b/templates/pages/hx-listitems.html
@@ -25,7 +25,7 @@
     </a>
 </div>
 {% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:1px;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-li-{{ page }}" hx-swap="outerHTML"></div>
+<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-li-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-mediumcard.html
+++ b/templates/pages/hx-mediumcard.html
@@ -63,7 +63,7 @@
     </a>
 </div>
 {% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:1px;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-mc-{{ page }}" hx-swap="outerHTML"></div>
+<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-mc-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-studio-lists.html
+++ b/templates/pages/hx-studio-lists.html
@@ -19,7 +19,7 @@
     </div>
 </div>
 {% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:1px;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-sl-{{ page }}" hx-swap="outerHTML"></div>
+<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-sl-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-studio.html
+++ b/templates/pages/hx-studio.html
@@ -38,7 +38,7 @@
     </a>
 </div>
 {% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:1px;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-st-{{ page }}" hx-swap="outerHTML"></div>
+<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-st-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-userlists.html
+++ b/templates/pages/hx-userlists.html
@@ -12,7 +12,7 @@
     </a>
 </div>
 {% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:1px;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-ul-{{ page }}" hx-swap="outerHTML"></div>
+<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-ul-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}


### PR DESCRIPTION
## Summary
Updated infinite scroll sentinel elements across all pagination templates to improve cleanup behavior and reduce unnecessary DOM elements.

## Key Changes
- Changed sentinel element height from `1px` to `0` for more efficient rendering
- Added `hx-on::after-request="this.remove()"` handler to automatically remove sentinel elements after the HTMX request completes
- Applied changes consistently across 5 pagination templates:
  - `hx-listitems.html`
  - `hx-mediumcard.html`
  - `hx-studio-lists.html`
  - `hx-studio.html`
  - `hx-userlists.html`

## Implementation Details
The sentinel divs are used to trigger infinite scroll loading when revealed. By automatically removing them after the request completes, we prevent DOM bloat from accumulating sentinel elements. The height reduction from `1px` to `0` further optimizes rendering performance while maintaining the reveal trigger functionality.

https://claude.ai/code/session_01NmsMtcT3L99SPrN8hajsCB