### PR TITLE
Add fade-in animation and placeholder for infinite scroll

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -15834,6 +15834,24 @@ body.sidebar-collapsed .sidebarbackground {
     color: var(--bs-white);
 }
 
+/* ── Infinite-scroll reveal ── */
+
+/* Items fade in when HTMX swaps them into the page */
+.inf-scroll-reveal {
+    animation: infScrollFadeIn 0.25s ease forwards;
+}
+
+@keyframes infScrollFadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* Invisible placeholder that reserves space while the next page loads */
+.inf-scroll-placeholder {
+    min-height: 120px;
+    visibility: hidden;
+}
+
 /* ── Layout-shift reduction ── */
 
 /* HTMX placeholder: reserves space for content loaded via hx-trigger="load" */

--- a/templates/pages/hx-comments.html
+++ b/templates/pages/hx-comments.html
@@ -1,5 +1,5 @@
 {% for comment in comments %}
-<div class="comment-item my-3 p-3" style="border-left: 3px solid var(--bs-secondary); border-radius: 4px;">
+<div class="comment-item my-3 p-3 inf-scroll-reveal" style="border-left: 3px solid var(--bs-secondary); border-radius: 4px;">
     <div class="d-flex align-items-center mb-2">
         <a href="/channel/{{ comment.user }}" class="text-decoration-none">
             <h6 class="mb-0 text-white">{{ comment.user }}</h6>

--- a/templates/pages/hx-listitems.html
+++ b/templates/pages/hx-listitems.html
@@ -1,5 +1,5 @@
 {% for item in items %}
-<div class="col-xl-2 col-lg-4 col-6 d-flex justify-content-center">
+<div class="col-xl-2 col-lg-4 col-6 d-flex justify-content-center inf-scroll-reveal">
     <a href="/l/{{ list_id }}/{{ item.id }}" class="text-decoration-none p-3 bg-hover rounded" preload="mouseover">
         <table>
             <tr>
@@ -29,9 +29,7 @@
 {% endif %}
 {% endfor %}
 {% if has_more %}
-<div id="inf-scroll-li-{{ page }}" class="col-12 text-center my-4">
-    <i class="fa-solid fa-spinner fa-spin-pulse fa-3x text-secondary"></i>
-</div>
+<div id="inf-scroll-li-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="col-12 text-center my-4">
     {% if items.is_empty() && page == 0 %}

--- a/templates/pages/hx-mediumcard.html
+++ b/templates/pages/hx-mediumcard.html
@@ -1,5 +1,5 @@
 {% for item in media %}
-<div class="col-xl-2 col-lg-4 col-6 d-flex justify-content-center">
+<div class="col-xl-2 col-lg-4 col-6 d-flex justify-content-center inf-scroll-reveal">
     <a
         href="/m/{{ item.id }}"
         class="text-decoration-none p-3 bg-hover rounded"
@@ -67,9 +67,7 @@
 {% endif %}
 {% endfor %}
 {% if has_more %}
-<div id="inf-scroll-mc-{{ page }}" class="col-12 text-center my-4">
-    <i class="fa-solid fa-spinner fa-spin-pulse fa-3x text-secondary"></i>
-</div>
+<div id="inf-scroll-mc-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="col-12 text-center my-4">
     {% if media.is_empty() && page == 0 %}

--- a/templates/pages/hx-search.html
+++ b/templates/pages/hx-search.html
@@ -5,7 +5,7 @@
 </div>
 {% endif %}
 {% for hit in search_results %}
-<a href="/m/{{ hit.id }}" class="search-result-card" preload="mouseover">
+<a href="/m/{{ hit.id }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
     <div class="search-card-thumbnail">
         <img src="{{ config.source_server_url }}/source/{{ hit.id }}/thumbnail.avif" alt="{{ hit.name }}" loading="lazy" />
         <div class="search-card-type-badge">
@@ -34,9 +34,7 @@
     <input type="hidden" name="media_type" value="{{ media_type }}" />
     <input type="hidden" name="sort_by" value="{{ sort_by }}" />
     <input type="hidden" name="date_range" value="{{ date_range }}" />
-    <div class="text-center my-4">
-        <i class="fa-solid fa-spinner fa-spin-pulse fa-3x"></i>
-    </div>
+    <div class="my-4 inf-scroll-placeholder"></div>
 </form>
 {% else %}
 <div class="text-center my-4">

