### PR TITLE
Restrict profile/channel pictures to image media only

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,11 +6,14 @@ fn main() {
         .output();
 
     let git_hash = match output {
-        Ok(o) => String::from_utf8(o.stdout)
-            .unwrap_or_else(|_| "unknown".to_owned())
-            .trim()
-            .to_owned(),
-        Err(_) => "unknown".to_owned(),
+        Ok(o) if o.status.success() => {
+            let hash = String::from_utf8(o.stdout)
+                .unwrap_or_default()
+                .trim()
+                .to_owned();
+            if hash.is_empty() { "unknown".to_owned() } else { hash }
+        }
+        _ => "unknown".to_owned(),
     };
 
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -281,7 +281,7 @@ async fn hx_settings_profile_picture(
         .unwrap_or(None);
 
     let media: Vec<PictureMedium> = sqlx::query(
-        "SELECT id, name, visibility FROM media WHERE owner=$1 AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
+        "SELECT id, name, visibility FROM media WHERE owner=$1 AND type='picture' AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
     )
     .bind(&user_info.login)
     .map(|row: sqlx::postgres::PgRow| {
@@ -316,8 +316,8 @@ async fn hx_settings_profile_picture_save(
     }
     let user_info = user_info.unwrap();
 
-    // Verify the medium belongs to this user and is public or hidden
-    let medium = sqlx::query("SELECT owner, visibility FROM media WHERE id=$1")
+    // Verify the medium belongs to this user, is an image, and is public or hidden
+    let medium = sqlx::query("SELECT owner, visibility, type FROM media WHERE id=$1")
         .bind(&form.medium_id)
         .fetch_one(&pool)
         .await;
@@ -326,8 +326,12 @@ async fn hx_settings_profile_picture_save(
             use sqlx::Row;
             let owner: String = record.get("owner");
             let visibility: String = record.get("visibility");
+            let medium_type: String = record.get("type");
             if owner != user_info.login {
                 return Html(minifi_html("<b class=\"text-danger\">You can only use your own media.</b>".to_owned()));
+            }
+            if medium_type != "picture" {
+                return Html(minifi_html("<b class=\"text-danger\">Only image media can be used as a profile picture.</b>".to_owned()));
             }
             if visibility != "public" && visibility != "hidden" {
                 return Html(minifi_html("<b class=\"text-danger\">Media must be public or hidden.</b>".to_owned()));
@@ -377,7 +381,7 @@ async fn hx_settings_channel_picture(
         .unwrap_or(None);
 
     let media: Vec<PictureMedium> = sqlx::query(
-        "SELECT id, name, visibility FROM media WHERE owner=$1 AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
+        "SELECT id, name, visibility FROM media WHERE owner=$1 AND type='picture' AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
     )
     .bind(&user_info.login)
     .map(|row: sqlx::postgres::PgRow| {
@@ -408,8 +412,8 @@ async fn hx_settings_channel_picture_save(
     }
     let user_info = user_info.unwrap();
 
-    // Verify the medium belongs to this user and is public or hidden
-    let medium = sqlx::query("SELECT owner, visibility FROM media WHERE id=$1")
+    // Verify the medium belongs to this user, is an image, and is public or hidden
+    let medium = sqlx::query("SELECT owner, visibility, type FROM media WHERE id=$1")
         .bind(&form.medium_id)
         .fetch_one(&pool)
         .await;
@@ -418,8 +422,12 @@ async fn hx_settings_channel_picture_save(
             use sqlx::Row;
             let owner: String = record.get("owner");
             let visibility: String = record.get("visibility");
+            let medium_type: String = record.get("type");
             if owner != user_info.login {
                 return Html(minifi_html("<b class=\"text-danger\">You can only use your own media.</b>".to_owned()));
+            }
+            if medium_type != "picture" {
+                return Html(minifi_html("<b class=\"text-danger\">Only image media can be used as a channel picture.</b>".to_owned()));
             }
             if visibility != "public" && visibility != "hidden" {
                 return Html(minifi_html("<b class=\"text-danger\">Media must be public or hidden.</b>".to_owned()));
@@ -443,12 +451,38 @@ async fn hx_settings_channel_picture_save(
 
 // --- Diagnostics ---
 
+fn get_os_distro() -> String {
+    if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
+        for line in content.lines() {
+            if line.starts_with("PRETTY_NAME=") {
+                return line[12..].trim_matches('"').to_owned();
+            }
+        }
+    }
+    std::env::consts::OS.to_owned()
+}
+
+fn get_kernel_version() -> String {
+    let output = std::process::Command::new("uname")
+        .arg("-r")
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            let v = String::from_utf8(o.stdout).unwrap_or_default().trim().to_owned();
+            if v.is_empty() { "unknown".to_owned() } else { v }
+        }
+        _ => "unknown".to_owned(),
+    }
+}
+
 #[derive(Template)]
 #[template(path = "pages/hx-settings-diagnostics.html", escape = "none")]
 struct HXSettingsDiagnosticsTemplate {
     git_commit: String,
     version: String,
-    os_info: String,
+    os_distro: String,
+    os_kernel: String,
+    os_arch: String,
 }
 async fn hx_settings_diagnostics(
     Extension(pool): Extension<PgPool>,
@@ -462,12 +496,16 @@ async fn hx_settings_diagnostics(
 
     let git_commit = env!("GIT_COMMIT_HASH").to_owned();
     let version = env!("CARGO_PKG_VERSION").to_owned();
-    let os_info = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
+    let os_distro = get_os_distro();
+    let os_kernel = get_kernel_version();
+    let os_arch = std::env::consts::ARCH.to_owned();
 
     let template = HXSettingsDiagnosticsTemplate {
         git_commit,
         version,
-        os_info,
+        os_distro,
+        os_kernel,
+        os_arch,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/templates/pages/hx-settings-channel-picture.html
+++ b/templates/pages/hx-settings-channel-picture.html
@@ -1,15 +1,17 @@
 <div class="col-12">
     <h5 class="mb-3">Channel Picture</h5>
-    {% if current_picture.is_some() %}
-    <div class="mb-3">
-        <p class="text-secondary">Current channel picture:</p>
-        <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="max-width:300px;max-height:170px;" class="border rounded">
-    </div>
-    {% else %}
-    <p class="text-secondary mb-3">No channel picture set.</p>
-    {% endif %}
-    <p class="text-secondary">Select a public or hidden image from your channel to use as your channel picture.</p>
     <form hx-post="/hx/settings/channel-picture" hx-target="#settings-result" hx-swap="innerHTML">
+        <div class="d-flex align-items-center gap-3 mb-3">
+            {% if current_picture.is_some() %}
+            <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="max-width:300px;max-height:170px;" class="border rounded flex-shrink-0">
+            {% else %}
+            <p class="text-secondary mb-0">No channel picture set.</p>
+            {% endif %}
+            {% if !media.is_empty() %}
+            <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
+            {% endif %}
+        </div>
+        <p class="text-secondary">Select a public or hidden image from your channel to use as your channel picture.</p>
         <div class="row g-2 mb-3">
             {% for m in media %}
             <div class="col-xl-2 col-lg-3 col-md-4 col-6">
@@ -28,8 +30,6 @@
         </div>
         {% if media.is_empty() %}
         <p class="text-secondary">You have no public or hidden images. Upload an image first.</p>
-        {% else %}
-        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
         {% endif %}
     </form>
     <div id="settings-result" class="mt-3"></div>

--- a/templates/pages/hx-settings-channel-picture.html
+++ b/templates/pages/hx-settings-channel-picture.html
@@ -8,7 +8,7 @@
     {% else %}
     <p class="text-secondary mb-3">No channel picture set.</p>
     {% endif %}
-    <p class="text-secondary">Select a public or hidden medium from your channel to use as your channel picture.</p>
+    <p class="text-secondary">Select a public or hidden image from your channel to use as your channel picture.</p>
     <form hx-post="/hx/settings/channel-picture" hx-target="#settings-result" hx-swap="innerHTML">
         <div class="row g-2 mb-3">
             {% for m in media %}
@@ -27,7 +27,7 @@
             {% endfor %}
         </div>
         {% if media.is_empty() %}
-        <p class="text-secondary">You have no public or hidden media. Upload some media first.</p>
+        <p class="text-secondary">You have no public or hidden images. Upload an image first.</p>
         {% else %}
         <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
         {% endif %}

--- a/templates/pages/hx-settings-diagnostics.html
+++ b/templates/pages/hx-settings-diagnostics.html
@@ -11,8 +11,16 @@
                 <td><code>{{ git_commit }}</code></td>
             </tr>
             <tr>
-                <td class="text-secondary">Server OS</td>
-                <td><code>{{ os_info }}</code></td>
+                <td class="text-secondary">OS Distro</td>
+                <td><code>{{ os_distro }}</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">Kernel</td>
+                <td><code>{{ os_kernel }}</code></td>
+            </tr>
+            <tr>
+                <td class="text-secondary">Architecture</td>
+                <td><code>{{ os_arch }}</code></td>
             </tr>
         </tbody>
     </table>
@@ -49,9 +57,9 @@
         var el = document.getElementById(id);
         if (!el) return;
         if (supported) {
-            el.innerHTML = '<code class="text-success">Supported</code>';
+            el.innerHTML = '<i class="fa-solid fa-check" style="color:var(--bs-success);"></i>';
         } else {
-            el.innerHTML = '<code class="text-danger">Not supported</code>';
+            el.innerHTML = '<i class="fa-solid fa-xmark" style="color:var(--bs-danger);"></i>';
         }
     }
     setResult('codec-av1', checkMediaSource('video/webm; codecs="av01.0.05M.08"'));

--- a/templates/pages/hx-settings-profile-picture.html
+++ b/templates/pages/hx-settings-profile-picture.html
@@ -8,7 +8,7 @@
     {% else %}
     <p class="text-secondary mb-3">No profile picture set.</p>
     {% endif %}
-    <p class="text-secondary">Select a public or hidden medium from your channel to use as your profile picture.</p>
+    <p class="text-secondary">Select a public or hidden image from your channel to use as your profile picture.</p>
     <form hx-post="/hx/settings/profile-picture" hx-target="#settings-result" hx-swap="innerHTML">
         <div class="row g-2 mb-3">
             {% for m in media %}
@@ -27,7 +27,7 @@
             {% endfor %}
         </div>
         {% if media.is_empty() %}
-        <p class="text-secondary">You have no public or hidden media. Upload some media first.</p>
+        <p class="text-secondary">You have no public or hidden images. Upload an image first.</p>
         {% else %}
         <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
         {% endif %}

--- a/templates/pages/hx-settings-profile-picture.html
+++ b/templates/pages/hx-settings-profile-picture.html
@@ -1,15 +1,17 @@
 <div class="col-12">
     <h5 class="mb-3">Profile Picture</h5>
-    {% if current_picture.is_some() %}
-    <div class="mb-3">
-        <p class="text-secondary">Current profile picture:</p>
-        <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="max-width:176px;max-height:176px;border-radius:50%;" class="border">
-    </div>
-    {% else %}
-    <p class="text-secondary mb-3">No profile picture set.</p>
-    {% endif %}
-    <p class="text-secondary">Select a public or hidden image from your channel to use as your profile picture.</p>
     <form hx-post="/hx/settings/profile-picture" hx-target="#settings-result" hx-swap="innerHTML">
+        <div class="d-flex align-items-center gap-3 mb-3">
+            {% if current_picture.is_some() %}
+            <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="width:88px;height:88px;border-radius:50%;object-fit:cover;" class="border flex-shrink-0">
+            {% else %}
+            <p class="text-secondary mb-0">No profile picture set.</p>
+            {% endif %}
+            {% if !media.is_empty() %}
+            <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
+            {% endif %}
+        </div>
+        <p class="text-secondary">Select a public or hidden image from your channel to use as your profile picture.</p>
         <div class="row g-2 mb-3">
             {% for m in media %}
             <div class="col-xl-2 col-lg-3 col-md-4 col-6">
@@ -28,8 +30,6 @@
         </div>
         {% if media.is_empty() %}
         <p class="text-secondary">You have no public or hidden images. Upload an image first.</p>
-        {% else %}
-        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-floppy-disk me-2"></i>Save</button>
         {% endif %}
     </form>
     <div id="settings-result" class="mt-3"></div>

--- a/templates/pages/hx-sidebar.html
+++ b/templates/pages/hx-sidebar.html
@@ -12,10 +12,3 @@
         Studio
     </a>
 </li>
-<li class="nav-item">
-    <a href="/settings" class="nav-link {% if active_item == "settings" %}active{% endif %} text-white
-        text-decoration-none my-2 fs-6 mx-3 bg-hover" preload="mouseover">
-        <i class="fa-solid fa-gear"></i>
-        Settings
-    </a>
-</li>

--- a/templates/pages/hx-usernav.html
+++ b/templates/pages/hx-usernav.html
@@ -3,6 +3,7 @@
     <div class="dropdown-content border shadow">
         <a class="dropdown-item" href="/channel/{{ user.login }}" preload="mouseover"><i class="fa-solid fa-house-flag mx-2"></i>My Channel</a>
         <a class="dropdown-item" href="/studio" preload="mouseover"><i class="fa-solid fa-pen-ruler mx-2"></i>Studio</a>
+        <a class="dropdown-item" href="/settings" preload="mouseover"><i class="fa-solid fa-gear mx-2"></i>Settings</a>
         <a class="dropdown-item" href="/hx/logout"><i class="fa-solid fa-arrow-right-from-bracket mx-2"></i>Log out</a>
     </div>
 </div>


### PR DESCRIPTION
## Summary
This PR adds type validation to ensure only image media can be used as profile and channel pictures, while also improving the diagnostics page to display more detailed system information.

## Key Changes

**Media Type Validation:**
- Added `type='picture'` filter to SQL queries when fetching media for profile and channel picture selection
- Added explicit type validation in `hx_settings_profile_picture_save` and `hx_settings_channel_picture_save` to reject non-image media with appropriate error messages
- Updated user-facing text to clarify that only "images" can be used (changed from generic "media")

**Diagnostics Page Improvements:**
- Refactored OS information display to show three separate fields:
  - OS Distribution (reads from `/etc/os-release` PRETTY_NAME, falls back to compile-time OS constant)
  - Kernel version (obtained via `uname -r` command)
  - Architecture (compile-time constant)
- Replaced text-based codec support indicators with Font Awesome icons (✓ for supported, ✗ for unsupported)

**Build Script Enhancement:**
- Improved git commit hash retrieval to properly check command success status and handle empty output

## Implementation Details
- New helper functions `get_os_distro()` and `get_kernel_version()` provide runtime system information detection
- Error handling ensures graceful fallbacks when system commands fail or files are unavailable
- Template changes maintain consistent UX while providing clearer feedback about media type restrictions

https://claude.ai/code/session_019iECZgTVsxDQ4Dvu3RHj36