### PR TITLE
Refactor likes/dislikes to use dedicated media_likes table

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -4,8 +4,6 @@ CREATE TABLE public.media (
 	description jsonb,
 	upload int8 DEFAULT EXTRACT(epoch FROM now()) NOT NULL,
 	"owner" varchar NOT NULL,
-	likes int8 DEFAULT 0 NOT NULL,
-	dislikes int8 DEFAULT 0 NOT NULL,
 	"views" int8 DEFAULT 0 NOT NULL,
 	public bool DEFAULT false NOT NULL,
 	visibility varchar DEFAULT 'hidden' NOT NULL,
@@ -80,5 +78,3 @@ CREATE TABLE public.media_likes (
 -- Migration for existing data:
 -- UPDATE public.media SET visibility = CASE WHEN public THEN 'public' ELSE 'hidden' END;
 -- UPDATE public.lists SET visibility = CASE WHEN public THEN 'public' ELSE 'hidden' END;
--- ALTER TABLE public.media DROP COLUMN likes;
--- ALTER TABLE public.media DROP COLUMN dislikes;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -170,7 +170,7 @@ async fn medium_in_list(
 
     // Also check media access
     let medium_row = sqlx::query(
-        "SELECT id,name,description,upload,owner,likes,dislikes,views,type,visibility,restricted_to_group FROM media WHERE id=$1;"
+        "SELECT id,name,description,upload,owner,views,type,visibility,restricted_to_group FROM media WHERE id=$1;"
     )
     .bind(mediumid.to_ascii_lowercase())
     .fetch_one(&pool)

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -102,7 +102,12 @@ async fn hx_trending_inner(
             let user = get_user_login(headers, &pool, redis.clone()).await;
             let user_login = user.map(|u| u.login).unwrap_or_default();
             sqlx::query(
-                "SELECT id,name,owner,views,type FROM media WHERE visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)) ORDER BY likes DESC LIMIT 31 OFFSET $2;"
+                "SELECT m.id, m.name, m.owner, m.views, m.type \
+                 FROM media m \
+                 LEFT JOIN media_likes ml ON m.id = ml.media_id \
+                 WHERE m.visibility = 'public' OR (m.visibility = 'restricted' AND m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)) \
+                 GROUP BY m.id, m.name, m.owner, m.views, m.type \
+                 ORDER BY COUNT(*) FILTER (WHERE ml.reaction = 'like') DESC LIMIT 31 OFFSET $2;"
             )
             .bind(&user_login)
             .bind(offset)


### PR DESCRIPTION
## Summary
This PR refactors the media likes/dislikes system from denormalized columns to a dedicated `media_likes` table, improving data integrity and query flexibility.

## Key Changes
- **Database Schema**: Removed `likes` and `dislikes` integer columns from the `media` table
- **Trending Query**: Updated the trending endpoint to join with `media_likes` table and count likes dynamically using `COUNT(*) FILTER (WHERE ml.reaction = 'like')` instead of relying on a stored column
- **Lists Query**: Removed references to `likes` and `dislikes` columns from the media selection query in `medium_in_list()`

## Implementation Details
- The trending query now uses a `LEFT JOIN` with `media_likes` and groups by media attributes to properly aggregate like counts
- Like counts are calculated on-the-fly from the `media_likes` table rather than being stored and maintained in the `media` table
- This approach provides better data consistency and allows for more flexible reaction tracking (the schema already supports different reaction types)

https://claude.ai/code/session_01TNLmCHCEBXbRiUABXGPEi6