### PR TITLE
Increase pagination page size from 30 to 40 items

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -90,10 +90,10 @@ async fn hx_usermedia_inner(
 ) -> axum::response::Html<Vec<u8>> {
     let user = get_user_login(headers, &pool, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
-    let offset = page * 30;
+    let offset = page * 40;
 
     let mut media: Vec<Medium> = sqlx::query(
-        "SELECT id,name,owner,views,type FROM media WHERE owner=$1 AND (visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY upload DESC LIMIT 31 OFFSET $3;"
+        "SELECT id,name,owner,views,type FROM media WHERE owner=$1 AND (visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY upload DESC LIMIT 41 OFFSET $3;"
     )
     .bind(&userid)
     .bind(&user_login)
@@ -112,9 +112,9 @@ async fn hx_usermedia_inner(
     .await
     .expect("Database error");
 
-    let has_more = media.len() == 31;
+    let has_more = media.len() == 41;
     if has_more {
-        media.truncate(30);
+        media.truncate(40);
     }
     let next_page = page + 1;
     let next_url = format!("/hx/usermedia/{}/{}", userid, next_page);

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -266,10 +266,10 @@ async fn hx_list_items_inner(
     listid: String,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
-    let offset = page * 30;
+    let offset = page * 40;
 
     let mut items: Vec<Medium> = sqlx::query(
-        "SELECT m.id, m.name, m.owner, m.views, m.type FROM list_items li INNER JOIN media m ON li.media_id = m.id WHERE li.list_id = $1 ORDER BY li.position ASC LIMIT 31 OFFSET $2;"
+        "SELECT m.id, m.name, m.owner, m.views, m.type FROM list_items li INNER JOIN media m ON li.media_id = m.id WHERE li.list_id = $1 ORDER BY li.position ASC LIMIT 41 OFFSET $2;"
     )
     .bind(&listid)
     .bind(offset)
@@ -287,9 +287,9 @@ async fn hx_list_items_inner(
     .await
     .expect("Database error");
 
-    let has_more = items.len() == 31;
+    let has_more = items.len() == 41;
     if has_more {
-        items.truncate(30);
+        items.truncate(40);
     }
     let next_page = page + 1;
     let next_url = format!("/hx/listitems/{}/{}", listid, next_page);
@@ -655,10 +655,10 @@ async fn hx_user_lists_inner(
 ) -> axum::response::Html<Vec<u8>> {
     let user = get_user_login(headers, &pool, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
-    let offset = page * 30;
+    let offset = page * 40;
 
     let mut lists: Vec<ListWithCount> = sqlx::query(
-        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND (l.visibility = 'public' OR (l.visibility = 'restricted' AND l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY l.created DESC LIMIT 31 OFFSET $3;"
+        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND (l.visibility = 'public' OR (l.visibility = 'restricted' AND l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY l.created DESC LIMIT 41 OFFSET $3;"
     )
     .bind(&userid)
     .bind(&user_login)
@@ -678,9 +678,9 @@ async fn hx_user_lists_inner(
     .await
     .expect("Database error");
 
-    let has_more = lists.len() == 31;
+    let has_more = lists.len() == 41;
     if has_more {
-        lists.truncate(30);
+        lists.truncate(40);
     }
     let next_page = page + 1;
     let next_url = format!("/hx/userlists/{}/{}", userid, next_page);

--- a/src/search.rs
+++ b/src/search.rs
@@ -187,8 +187,8 @@ async fn hx_search(
         return Html("".to_owned());
     }
 
-    let hits_per_page: usize = 31;
-    let offset = pageid * 30;
+    let hits_per_page: usize = 41;
+    let offset = pageid * 40;
     let next_page = pageid + 1;
 
     let media_type = form.media_type.clone().unwrap_or_default();
@@ -279,9 +279,9 @@ async fn hx_search(
                 })
                 .collect();
 
-            let has_more = hits.len() == 31;
+            let has_more = hits.len() == 41;
             if has_more {
-                hits.truncate(30);
+                hits.truncate(40);
             }
 
             if hits.is_empty() && pageid == 0 {

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -79,10 +79,10 @@ async fn hx_studio_inner(
         ));
     }
     let user_info = user_info.unwrap();
-    let offset = page * 30;
+    let offset = page * 40;
 
     let mut media: Vec<MediumStudio> = sqlx::query(
-        "SELECT id,name,description,views,type FROM media WHERE owner=$1 ORDER BY upload DESC LIMIT 31 OFFSET $2;"
+        "SELECT id,name,description,views,type FROM media WHERE owner=$1 ORDER BY upload DESC LIMIT 41 OFFSET $2;"
     )
     .bind(&user_info.login)
     .bind(offset)
@@ -100,9 +100,9 @@ async fn hx_studio_inner(
     .await
     .expect("Database error");
 
-    let has_more = media.len() == 31;
+    let has_more = media.len() == 41;
     if has_more {
-        media.truncate(30);
+        media.truncate(40);
     }
     let next_page = page + 1;
     let next_url = format!("/hx/studio/{}", next_page);
@@ -172,10 +172,10 @@ async fn hx_studio_lists_inner(
         ));
     }
     let user_info = user_info.unwrap();
-    let offset = page * 30;
+    let offset = page * 40;
 
     let mut lists: Vec<ListWithCount> = sqlx::query(
-        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC LIMIT 31 OFFSET $2;"
+        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC LIMIT 41 OFFSET $2;"
     )
     .bind(&user_info.login)
     .bind(offset)
@@ -194,9 +194,9 @@ async fn hx_studio_lists_inner(
     .await
     .expect("Database error");
 
-    let has_more = lists.len() == 31;
+    let has_more = lists.len() == 41;
     if has_more {
-        lists.truncate(30);
+        lists.truncate(40);
     }
     let next_page = page + 1;
     let next_url = format!("/hx/studio/lists/{}", next_page);

--- a/templates/pages/hx-listitems.html
+++ b/templates/pages/hx-listitems.html
@@ -24,8 +24,8 @@
         </table>
     </a>
 </div>
-{% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-li-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
+{% if loop.index == 15 && has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-li-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-mediumcard.html
+++ b/templates/pages/hx-mediumcard.html
@@ -62,8 +62,8 @@
         </table>
     </a>
 </div>
-{% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-mc-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
+{% if loop.index == 15 && has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-mc-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-search.html
+++ b/templates/pages/hx-search.html
@@ -27,15 +27,17 @@
         </div>
     </div>
 </a>
-{% endfor %}
-{% if has_more %}
-<form hx-post="/hx/search/{{ next_page }}" hx-trigger="revealed" hx-swap="outerHTML">
+{% if loop.index == 15 && has_more %}
+<form style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-post="/hx/search/{{ next_page }}" hx-trigger="revealed" hx-target="#inf-scroll-sr-{{ next_page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()">
     <input type="hidden" name="search" value="{{ search_term }}" />
     <input type="hidden" name="media_type" value="{{ media_type }}" />
     <input type="hidden" name="sort_by" value="{{ sort_by }}" />
     <input type="hidden" name="date_range" value="{{ date_range }}" />
-    <div class="my-4 inf-scroll-placeholder"></div>
 </form>
+{% endif %}
+{% endfor %}
+{% if has_more %}
+<div id="inf-scroll-sr-{{ next_page }}" class="my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="text-center my-4">
     <p class="text-secondary"><i class="fa-solid fa-circle-check me-2"></i>You have reached the end.</p>

--- a/templates/pages/hx-studio-lists.html
+++ b/templates/pages/hx-studio-lists.html
@@ -18,8 +18,8 @@
         </p>
     </div>
 </div>
-{% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-sl-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
+{% if loop.index == 15 && has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-sl-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-studio.html
+++ b/templates/pages/hx-studio.html
@@ -37,8 +37,8 @@
         </table>
     </a>
 </div>
-{% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-st-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
+{% if loop.index == 15 && has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-st-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}

--- a/templates/pages/hx-userlists.html
+++ b/templates/pages/hx-userlists.html
@@ -11,8 +11,8 @@
         </div>
     </a>
 </div>
-{% if loop.index == 20 && has_more %}
-<div class="col-12" style="height:0;overflow:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-ul-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
+{% if loop.index == 15 && has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-ul-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 {% endif %}
 {% endfor %}
 {% if has_more %}


### PR DESCRIPTION
## Summary
This PR increases the pagination page size across all paginated endpoints and templates from 30 items per page to 40 items per page. This includes updates to database query limits, offset calculations, and infinite scroll trigger points.

## Key Changes

- **Backend pagination updates**: Updated all paginated queries to fetch 41 items (40 displayed + 1 for "has_more" detection) across:
  - List items endpoint (`hx_list_items_inner`)
  - User lists endpoint (`hx_user_lists_inner`)
  - Studio media endpoint (`hx_studio_inner`)
  - Studio lists endpoint (`hx_studio_lists_inner`)
  - User media/channel endpoint (`hx_usermedia_inner`)
  - Search endpoint (`hx_search`)

- **Offset calculation**: Updated all offset calculations from `page * 30` to `page * 40`

- **Infinite scroll trigger optimization**: Adjusted the infinite scroll trigger point from `loop.index == 20` to `loop.index == 15` across all paginated templates, allowing the next page to load earlier in the scroll sequence

- **Search template refactoring**: Improved the search results infinite scroll implementation by:
  - Moving the trigger form inside the loop with conditional rendering at index 15
  - Adding hidden styling attributes for better accessibility
  - Separating the placeholder div from the form logic

## Implementation Details

The "has_more" detection logic remains unchanged - it still fetches one extra item (41 total) and truncates to the display size (40) to determine if additional pages exist. This pattern is consistently applied across all paginated endpoints.

All template changes maintain the same infinite scroll behavior while improving the trigger timing and HTML structure for better performance and accessibility.

https://claude.ai/code/session_01KH5hJSeRVEBRunRkmxdqLd