--- a/templates/pages/hx-studio-lists.html
+++ b/templates/pages/hx-studio-lists.html
@@ -1,5 +1,5 @@
 {% for list in lists %}
-<div class="col-xl-3 col-lg-4 col-6 my-3">
+<div class="col-xl-3 col-lg-4 col-6 my-3 inf-scroll-reveal">
     <div class="bg-hover rounded border p-3" style="min-height: 80px;">
         <div class="d-flex justify-content-between align-items-start">
             <a href="/list/{{ list.id }}" class="text-decoration-none" preload="mouseover">
@@ -23,9 +23,7 @@
 {% endif %}
 {% endfor %}
 {% if has_more %}
-<div id="inf-scroll-sl-{{ page }}" class="col-12 text-center my-4">
-    <i class="fa-solid fa-spinner fa-spin-pulse fa-3x text-secondary"></i>
-</div>
+<div id="inf-scroll-sl-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="col-12 text-center my-4">
     {% if lists.is_empty() && page == 0 %}

--- a/templates/pages/hx-studio.html
+++ b/templates/pages/hx-studio.html
@@ -1,5 +1,5 @@
 {% for medium in media %}
-<div class="col-xl-2 col-lg-4 col-6 d-flex justify-content-center">
+<div class="col-xl-2 col-lg-4 col-6 d-flex justify-content-center inf-scroll-reveal">
     <a
         href="/studio/edit/{{ medium.id }}"
         class="text-decoration-none p-3 bg-hover rounded"
@@ -42,9 +42,7 @@
 {% endif %}
 {% endfor %}
 {% if has_more %}
-<div id="inf-scroll-st-{{ page }}" class="col-12 text-center my-4">
-    <i class="fa-solid fa-spinner fa-spin-pulse fa-3x text-secondary"></i>
-</div>
+<div id="inf-scroll-st-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="col-12 text-center my-4">
     {% if media.is_empty() && page == 0 %}

--- a/templates/pages/hx-userlists.html
+++ b/templates/pages/hx-userlists.html
@@ -1,5 +1,5 @@
 {% for list in lists %}
-<div class="col-xl-3 col-lg-4 col-6 my-3">
+<div class="col-xl-3 col-lg-4 col-6 my-3 inf-scroll-reveal">
     <a href="/list/{{ list.id }}" class="text-decoration-none" preload="mouseover">
         <div class="bg-hover rounded border p-3" style="min-height: 80px;">
             <b class="text-white"><i class="fa-solid fa-list me-2"></i>{{ list.name }}</b>
@@ -16,9 +16,7 @@
 {% endif %}
 {% endfor %}
 {% if has_more %}
-<div id="inf-scroll-ul-{{ page }}" class="col-12 text-center my-4">
-    <i class="fa-solid fa-spinner fa-spin-pulse fa-3x text-secondary"></i>
-</div>
+<div id="inf-scroll-ul-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="col-12 text-center my-4">
     {% if lists.is_empty() && page == 0 %}


### PR DESCRIPTION
## Summary
This PR enhances the infinite scroll user experience by adding a fade-in animation for newly loaded items and replacing loading spinners with invisible placeholders that reserve space during page loads.

## Key Changes
- **New CSS animations**: Added `inf-scroll-reveal` class with a 0.25s fade-in animation and `inf-scroll-placeholder` class for space reservation (120px min-height)
- **Updated item templates**: Applied `inf-scroll-reveal` class to all dynamically loaded content items across 8 templates:
  - List items (`hx-listitems.html`)
  - Media cards (`hx-mediumcard.html`)
  - Search results (`hx-search.html`)
  - Studio lists (`hx-studio-lists.html`)
  - Studio media (`hx-studio.html`)
  - User lists (`hx-userlists.html`)
  - Comments (`hx-comments.html`)
- **Replaced loading indicators**: Removed visible spinner icons from all infinite scroll placeholders and replaced them with the new `inf-scroll-placeholder` div that maintains layout stability

## Implementation Details
- The fade-in animation uses `animation: infScrollFadeIn 0.25s ease forwards` to smoothly reveal items as HTMX swaps them into the page
- Placeholders use `visibility: hidden` instead of `display: none` to preserve space while content loads, reducing cumulative layout shift
- Changes are consistent across all paginated/infinite scroll sections in the application

https://claude.ai/code/session_01Br9SkDVkfXwzmWj3eQ82DG