### PR TITLE
Refactor groups list into separate template component

### DIFF
--- a/src/groups.rs
+++ b/src/groups.rs
@@ -57,6 +57,12 @@ struct HXStudioGroupsTemplate {
     groups: Vec<UserGroupWithCount>,
 }
 
+#[derive(Template)]
+#[template(path = "pages/hx-groups-list.html", escape = "none")]
+struct HXGroupsListTemplate {
+    groups: Vec<UserGroupWithCount>,
+}
+
 async fn hx_studio_groups(
     Extension(pool): Extension<PgPool>,
     Extension(redis): Extension<RedisConn>,
@@ -131,7 +137,7 @@ async fn hx_create_group(
     .await
     .expect("Database error");
 
-    let template = HXStudioGroupsTemplate { groups };
+    let template = HXGroupsListTemplate { groups };
     Html(minifi_html(template.render().unwrap()))
 }
 
@@ -211,7 +217,7 @@ async fn hx_delete_group(
     .await
     .expect("Database error");
 
-    let template = HXStudioGroupsTemplate { groups };
+    let template = HXGroupsListTemplate { groups };
     Html(minifi_html(template.render().unwrap()))
 }
 

--- a/templates/pages/hx-groups-list.html
+++ b/templates/pages/hx-groups-list.html
@@ -1,14 +1,3 @@
-<div class="col-12 mb-3">
-    <form hx-post="/hx/creategroup" hx-target="#groups-list" hx-swap="innerHTML">
-        <div class="input-group" style="max-width:500px;">
-            <input type="text" name="name" class="form-control" placeholder="New group name..." required>
-            <button type="submit" class="btn btn-primary">
-                <i class="fa-solid fa-plus"></i>&nbsp;Create Group
-            </button>
-        </div>
-    </form>
-</div>
-<div id="groups-list" class="row">
 {% for group in groups %}
 <div class="col-xl-4 col-lg-6 col-12 my-3">
     <div class="bg-hover rounded border p-3" style="min-height: 80px;">
@@ -34,5 +23,4 @@
 {% endif %}
 <div class="col-12">
     <div id="group-members-panel"></div>
-</div>
 </div>

--- a/templates/pages/studio-groups.html
+++ b/templates/pages/studio-groups.html
@@ -36,7 +36,7 @@
                         </div>
                     </form>
                 </div>
-                <div id="groups-list" hx-get="/hx/studio/groups" hx-trigger="load" class="row mb-3 hx-placeholder">
+                <div id="groups-list" hx-get="/hx/studio/groups" hx-trigger="load" hx-select="#groups-list" hx-swap="outerHTML" class="row mb-3 hx-placeholder">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
Extracted the groups list rendering logic into a dedicated reusable template component to improve code organization and maintainability.

## Key Changes
- **New template component**: Created `hx-groups-list.html` containing the groups list markup that was previously embedded in `hx-studio-groups.html`
- **Template separation**: Moved the groups grid, empty state message, and members panel from the main studio groups template into the new dedicated component
- **Updated handlers**: Modified `hx_create_group` and `hx_delete_group` handlers to use the new `HXGroupsListTemplate` instead of `HXStudioGroupsTemplate` for their responses
- **HTMX swap behavior**: Added explicit `hx-swap="innerHTML"` to the delete group action for consistent swap behavior
- **Studio groups template**: Updated `hx-studio-groups.html` to wrap the groups list in a container div and include the form for creating new groups
- **Page template update**: Modified `studio-groups.html` to use `hx-select="#groups-list"` and `hx-swap="outerHTML"` for proper HTMX targeting of the groups list container

## Implementation Details
- The new `HXGroupsListTemplate` struct mirrors the structure of `HXStudioGroupsTemplate` but is specifically designed for rendering just the groups list content
- This separation allows the create/delete operations to return only the updated list without the form, reducing response payload size
- The groups list is now wrapped in a `<div id="groups-list" class="row">` container to support HTMX swapping operations

https://claude.ai/code/session_016cVQGbmnaWEunA4z95dXta