### PR TITLE
Add user settings page with profile and account management

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output();
+
+    let git_hash = match output {
+        Ok(o) => String::from_utf8(o.stdout)
+            .unwrap_or_else(|_| "unknown".to_owned())
+            .trim()
+            .to_owned(),
+        Err(_) => "unknown".to_owned(),
+    };
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 #![allow(non_snake_case)]
 
 use argon2::Argon2;
+use argon2::PasswordHasher;
 use argon2::PasswordVerifier;
 use axum::http::StatusCode;
 use mimalloc::MiMalloc;
@@ -170,6 +171,21 @@ async fn main() {
         .route("/hx/deletelist/{listid}", get(hx_delete_list))
         .route("/hx/userlists/{userid}", get(hx_user_lists))
         .route("/hx/userlists/{userid}/{page}", get(hx_user_lists_page))
+        // Settings routes
+        .route("/settings", get(settings))
+        .route("/settings/password", get(settings_password))
+        .route("/settings/profile-picture", get(settings_profile_picture))
+        .route("/settings/channel-picture", get(settings_channel_picture))
+        .route("/settings/diagnostics", get(settings_diagnostics))
+        .route("/hx/settings/channel-name", get(hx_settings_channel_name))
+        .route("/hx/settings/channel-name", post(hx_settings_channel_name_save))
+        .route("/hx/settings/password", get(hx_settings_password))
+        .route("/hx/settings/password", post(hx_settings_password_save))
+        .route("/hx/settings/profile-picture", get(hx_settings_profile_picture))
+        .route("/hx/settings/profile-picture", post(hx_settings_profile_picture_save))
+        .route("/hx/settings/channel-picture", get(hx_settings_channel_picture))
+        .route("/hx/settings/channel-picture", post(hx_settings_channel_picture_save))
+        .route("/hx/settings/diagnostics", get(hx_settings_diagnostics))
         // Group management routes
         .route("/studio/groups", get(studio_groups))
         .route("/hx/studio/groups", get(hx_studio_groups))
@@ -214,3 +230,4 @@ include!("concept.rs");
 include!("serve.rs");
 include!("lists.rs");
 include!("groups.rs");
+include!("settings.rs");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,473 @@
+#[derive(Template)]
+#[template(path = "pages/settings.html", escape = "none")]
+struct SettingsTemplate {
+    sidebar: String,
+    config: Config,
+    common_headers: CommonHeaders,
+    active_tab: String,
+}
+
+async fn settings(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let sidebar = generate_sidebar(&config, "settings".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = SettingsTemplate {
+        sidebar,
+        config,
+        common_headers,
+        active_tab: "channel_name".to_owned(),
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn settings_password(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let sidebar = generate_sidebar(&config, "settings".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = SettingsTemplate {
+        sidebar,
+        config,
+        common_headers,
+        active_tab: "password".to_owned(),
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn settings_profile_picture(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let sidebar = generate_sidebar(&config, "settings".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = SettingsTemplate {
+        sidebar,
+        config,
+        common_headers,
+        active_tab: "profile_picture".to_owned(),
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn settings_channel_picture(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let sidebar = generate_sidebar(&config, "settings".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = SettingsTemplate {
+        sidebar,
+        config,
+        common_headers,
+        active_tab: "channel_picture".to_owned(),
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn settings_diagnostics(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+        return Html(minifi_html(
+            "<script>window.location.replace(\"/login\");</script>".to_owned(),
+        ));
+    }
+    let sidebar = generate_sidebar(&config, "settings".to_owned());
+    let common_headers = extract_common_headers(&headers).unwrap();
+    let template = SettingsTemplate {
+        sidebar,
+        config,
+        common_headers,
+        active_tab: "diagnostics".to_owned(),
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+// --- HTMX tab content handlers ---
+
+#[derive(Template)]
+#[template(path = "pages/hx-settings-channel-name.html", escape = "none")]
+struct HXSettingsChannelNameTemplate {
+    current_name: String,
+}
+async fn hx_settings_channel_name(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+    let template = HXSettingsChannelNameTemplate {
+        current_name: user_info.name,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChannelNameForm {
+    channel_name: String,
+}
+async fn hx_settings_channel_name_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Form(form): Form<ChannelNameForm>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+    let new_name = form.channel_name.trim();
+    if new_name.is_empty() || new_name.len() > 100 {
+        return Html(minifi_html("<b class=\"text-danger\">Channel name must be between 1 and 100 characters.</b>".to_owned()));
+    }
+    let result = sqlx::query("UPDATE users SET name=$1 WHERE login=$2;")
+        .bind(new_name)
+        .bind(&user_info.login)
+        .execute(&pool)
+        .await;
+    if result.is_err() {
+        return Html(minifi_html("<b class=\"text-danger\">Failed to update channel name.</b>".to_owned()));
+    }
+    Html(minifi_html(format!("<b class=\"text-success\">Channel name updated to \"{}\".</b>", askama::filters::escape(new_name, askama::filters::Html).unwrap())))
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-settings-password.html", escape = "none")]
+struct HXSettingsPasswordTemplate {}
+async fn hx_settings_password(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let template = HXSettingsPasswordTemplate {};
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Serialize, Deserialize)]
+struct PasswordForm {
+    current_password: String,
+    new_password: String,
+    confirm_password: String,
+}
+async fn hx_settings_password_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Form(form): Form<PasswordForm>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+
+    if form.new_password != form.confirm_password {
+        return Html(minifi_html("<b class=\"text-danger\">New passwords do not match.</b>".to_owned()));
+    }
+    if form.new_password.len() < 8 {
+        return Html(minifi_html("<b class=\"text-danger\">New password must be at least 8 characters.</b>".to_owned()));
+    }
+
+    // Verify current password
+    let stored = sqlx::query_scalar::<_, String>("SELECT password_hash FROM users WHERE login=$1")
+        .bind(&user_info.login)
+        .fetch_one(&pool)
+        .await;
+    if stored.is_err() {
+        return Html(minifi_html("<b class=\"text-danger\">Failed to verify current password.</b>".to_owned()));
+    }
+    let stored_hash = stored.unwrap();
+    if Argon2::default()
+        .verify_password(form.current_password.as_bytes(), &PasswordHash::new(&stored_hash).unwrap())
+        .is_err()
+    {
+        return Html(minifi_html("<b class=\"text-danger\">Current password is incorrect.</b>".to_owned()));
+    }
+
+    // Hash new password with Argon2id
+    let salt = argon2::password_hash::SaltString::generate(&mut argon2::password_hash::rand_core::OsRng);
+    let new_hash = Argon2::default()
+        .hash_password(form.new_password.as_bytes(), &salt);
+    if new_hash.is_err() {
+        return Html(minifi_html("<b class=\"text-danger\">Failed to hash new password.</b>".to_owned()));
+    }
+    let new_hash_string = new_hash.unwrap().to_string();
+
+    let result = sqlx::query("UPDATE users SET password_hash=$1 WHERE login=$2;")
+        .bind(&new_hash_string)
+        .bind(&user_info.login)
+        .execute(&pool)
+        .await;
+    if result.is_err() {
+        return Html(minifi_html("<b class=\"text-danger\">Failed to update password.</b>".to_owned()));
+    }
+    Html(minifi_html("<b class=\"text-success\">Password updated successfully.</b>".to_owned()))
+}
+
+// --- Profile Picture ---
+
+#[derive(Serialize, Deserialize)]
+struct PictureMedium {
+    id: String,
+    name: String,
+    visibility: String,
+}
+#[derive(Template)]
+#[template(path = "pages/hx-settings-profile-picture.html", escape = "none")]
+struct HXSettingsProfilePictureTemplate {
+    media: Vec<PictureMedium>,
+    current_picture: Option<String>,
+    config: Config,
+}
+async fn hx_settings_profile_picture(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+
+    let current_picture: Option<String> = sqlx::query_scalar("SELECT profile_picture FROM users WHERE login=$1")
+        .bind(&user_info.login)
+        .fetch_one(&pool)
+        .await
+        .unwrap_or(None);
+
+    let media: Vec<PictureMedium> = sqlx::query(
+        "SELECT id, name, visibility FROM media WHERE owner=$1 AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
+    )
+    .bind(&user_info.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        PictureMedium {
+            id: row.get("id"),
+            name: row.get("name"),
+            visibility: row.get("visibility"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .unwrap_or_default();
+
+    let template = HXSettingsProfilePictureTemplate { media, current_picture, config };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+#[derive(Serialize, Deserialize)]
+struct PictureForm {
+    medium_id: String,
+}
+async fn hx_settings_profile_picture_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Form(form): Form<PictureForm>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+
+    // Verify the medium belongs to this user and is public or hidden
+    let medium = sqlx::query("SELECT owner, visibility FROM media WHERE id=$1")
+        .bind(&form.medium_id)
+        .fetch_one(&pool)
+        .await;
+    match medium {
+        Ok(record) => {
+            use sqlx::Row;
+            let owner: String = record.get("owner");
+            let visibility: String = record.get("visibility");
+            if owner != user_info.login {
+                return Html(minifi_html("<b class=\"text-danger\">You can only use your own media.</b>".to_owned()));
+            }
+            if visibility != "public" && visibility != "hidden" {
+                return Html(minifi_html("<b class=\"text-danger\">Media must be public or hidden.</b>".to_owned()));
+            }
+        }
+        Err(_) => {
+            return Html(minifi_html("<b class=\"text-danger\">Medium not found.</b>".to_owned()));
+        }
+    }
+
+    let result = sqlx::query("UPDATE users SET profile_picture=$1 WHERE login=$2;")
+        .bind(&form.medium_id)
+        .bind(&user_info.login)
+        .execute(&pool)
+        .await;
+    if result.is_err() {
+        return Html(minifi_html("<b class=\"text-danger\">Failed to update profile picture.</b>".to_owned()));
+    }
+    Html(minifi_html("<b class=\"text-success\">Profile picture updated.</b>".to_owned()))
+}
+
+// --- Channel Picture ---
+
+#[derive(Template)]
+#[template(path = "pages/hx-settings-channel-picture.html", escape = "none")]
+struct HXSettingsChannelPictureTemplate {
+    media: Vec<PictureMedium>,
+    current_picture: Option<String>,
+    config: Config,
+}
+async fn hx_settings_channel_picture(
+    Extension(config): Extension<Config>,
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+
+    let current_picture: Option<String> = sqlx::query_scalar("SELECT channel_picture FROM users WHERE login=$1")
+        .bind(&user_info.login)
+        .fetch_one(&pool)
+        .await
+        .unwrap_or(None);
+
+    let media: Vec<PictureMedium> = sqlx::query(
+        "SELECT id, name, visibility FROM media WHERE owner=$1 AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
+    )
+    .bind(&user_info.login)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        PictureMedium {
+            id: row.get("id"),
+            name: row.get("name"),
+            visibility: row.get("visibility"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .unwrap_or_default();
+
+    let template = HXSettingsChannelPictureTemplate { media, current_picture, config };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+async fn hx_settings_channel_picture_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Form(form): Form<PictureForm>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+
+    // Verify the medium belongs to this user and is public or hidden
+    let medium = sqlx::query("SELECT owner, visibility FROM media WHERE id=$1")
+        .bind(&form.medium_id)
+        .fetch_one(&pool)
+        .await;
+    match medium {
+        Ok(record) => {
+            use sqlx::Row;
+            let owner: String = record.get("owner");
+            let visibility: String = record.get("visibility");
+            if owner != user_info.login {
+                return Html(minifi_html("<b class=\"text-danger\">You can only use your own media.</b>".to_owned()));
+            }
+            if visibility != "public" && visibility != "hidden" {
+                return Html(minifi_html("<b class=\"text-danger\">Media must be public or hidden.</b>".to_owned()));
+            }
+        }
+        Err(_) => {
+            return Html(minifi_html("<b class=\"text-danger\">Medium not found.</b>".to_owned()));
+        }
+    }
+
+    let result = sqlx::query("UPDATE users SET channel_picture=$1 WHERE login=$2;")
+        .bind(&form.medium_id)
+        .bind(&user_info.login)
+        .execute(&pool)
+        .await;
+    if result.is_err() {
+        return Html(minifi_html("<b class=\"text-danger\">Failed to update channel picture.</b>".to_owned()));
+    }
+    Html(minifi_html("<b class=\"text-success\">Channel picture updated.</b>".to_owned()))
+}
+
+// --- Diagnostics ---
+
+#[derive(Template)]
+#[template(path = "pages/hx-settings-diagnostics.html", escape = "none")]
+struct HXSettingsDiagnosticsTemplate {
+    git_commit: String,
+    version: String,
+    os_info: String,
+}
+async fn hx_settings_diagnostics(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
+    }
+
+    let git_commit = env!("GIT_COMMIT_HASH").to_owned();
+    let version = env!("CARGO_PKG_VERSION").to_owned();
+    let os_info = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
+
+    let template = HXSettingsDiagnosticsTemplate {
+        git_commit,
+        version,
+        os_info,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}

--- a/templates/pages/hx-settings-channel-name.html
+++ b/templates/pages/hx-settings-channel-name.html
@@ -1,0 +1,11 @@
+<div class="col-12 col-md-8 col-lg-6">
+    <h5 class="mb-3">Change Channel Name</h5>
+    <form hx-post="/hx/settings/channel-name" hx-target="#settings-result" hx-swap="innerHTML">
+        <div class="mb-3">
+            <label for="channel_name" class="form-label">Channel Name</label>
+            <input type="text" class="form-control" id="channel_name" name="channel_name" value="{{ current_name }}" maxlength="100" required>
+        </div>
+        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
+    </form>
+    <div id="settings-result" class="mt-3"></div>
+</div>

--- a/templates/pages/hx-settings-channel-picture.html
+++ b/templates/pages/hx-settings-channel-picture.html
@@ -1,0 +1,40 @@
+<div class="col-12">
+    <h5 class="mb-3">Channel Picture</h5>
+    {% if current_picture.is_some() %}
+    <div class="mb-3">
+        <p class="text-secondary">Current channel picture:</p>
+        <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="max-width:300px;max-height:170px;" class="border rounded">
+    </div>
+    {% else %}
+    <p class="text-secondary mb-3">No channel picture set.</p>
+    {% endif %}
+    <p class="text-secondary">Select a public or hidden medium from your channel to use as your channel picture.</p>
+    <form hx-post="/hx/settings/channel-picture" hx-target="#settings-result" hx-swap="innerHTML">
+        <div class="row g-2 mb-3">
+            {% for m in media %}
+            <div class="col-xl-2 col-lg-3 col-md-4 col-6">
+                <label class="d-block">
+                    <input type="radio" name="medium_id" value="{{ m.id }}" class="d-none" {% if current_picture.is_some() && current_picture.clone().unwrap() == m.id %}checked{% endif %}>
+                    <div class="card bg-hover p-1 text-center medium-select-card" style="cursor:pointer;">
+                        <img src="{{ config.source_server_url }}/source/{{ m.id }}/thumbnail.avif" style="width:100%;height:99px;object-fit:cover;" class="rounded">
+                        <small class="text-white text-truncate mt-1">{{ m.name }}</small>
+                        {% if m.visibility == "hidden" %}
+                        <small class="text-secondary"><i class="fa-solid fa-eye-slash"></i> Hidden</small>
+                        {% endif %}
+                    </div>
+                </label>
+            </div>
+            {% endfor %}
+        </div>
+        {% if media.is_empty() %}
+        <p class="text-secondary">You have no public or hidden media. Upload some media first.</p>
+        {% else %}
+        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
+        {% endif %}
+    </form>
+    <div id="settings-result" class="mt-3"></div>
+</div>
+<style>
+    .medium-select-card { border: 2px solid transparent; }
+    input[type="radio"]:checked + .medium-select-card { border-color: var(--bs-primary); }
+</style>

--- a/templates/pages/hx-settings-diagnostics.html
+++ b/templates/pages/hx-settings-diagnostics.html
@@ -1,0 +1,62 @@
+<div class="col-12 col-md-8 col-lg-6">
+    <h5 class="mb-3">Diagnostics</h5>
+    <table class="table table-dark table-bordered">
+        <tbody>
+            <tr>
+                <td class="text-secondary">Version</td>
+                <td><code>{{ version }}</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">Git Commit</td>
+                <td><code>{{ git_commit }}</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">Server OS</td>
+                <td><code>{{ os_info }}</code></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h5 class="mb-3 mt-4">Browser Codec Support</h5>
+    <table class="table table-dark table-bordered">
+        <tbody>
+            <tr>
+                <td class="text-secondary">AV1</td>
+                <td id="codec-av1"><code>Checking...</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">VP9</td>
+                <td id="codec-vp9"><code>Checking...</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">H.265 (HEVC)</td>
+                <td id="codec-h265"><code>Checking...</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">Opus</td>
+                <td id="codec-opus"><code>Checking...</code></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+<script>
+(function() {
+    function checkMediaSource(codec) {
+        if (typeof MediaSource === 'undefined') return false;
+        try { return MediaSource.isTypeSupported(codec); } catch(e) { return false; }
+    }
+    function setResult(id, supported) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        if (supported) {
+            el.innerHTML = '<code class="text-success">Supported</code>';
+        } else {
+            el.innerHTML = '<code class="text-danger">Not supported</code>';
+        }
+    }
+    setResult('codec-av1', checkMediaSource('video/webm; codecs="av01.0.05M.08"'));
+    setResult('codec-vp9', checkMediaSource('video/webm; codecs="vp9"'));
+    setResult('codec-h265', checkMediaSource('video/mp4; codecs="hvc1.1.6.L93.B0"'));
+    setResult('codec-opus', checkMediaSource('audio/webm; codecs="opus"'));
+})();
+</script>

--- a/templates/pages/hx-settings-password.html
+++ b/templates/pages/hx-settings-password.html
@@ -1,0 +1,19 @@
+<div class="col-12 col-md-8 col-lg-6">
+    <h5 class="mb-3">Change Password</h5>
+    <form hx-post="/hx/settings/password" hx-target="#settings-result" hx-swap="innerHTML">
+        <div class="mb-3">
+            <label for="current_password" class="form-label">Current Password</label>
+            <input type="password" class="form-control" id="current_password" name="current_password" required>
+        </div>
+        <div class="mb-3">
+            <label for="new_password" class="form-label">New Password</label>
+            <input type="password" class="form-control" id="new_password" name="new_password" minlength="8" required>
+        </div>
+        <div class="mb-3">
+            <label for="confirm_password" class="form-label">Confirm New Password</label>
+            <input type="password" class="form-control" id="confirm_password" name="confirm_password" minlength="8" required>
+        </div>
+        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Update Password</button>
+    </form>
+    <div id="settings-result" class="mt-3"></div>
+</div>

--- a/templates/pages/hx-settings-profile-picture.html
+++ b/templates/pages/hx-settings-profile-picture.html
@@ -1,0 +1,40 @@
+<div class="col-12">
+    <h5 class="mb-3">Profile Picture</h5>
+    {% if current_picture.is_some() %}
+    <div class="mb-3">
+        <p class="text-secondary">Current profile picture:</p>
+        <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="max-width:176px;max-height:176px;border-radius:50%;" class="border">
+    </div>
+    {% else %}
+    <p class="text-secondary mb-3">No profile picture set.</p>
+    {% endif %}
+    <p class="text-secondary">Select a public or hidden medium from your channel to use as your profile picture.</p>
+    <form hx-post="/hx/settings/profile-picture" hx-target="#settings-result" hx-swap="innerHTML">
+        <div class="row g-2 mb-3">
+            {% for m in media %}
+            <div class="col-xl-2 col-lg-3 col-md-4 col-6">
+                <label class="d-block">
+                    <input type="radio" name="medium_id" value="{{ m.id }}" class="d-none" {% if current_picture.is_some() && current_picture.clone().unwrap() == m.id %}checked{% endif %}>
+                    <div class="card bg-hover p-1 text-center medium-select-card" style="cursor:pointer;">
+                        <img src="{{ config.source_server_url }}/source/{{ m.id }}/thumbnail.avif" style="width:100%;height:99px;object-fit:cover;" class="rounded">
+                        <small class="text-white text-truncate mt-1">{{ m.name }}</small>
+                        {% if m.visibility == "hidden" %}
+                        <small class="text-secondary"><i class="fa-solid fa-eye-slash"></i> Hidden</small>
+                        {% endif %}
+                    </div>
+                </label>
+            </div>
+            {% endfor %}
+        </div>
+        {% if media.is_empty() %}
+        <p class="text-secondary">You have no public or hidden media. Upload some media first.</p>
+        {% else %}
+        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
+        {% endif %}
+    </form>
+    <div id="settings-result" class="mt-3"></div>
+</div>
+<style>
+    .medium-select-card { border: 2px solid transparent; }
+    input[type="radio"]:checked + .medium-select-card { border-color: var(--bs-primary); }
+</style>

--- a/templates/pages/hx-sidebar.html
+++ b/templates/pages/hx-sidebar.html
@@ -12,3 +12,10 @@
         Studio
     </a>
 </li>
+<li class="nav-item">
+    <a href="/settings" class="nav-link {% if active_item == "settings" %}active{% endif %} text-white
+        text-decoration-none my-2 fs-6 mx-3 bg-hover" preload="mouseover">
+        <i class="fa-solid fa-gear"></i>
+        Settings
+    </a>
+</li>

--- a/templates/pages/settings.html
+++ b/templates/pages/settings.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    {% include "component-dependencies.html" %}
+
+    <title>Settings</title>
+
+    <meta property="og:title" content="{{ config.instancename }} Settings" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://{{ common_headers.host }}/settings" />
+</head>
+
+<body hx-ext="preload">
+    {% set page_title = "Settings" %}
+    {{ sidebar }}
+    {% include "component-navbar.html" %}
+    <div class="row maincontentrow g-3 py-2 ps-2 w-100">
+        <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+            <div class="card py-3 px-3 text-white" style="min-height:30vh;">
+                <ul class="nav nav-tabs mb-3">
+                    <li class="nav-item">
+                        <button class="nav-link {% if active_tab == "channel_name" %}active {% endif %}text-white"
+                                hx-get="/hx/settings/channel-name"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/settings"
+                                hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                            <i class="fa-solid fa-signature me-2"></i>Channel Name
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link {% if active_tab == "password" %}active {% endif %}text-white"
+                                hx-get="/hx/settings/password"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/settings/password"
+                                hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                            <i class="fa-solid fa-lock me-2"></i>Password
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link {% if active_tab == "profile_picture" %}active {% endif %}text-white"
+                                hx-get="/hx/settings/profile-picture"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/settings/profile-picture"
+                                hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                            <i class="fa-solid fa-user-circle me-2"></i>Profile Picture
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link {% if active_tab == "channel_picture" %}active {% endif %}text-white"
+                                hx-get="/hx/settings/channel-picture"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/settings/channel-picture"
+                                hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                            <i class="fa-solid fa-image me-2"></i>Channel Picture
+                        </button>
+                    </li>
+                    <li class="nav-item">
+                        <button class="nav-link {% if active_tab == "diagnostics" %}active {% endif %}text-white"
+                                hx-get="/hx/settings/diagnostics"
+                                hx-target="#tab-content"
+                                hx-swap="innerHTML"
+                                hx-push-url="/settings/diagnostics"
+                                hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                            <i class="fa-solid fa-stethoscope me-2"></i>Diagnostics
+                        </button>
+                    </li>
+                </ul>
+                <div id="tab-content" class="row">
+                    {% if active_tab == "password" %}
+                    <div hx-get="/hx/settings/password" hx-trigger="load" class="mb-3 hx-placeholder">
+                    </div>
+                    {% else if active_tab == "profile_picture" %}
+                    <div hx-get="/hx/settings/profile-picture" hx-trigger="load" class="mb-3 hx-placeholder">
+                    </div>
+                    {% else if active_tab == "channel_picture" %}
+                    <div hx-get="/hx/settings/channel-picture" hx-trigger="load" class="mb-3 hx-placeholder">
+                    </div>
+                    {% else if active_tab == "diagnostics" %}
+                    <div hx-get="/hx/settings/diagnostics" hx-trigger="load" class="mb-3 hx-placeholder">
+                    </div>
+                    {% else %}
+                    <div hx-get="/hx/settings/channel-name" hx-trigger="load" class="mb-3 hx-placeholder">
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
This PR adds a comprehensive user settings page that allows users to manage their account and profile information. The implementation includes a tabbed interface with HTMX for dynamic content loading, along with backend handlers for various settings operations.

## Key Changes

- **Settings Page Structure**: Created a main settings page (`/settings`) with a tabbed navigation interface supporting five different settings categories
- **Channel Name Management**: Added ability to update channel name with validation (1-100 characters)
- **Password Management**: Implemented secure password change functionality with current password verification and Argon2 hashing
- **Profile Picture Settings**: Added UI to select and set profile picture from user's public/hidden media
- **Channel Picture Settings**: Added UI to select and set channel picture from user's public/hidden media
- **Diagnostics Tab**: Created diagnostics view displaying version info, git commit hash, OS information, and browser codec support detection
- **HTMX Integration**: Implemented dynamic tab content loading via HTMX endpoints for seamless UX without full page reloads
- **Build Script**: Added `build.rs` to capture git commit hash at compile time for diagnostics display
- **Sidebar Navigation**: Updated sidebar to include link to settings page

## Implementation Details

- All settings endpoints require authentication with redirect to login if not authenticated
- Password changes use Argon2id hashing with proper salt generation
- Media selection for pictures validates ownership and visibility (public/hidden only)
- Form submissions return user-friendly success/error messages
- Diagnostics page includes client-side JavaScript to detect browser codec support (AV1, VP9, H.265, Opus)
- Settings use form-based HTMX POST requests with inline result feedback

https://claude.ai/code/session_01WTrYWb5ZbvwrcmMppgVbPz