### PR TITLE
Add system groups for automatic user access control

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -93,7 +93,7 @@ async fn hx_usermedia_inner(
     let offset = page * 40;
 
     let mut media: Vec<Medium> = sqlx::query(
-        "SELECT id,name,owner,views,type FROM media WHERE owner=$1 AND (visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY upload DESC LIMIT 41 OFFSET $3;"
+        "SELECT id,name,owner,views,type FROM media WHERE owner=$1 AND (visibility = 'public' OR (visibility = 'restricted' AND (restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) OR (restricted_to_group = '__all_registered__' AND $2 != '') OR (restricted_to_group = '__subscribers__' AND $2 != '' AND owner IN (SELECT target FROM subscriptions WHERE subscriber = $2))))) ORDER BY upload DESC LIMIT 41 OFFSET $3;"
     )
     .bind(&userid)
     .bind(&user_login)

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -70,7 +70,22 @@ async fn hx_studio_groups(
     }
     let user_info = user_info.unwrap();
 
-    let groups: Vec<UserGroupWithCount> = sqlx::query(
+    let mut groups: Vec<UserGroupWithCount> = vec![
+        UserGroupWithCount {
+            id: SYSTEM_GROUP_ALL_REGISTERED.to_owned(),
+            name: "All Registered Users".to_owned(),
+            owner: user_info.login.clone(),
+            member_count: None,
+        },
+        UserGroupWithCount {
+            id: SYSTEM_GROUP_SUBSCRIBERS.to_owned(),
+            name: "Subscribers Only".to_owned(),
+            owner: user_info.login.clone(),
+            member_count: None,
+        },
+    ];
+
+    let user_groups: Vec<UserGroupWithCount> = sqlx::query(
         "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
     )
     .bind(&user_info.login)
@@ -86,6 +101,8 @@ async fn hx_studio_groups(
     .fetch_all(&pool)
     .await
     .expect("Database error");
+
+    groups.extend(user_groups);
 
     let template = HXStudioGroupsTemplate { groups };
     Html(minifi_html(template.render().unwrap()))
@@ -113,8 +130,23 @@ async fn hx_create_group(
         .await
         .expect("Database error");
 
-    // Return updated groups list
-    let groups: Vec<UserGroupWithCount> = sqlx::query(
+    // Return updated groups list (with system groups prepended)
+    let mut groups: Vec<UserGroupWithCount> = vec![
+        UserGroupWithCount {
+            id: SYSTEM_GROUP_ALL_REGISTERED.to_owned(),
+            name: "All Registered Users".to_owned(),
+            owner: user_info.login.clone(),
+            member_count: None,
+        },
+        UserGroupWithCount {
+            id: SYSTEM_GROUP_SUBSCRIBERS.to_owned(),
+            name: "Subscribers Only".to_owned(),
+            owner: user_info.login.clone(),
+            member_count: None,
+        },
+    ];
+
+    let user_groups: Vec<UserGroupWithCount> = sqlx::query(
         "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
     )
     .bind(&user_info.login)
@@ -131,6 +163,8 @@ async fn hx_create_group(
     .await
     .expect("Database error");
 
+    groups.extend(user_groups);
+
     let template = HXStudioGroupsTemplate { groups };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -146,6 +180,11 @@ async fn hx_delete_group(
         return Html("".as_bytes().to_vec());
     }
     let user_info = user_info.unwrap();
+
+    // Prevent deletion of system groups
+    if is_system_group(&groupid) {
+        return Html("".as_bytes().to_vec());
+    }
 
     // Verify ownership
     let owner_check: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT owner FROM user_groups WHERE id = $1;")
@@ -193,8 +232,23 @@ async fn hx_delete_group(
     // Invalidate Redis group membership cache
     let _: Result<(), _> = redis.clone().del(format!("group:{}:members", groupid)).await;
 
-    // Return updated groups list
-    let groups: Vec<UserGroupWithCount> = sqlx::query(
+    // Return updated groups list (with system groups prepended)
+    let mut groups: Vec<UserGroupWithCount> = vec![
+        UserGroupWithCount {
+            id: SYSTEM_GROUP_ALL_REGISTERED.to_owned(),
+            name: "All Registered Users".to_owned(),
+            owner: user_info.login.clone(),
+            member_count: None,
+        },
+        UserGroupWithCount {
+            id: SYSTEM_GROUP_SUBSCRIBERS.to_owned(),
+            name: "Subscribers Only".to_owned(),
+            owner: user_info.login.clone(),
+            member_count: None,
+        },
+    ];
+
+    let user_groups: Vec<UserGroupWithCount> = sqlx::query(
         "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
     )
     .bind(&user_info.login)
@@ -210,6 +264,8 @@ async fn hx_delete_group(
     .fetch_all(&pool)
     .await
     .expect("Database error");
+
+    groups.extend(user_groups);
 
     let template = HXStudioGroupsTemplate { groups };
     Html(minifi_html(template.render().unwrap()))
@@ -234,6 +290,21 @@ async fn hx_group_members(
         return Html("".as_bytes().to_vec());
     }
     let user_info = user_info.unwrap();
+
+    // System groups are automatically managed - show info instead of member list
+    if is_system_group(&groupid) {
+        let group = if groupid == SYSTEM_GROUP_ALL_REGISTERED {
+            UserGroup { id: groupid, name: "All Registered Users".to_owned(), owner: user_info.login.clone() }
+        } else {
+            UserGroup { id: groupid, name: "Subscribers Only".to_owned(), owner: user_info.login.clone() }
+        };
+        let template = HXGroupMembersTemplate {
+            group,
+            members: vec![],
+            is_owner: false, // prevents showing add/remove controls
+        };
+        return Html(minifi_html(template.render().unwrap()));
+    }
 
     let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
         .bind(&groupid)
@@ -287,6 +358,11 @@ async fn hx_add_group_member(
         return Html("".as_bytes().to_vec());
     }
     let user_info = user_info.unwrap();
+
+    // System groups cannot have members manually added
+    if is_system_group(&groupid) {
+        return Html("".as_bytes().to_vec());
+    }
 
     // Verify group ownership
     let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
@@ -363,6 +439,11 @@ async fn hx_remove_group_member(
     }
     let user_info = user_info.unwrap();
 
+    // System groups cannot have members manually removed
+    if is_system_group(&groupid) {
+        return Html("".as_bytes().to_vec());
+    }
+
     // Verify group ownership
     let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
         .bind(&groupid)
@@ -428,7 +509,9 @@ async fn hx_user_groups_json(
     }
     let user_info = user_info.unwrap();
 
-    let groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+    let mut groups = system_groups_for_owner(&user_info.login);
+
+    let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
         .bind(&user_info.login)
         .map(|row: sqlx::postgres::PgRow| {
             use sqlx::Row;
@@ -441,6 +524,8 @@ async fn hx_user_groups_json(
         .fetch_all(&pool)
         .await
         .unwrap_or_default();
+
+    groups.extend(user_groups);
 
     Json(groups)
 }

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -286,6 +286,39 @@ async fn move_dir(src: &str, dest: &str) -> io::Result<()> {
     Ok(())
 }
 
+const SYSTEM_GROUP_ALL_REGISTERED: &str = "__all_registered__";
+const SYSTEM_GROUP_SUBSCRIBERS: &str = "__subscribers__";
+
+fn is_system_group(group_id: &str) -> bool {
+    group_id == SYSTEM_GROUP_ALL_REGISTERED || group_id == SYSTEM_GROUP_SUBSCRIBERS
+}
+
+fn system_groups_for_owner(owner: &str) -> Vec<UserGroup> {
+    vec![
+        UserGroup {
+            id: SYSTEM_GROUP_ALL_REGISTERED.to_owned(),
+            name: "All Registered Users".to_owned(),
+            owner: owner.to_owned(),
+        },
+        UserGroup {
+            id: SYSTEM_GROUP_SUBSCRIBERS.to_owned(),
+            name: "Subscribers Only".to_owned(),
+            owner: owner.to_owned(),
+        },
+    ]
+}
+
+async fn is_subscribed(pool: &PgPool, subscriber: &str, target: &str) -> bool {
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM subscriptions WHERE subscriber = $1 AND target = $2)"
+    )
+    .bind(subscriber)
+    .bind(target)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(false)
+}
+
 async fn is_group_member(pool: &PgPool, group_id: &str, user_login: &str, mut redis: RedisConn) -> bool {
     let redis_key = format!("group:{}:members", group_id);
 
@@ -322,6 +355,12 @@ async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_gr
                     return true;
                 }
                 if let Some(group_id) = restricted_to_group {
+                    if group_id == SYSTEM_GROUP_ALL_REGISTERED {
+                        return true; // user is logged in
+                    }
+                    if group_id == SYSTEM_GROUP_SUBSCRIBERS {
+                        return is_subscribed(pool, &u.login, owner).await;
+                    }
                     return is_group_member(pool, group_id, &u.login, redis).await;
                 }
             }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -357,8 +357,9 @@ async fn hx_list_modal(
     .await
     .expect("Database error");
 
-    // Fetch user's groups for visibility selection in create form
-    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+    // Fetch user's groups for visibility selection in create form (system groups + user groups)
+    let mut owner_groups = system_groups_for_owner(&user_info.login);
+    let user_groups_list: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
         .bind(&user_info.login)
         .map(|row: sqlx::postgres::PgRow| {
             use sqlx::Row;
@@ -371,6 +372,7 @@ async fn hx_list_modal(
         .fetch_all(&pool)
         .await
         .unwrap_or_default();
+    owner_groups.extend(user_groups_list);
 
     let template = HXListModalTemplate {
         lists,
@@ -438,8 +440,9 @@ async fn hx_create_list(
     .await
     .expect("Database error");
 
-    // Fetch user's groups for visibility selection in create form
-    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+    // Fetch user's groups for visibility selection in create form (system groups + user groups)
+    let mut owner_groups = system_groups_for_owner(&user_info.login);
+    let user_groups_list: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
         .bind(&user_info.login)
         .map(|row: sqlx::postgres::PgRow| {
             use sqlx::Row;
@@ -452,6 +455,7 @@ async fn hx_create_list(
         .fetch_all(&pool)
         .await
         .unwrap_or_default();
+    owner_groups.extend(user_groups_list);
 
     let template = HXListModalTemplate {
         lists,
@@ -666,7 +670,7 @@ async fn hx_user_lists_inner(
     let offset = page * 40;
 
     let mut lists: Vec<ListWithCount> = sqlx::query(
-        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND (l.visibility = 'public' OR (l.visibility = 'restricted' AND l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2))) ORDER BY l.created DESC LIMIT 41 OFFSET $3;"
+        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND (l.visibility = 'public' OR (l.visibility = 'restricted' AND (l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) OR (l.restricted_to_group = '__all_registered__' AND $2 != '') OR (l.restricted_to_group = '__subscribers__' AND $2 != '' AND l.owner IN (SELECT target FROM subscriptions WHERE subscriber = $2))))) ORDER BY l.created DESC LIMIT 41 OFFSET $3;"
     )
     .bind(&userid)
     .bind(&user_login)

--- a/src/search.rs
+++ b/src/search.rs
@@ -44,20 +44,46 @@ async fn build_visibility_filter(pool: &PgPool, user: &Option<User>) -> String {
         .await
         .unwrap_or_default();
 
-        if group_ids.is_empty() {
-            return "visibility = 'public'".to_owned();
-        }
+        // Fetch channels the user is subscribed to
+        let subscribed_channels: Vec<String> = sqlx::query_scalar(
+            "SELECT target FROM subscriptions WHERE subscriber = $1"
+        )
+        .bind(&u.login)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default();
 
-        let group_list = group_ids
+        // Build the list of group IDs + system group for all registered users
+        let mut all_group_ids = group_ids;
+        all_group_ids.push(SYSTEM_GROUP_ALL_REGISTERED.to_owned());
+
+        let group_list = all_group_ids
             .iter()
             .map(|g| format!("'{}'", g.replace('\'', "")))
             .collect::<Vec<_>>()
             .join(", ");
 
-        format!(
+        let mut filter = format!(
             "visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN [{}])",
             group_list
-        )
+        );
+
+        // For subscribers-only content, we need to check if the user is subscribed to the owner
+        // Meilisearch doesn't support subqueries, so we add owner-based filters
+        if !subscribed_channels.is_empty() {
+            let owner_list = subscribed_channels
+                .iter()
+                .map(|o| format!("'{}'", o.replace('\'', "")))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            filter = format!(
+                "{} OR (visibility = 'restricted' AND restricted_to_group = '{}' AND owner IN [{}])",
+                filter, SYSTEM_GROUP_SUBSCRIBERS, owner_list
+            );
+        }
+
+        filter
     } else {
         "visibility = 'public'".to_owned()
     }

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -254,8 +254,9 @@ async fn studio_edit(
                 ));
             }
 
-            // Fetch user's groups for the dropdown
-            let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+            // Fetch user's groups for the dropdown (system groups + user groups)
+            let mut owner_groups = system_groups_for_owner(&user_info.login);
+            let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
                 .bind(&user_info.login)
                 .map(|row: sqlx::postgres::PgRow| {
                     UserGroup {
@@ -267,6 +268,7 @@ async fn studio_edit(
                 .fetch_all(&pool)
                 .await
                 .unwrap_or_default();
+            owner_groups.extend(user_groups);
 
             let sidebar = generate_sidebar(&config, "studio".to_owned());
             let common_headers = extract_common_headers(&headers).unwrap();

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -63,7 +63,7 @@ async fn hx_subscriptions_inner(
         "SELECT m.id, m.name, m.owner, m.views, m.type
          FROM media m
          INNER JOIN subscriptions s ON m.owner = s.target
-         WHERE s.subscriber = $1 AND (m.visibility = 'public' OR (m.visibility = 'restricted' AND m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)))
+         WHERE s.subscriber = $1 AND (m.visibility = 'public' OR (m.visibility = 'restricted' AND (m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1) OR m.restricted_to_group = '__all_registered__' OR (m.restricted_to_group = '__subscribers__' AND m.owner IN (SELECT target FROM subscriptions WHERE subscriber = $1)))))
          ORDER BY m.upload DESC
          LIMIT 31 OFFSET $2;"
     )

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -105,7 +105,7 @@ async fn hx_trending_inner(
                 "SELECT m.id, m.name, m.owner, m.views, m.type \
                  FROM media m \
                  LEFT JOIN media_likes ml ON m.id = ml.media_id \
-                 WHERE m.visibility = 'public' OR (m.visibility = 'restricted' AND m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)) \
+                 WHERE m.visibility = 'public' OR (m.visibility = 'restricted' AND (m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1) OR (m.restricted_to_group = '__all_registered__' AND $1 != '') OR (m.restricted_to_group = '__subscribers__' AND $1 != '' AND m.owner IN (SELECT target FROM subscriptions WHERE subscriber = $1)))) \
                  GROUP BY m.id, m.name, m.owner, m.views, m.type \
                  ORDER BY COUNT(*) FILTER (WHERE ml.reaction = 'like') DESC LIMIT 31 OFFSET $2;"
             )

--- a/templates/pages/hx-group-members.html
+++ b/templates/pages/hx-group-members.html
@@ -3,6 +3,16 @@
         <h5 class="text-white m-0"><i class="fa-solid fa-users me-2"></i>{{ group.name }} - Members</h5>
     </div>
     <hr class="mt-0">
+    {% if group.id == "__all_registered__" || group.id == "__subscribers__" %}
+    <div class="text-secondary">
+        <i class="fa-solid fa-circle-info me-2"></i>
+        {% if group.id == "__all_registered__" %}
+        This is an automatic group that includes all registered users. Any logged-in user will have access to media or lists restricted to this group. Membership is managed automatically and cannot be changed.
+        {% else %}
+        This is an automatic group that includes all users subscribed to your channel. Only users who have subscribed to you will have access to media or lists restricted to this group. Membership is managed automatically and cannot be changed.
+        {% endif %}
+    </div>
+    {% else %}
     {% if is_owner %}
     <form hx-post="/hx/group/{{ group.id }}/addmember" hx-target="#group-members-panel" class="mb-3">
         <div class="input-group" style="max-width:400px;">
@@ -49,5 +59,6 @@
             </tbody>
         </table>
     </div>
+    {% endif %}
     {% endif %}
 </div>

--- a/templates/pages/hx-studio-groups.html
+++ b/templates/pages/hx-studio-groups.html
@@ -3,9 +3,21 @@
     <div class="bg-hover rounded border p-3" style="min-height: 80px;">
         <div class="d-flex justify-content-between align-items-start">
             <div>
+                {% if group.id == "__all_registered__" || group.id == "__subscribers__" %}
+                <b class="text-white"><i class="fa-solid fa-shield-halved me-2"></i>{{ group.name }}</b>
+                <p class="text-secondary mb-0">
+                    {% if group.id == "__all_registered__" %}
+                    Automatically includes all logged-in users
+                    {% else %}
+                    Automatically includes users subscribed to your channel
+                    {% endif %}
+                </p>
+                {% else %}
                 <b class="text-white"><i class="fa-solid fa-users me-2"></i>{{ group.name }}</b>
                 <p class="text-secondary mb-0">{{ group.member_count.unwrap_or(0) }} members</p>
+                {% endif %}
             </div>
+            {% if group.id != "__all_registered__" && group.id != "__subscribers__" %}
             <div class="d-flex gap-2">
                 <span hx-get="/hx/group/{{ group.id }}/members" hx-target="#group-members-panel" class="text-primary" style="cursor:pointer;" title="Manage members">
                     <i class="fa-solid fa-user-gear"></i>
@@ -14,13 +26,11 @@
                     <i class="fa-solid fa-trash"></i>
                 </span>
             </div>
+            {% endif %}
         </div>
     </div>
 </div>
 {% endfor %}
-{% if groups.is_empty() %}
-<p class="text-secondary text-center">No groups yet. Create one above to restrict media and lists to specific users.</p>
-{% endif %}
 <div class="col-12">
     <div id="group-members-panel"></div>
 </div>


### PR DESCRIPTION
## Summary
This PR introduces two built-in system groups that automatically manage access to restricted media and lists based on user authentication status and subscription relationships, eliminating the need for manual group membership management in these common scenarios.

## Key Changes

- **System Groups**: Added two new automatic groups:
  - `__all_registered__`: Includes all logged-in users
  - `__subscribers__`: Includes users subscribed to a channel owner
  
- **Group Management**: 
  - System groups are now prepended to user group lists in all group-related endpoints
  - System groups cannot be deleted, and members cannot be manually added/removed
  - Special UI treatment in templates to indicate automatic membership and prevent modification attempts
  
- **Access Control**:
  - Updated `can_access_restricted()` to recognize system groups and check subscription status via new `is_subscribed()` helper
  - Modified all visibility queries across media, lists, and subscriptions to include system group logic
  - Search visibility filter now accounts for subscriber-based access to `__subscribers__` group content
  
- **Database Queries**: Updated SQL queries in:
  - `hx_usermedia_inner()` - media visibility filtering
  - `hx_subscriptions_inner()` - subscription feed filtering  
  - `hx_trending_inner()` - trending content filtering
  - `hx_user_lists_inner()` - list visibility filtering
  - Meilisearch filter building - search result filtering

- **UI Updates**:
  - System groups display with shield icon and descriptive text about automatic membership
  - Removed "No groups yet" message since system groups are always present
  - System groups don't show member count or management controls
  - Group member panel shows informational message for system groups instead of member list

- **Helper Functions**: Added utility functions:
  - `is_system_group()` - checks if a group ID is a system group
  - `system_groups_for_owner()` - returns system groups for a given owner
  - `is_subscribed()` - checks subscription relationship between users

## Implementation Details
System groups are identified by reserved ID prefixes (`__all_registered__` and `__subscribers__`) and are treated specially throughout the codebase to prevent modification while maintaining consistent access control semantics across all content visibility checks.

https://claude.ai/code/session_01YDW22kGKZwCdw6ErUFioCd