### PR TITLE
Replace inline visibility toggles with TomSelect components

### DIFF
--- a/templates/pages/component-dependencies.html
+++ b/templates/pages/component-dependencies.html
@@ -25,4 +25,6 @@ html.sidebar-will-collapse .sidebarbackground { transform: translateX(-100%); }
 <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets/highlight.min.js"></script>
 <link href="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets/styles/vs2015.min.css" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/quill@2/dist/quill.js" defer></script>
+<link href="https://cdn.jsdelivr.net/npm/tom-select/dist/css/tom-select.bootstrap5.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/tom-select/dist/js/tom-select.complete.min.js" defer></script>
 <script src="/script.js"></script>

--- a/templates/pages/concept.html
+++ b/templates/pages/concept.html
@@ -144,16 +144,24 @@
                             </div>
                         </div>
                         <script>
-                        document.getElementById('medium_visibility').addEventListener('change', function() {
-                            var groupSelect = document.getElementById('medium_restricted_group');
+                        document.addEventListener('DOMContentLoaded', function() {
+                            var visTomSelect = new TomSelect('#medium_visibility', { create: false });
+                            var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true });
                             var noGroupsHint = document.getElementById('no-groups-hint');
-                            if (this.value === 'restricted') {
-                                groupSelect.style.display = '';
-                                if (noGroupsHint) noGroupsHint.style.display = '';
-                            } else {
-                                groupSelect.style.display = 'none';
-                                if (noGroupsHint) noGroupsHint.style.display = 'none';
+
+                            // Show/hide group selector wrapper based on visibility
+                            function updateGroupVisibility() {
+                                var wrapper = groupTomSelect.wrapper;
+                                if (visTomSelect.getValue() === 'restricted') {
+                                    wrapper.style.display = '';
+                                    if (noGroupsHint) noGroupsHint.style.display = '';
+                                } else {
+                                    wrapper.style.display = 'none';
+                                    if (noGroupsHint) noGroupsHint.style.display = 'none';
+                                }
                             }
+                            updateGroupVisibility();
+                            document.getElementById('medium_visibility').addEventListener('change', updateGroupVisibility);
                         });
                         </script>
                         <div class="form-group row my-3">

--- a/templates/pages/hx-listmodal.html
+++ b/templates/pages/hx-listmodal.html
@@ -39,12 +39,12 @@
                 </button>
             </div>
             <div class="d-flex align-items-center gap-2 mx-2">
-                <select name="visibility" class="form-select form-select-sm" style="width:auto;" id="listmodal-visibility" onchange="document.getElementById('listmodal-group-select').style.display = this.value === 'restricted' ? '' : 'none'">
+                <select name="visibility" class="form-select form-select-sm" style="width:auto;" id="listmodal-visibility">
                     <option value="hidden">Private</option>
                     <option value="public">Public</option>
                     <option value="restricted">Restricted to Group</option>
                 </select>
-                <select name="restricted_group" class="form-select form-select-sm" style="width:auto;display:none;" id="listmodal-group-select">
+                <select name="restricted_group" class="form-select form-select-sm" style="width:auto;" id="listmodal-group-select">
                     <option value="">-- Group --</option>
                     {% for group in owner_groups %}
                     <option value="{{ group.id }}">{{ group.name }}</option>
@@ -54,3 +54,20 @@
         </form>
     </div>
 </div>
+<script>
+(function() {
+    var visEl = document.getElementById('listmodal-visibility');
+    var groupEl = document.getElementById('listmodal-group-select');
+    if (!visEl || !groupEl || typeof TomSelect === 'undefined') return;
+    if (visEl.tomselect) visEl.tomselect.destroy();
+    if (groupEl.tomselect) groupEl.tomselect.destroy();
+    var visTomSelect = new TomSelect(visEl, { create: false });
+    var groupTomSelect = new TomSelect(groupEl, { create: false, allowEmptyOption: true });
+    groupTomSelect.wrapper.style.width = 'auto';
+    function updateGroupVisibility() {
+        groupTomSelect.wrapper.style.display = visTomSelect.getValue() === 'restricted' ? '' : 'none';
+    }
+    updateGroupVisibility();
+    visEl.addEventListener('change', updateGroupVisibility);
+})();
+</script>

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -160,28 +160,29 @@
                         </div>
                         <script>
                         document.addEventListener('DOMContentLoaded', function() {
-                            var visSelect = document.getElementById('medium_visibility');
-                            var groupSelect = document.getElementById('medium_restricted_group');
+                            var visTomSelect = new TomSelect('#medium_visibility', { create: false });
+                            var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true });
                             var noGroupsHint = document.getElementById('no-groups-hint');
 
                             // Set initial selected group value
                             var currentGroup = '{{ medium.restricted_to_group }}';
                             if (currentGroup) {
-                                groupSelect.value = currentGroup;
+                                groupTomSelect.setValue(currentGroup);
                             }
 
-                            // Show/hide group selector based on visibility
+                            // Show/hide group selector wrapper based on visibility
                             function updateGroupVisibility() {
-                                if (visSelect.value === 'restricted') {
-                                    groupSelect.style.display = '';
+                                var wrapper = groupTomSelect.wrapper;
+                                if (visTomSelect.getValue() === 'restricted') {
+                                    wrapper.style.display = '';
                                     if (noGroupsHint) noGroupsHint.style.display = '';
                                 } else {
-                                    groupSelect.style.display = 'none';
+                                    wrapper.style.display = 'none';
                                     if (noGroupsHint) noGroupsHint.style.display = 'none';
                                 }
                             }
                             updateGroupVisibility();
-                            visSelect.addEventListener('change', updateGroupVisibility);
+                            document.getElementById('medium_visibility').addEventListener('change', updateGroupVisibility);
                         });
                         </script>
                         <div class="form-group row my-3">


### PR DESCRIPTION
## Summary
This PR refactors visibility and group selection controls across multiple templates to use TomSelect, a modern select component library, replacing inline event handlers and direct DOM manipulation with a more robust and consistent approach.

## Key Changes
- **concept.html**: Migrated visibility toggle from inline `addEventListener` to TomSelect-based implementation with proper initialization in `DOMContentLoaded` event
- **studio-edit.html**: Updated to use TomSelect for both visibility and group selection, with proper value setting via `setValue()` method and wrapper-based visibility toggling
- **hx-listmodal.html**: Converted inline `onchange` handler to TomSelect implementation with IIFE pattern for safe initialization and cleanup
- **component-dependencies.html**: Added TomSelect library dependencies (CSS and JS) to support the new components across all templates

## Implementation Details
- All three templates now use consistent TomSelect initialization patterns with `create: false` and `allowEmptyOption: true` options
- Visibility toggling now targets the TomSelect wrapper element (`wrapper.style.display`) instead of the raw select element
- Added proper initialization guards in hx-listmodal.html to check for TomSelect availability and destroy existing instances before creating new ones
- Maintained backward compatibility by preserving the same HTML structure and form field names
- Group selection values are properly set using TomSelect's `setValue()` method instead of direct property assignment

https://claude.ai/code/session_012ZjCi4bpfBNRoGviVBTBrz