### PR TITLE
Use Bootstrap CSS variables for like/dislike button colors

### DIFF
--- a/src/likes_dislikes.rs
+++ b/src/likes_dislikes.rs
@@ -1,6 +1,6 @@
 fn like_dislike_html(mediumid: &str, likes: i64, dislikes: i64, user_reaction: Option<&str>) -> String {
-    let like_color = if user_reaction == Some("like") { "#ffd700" } else { "white" };
-    let dislike_color = if user_reaction == Some("dislike") { "#ffd700" } else { "white" };
+    let like_color = if user_reaction == Some("like") { "#ffd700" } else { "var(--bs-success)" };
+    let dislike_color = if user_reaction == Some("dislike") { "#ffd700" } else { "var(--bs-warning)" };
     format!(
         r#"<li class="d-flex align-items-center mx-2"><a class="text-decoration-none" style="cursor: pointer; color: {like_color}" hx-get="/hx/like/{mediumid}" hx-swap="outerHTML" hx-target="closest li"><i class="fa-solid fa-thumbs-up fa-xl"></i>&nbsp;<b>{likes}</b></a><span class="text-white mx-2">|</span><a class="text-decoration-none" style="cursor: pointer; color: {dislike_color}" hx-get="/hx/dislike/{mediumid}" hx-swap="outerHTML" hx-target="closest li"><i class="fa-solid fa-thumbs-down fa-xl"></i>&nbsp;<b>{dislikes}</b></a></li>"#
     )
@@ -8,7 +8,7 @@ fn like_dislike_html(mediumid: &str, likes: i64, dislikes: i64, user_reaction: O
 
 fn like_dislike_html_unauth(mediumid: &str, likes: i64, dislikes: i64) -> String {
     format!(
-        r#"<li class="d-flex align-items-center mx-2"><a class="text-decoration-none text-white" href="/login"><i class="fa-solid fa-thumbs-up fa-xl"></i>&nbsp;<b>{likes}</b></a><span class="text-white mx-2">|</span><a class="text-decoration-none text-white" href="/login"><i class="fa-solid fa-thumbs-down fa-xl"></i>&nbsp;<b>{dislikes}</b></a></li>"#
+        r#"<li class="d-flex align-items-center mx-2"><a class="text-decoration-none" style="color: var(--bs-success)" href="/login"><i class="fa-solid fa-thumbs-up fa-xl"></i>&nbsp;<b>{likes}</b></a><span class="text-white mx-2">|</span><a class="text-decoration-none" style="color: var(--bs-warning)" href="/login"><i class="fa-solid fa-thumbs-down fa-xl"></i>&nbsp;<b>{dislikes}</b></a></li>"#
     )
 }
 


### PR DESCRIPTION
## Summary
Updated the like/dislike button styling to use Bootstrap CSS variables instead of hardcoded colors, improving consistency with the application's theme system.

## Key Changes
- Replaced hardcoded `"white"` color with `"var(--bs-success)"` for default like button color
- Replaced hardcoded `"white"` color with `"var(--bs-warning)"` for default dislike button color
- Updated unauthenticated user view to use inline `style` attributes with Bootstrap variables instead of `text-white` class
- Maintained the gold (`#ffd700`) highlight color for active user reactions

## Implementation Details
- The changes apply to both authenticated (`like_dislike_html`) and unauthenticated (`like_dislike_html_unauth`) views
- Bootstrap CSS variables (`--bs-success` and `--bs-warning`) will automatically adapt to theme changes, improving maintainability
- Active reaction state (when user has liked/disliked) continues to use the distinctive gold color for clear visual feedback

https://claude.ai/code/session_01HT8eHmKjmTch8EWyXD4A8Q