### PR TITLE
Add preload="mouseover" to navigation tab buttons

### DIFF
--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -40,10 +40,10 @@
             <div class="card py-3 px-3 text-white">
                 <ul class="nav nav-tabs mb-3">
                     <li class="nav-item">
-                        <button class="nav-link active text-white" hx-get="/hx/usermedia/{{ user.login }}" hx-target="#tab-content" hx-swap="innerHTML" hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active')"><i class="fa-solid fa-photo-film me-2"></i>Media</button>
+                        <button class="nav-link active text-white" hx-get="/hx/usermedia/{{ user.login }}" hx-target="#tab-content" hx-swap="innerHTML" preload="mouseover" hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active')"><i class="fa-solid fa-photo-film me-2"></i>Media</button>
                     </li>
                     <li class="nav-item">
-                        <button class="nav-link text-white" hx-get="/hx/userlists/{{ user.login }}" hx-target="#tab-content" hx-swap="innerHTML" hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active')"><i class="fa-solid fa-list me-2"></i>Lists</button>
+                        <button class="nav-link text-white" hx-get="/hx/userlists/{{ user.login }}" hx-target="#tab-content" hx-swap="innerHTML" preload="mouseover" hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active')"><i class="fa-solid fa-list me-2"></i>Lists</button>
                     </li>
                 </ul>
                 <div id="tab-content" class="row">

--- a/templates/pages/settings.html
+++ b/templates/pages/settings.html
@@ -25,6 +25,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/settings"
+                                preload="mouseover"
                                 hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
                             <i class="fa-solid fa-signature me-2"></i>Channel Name
                         </button>
@@ -35,6 +36,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/settings/password"
+                                preload="mouseover"
                                 hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
                             <i class="fa-solid fa-lock me-2"></i>Password
                         </button>
@@ -45,6 +47,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/settings/profile-picture"
+                                preload="mouseover"
                                 hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
                             <i class="fa-solid fa-user-circle me-2"></i>Profile Picture
                         </button>
@@ -55,6 +58,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/settings/channel-picture"
+                                preload="mouseover"
                                 hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
                             <i class="fa-solid fa-image me-2"></i>Channel Picture
                         </button>
@@ -65,6 +69,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/settings/diagnostics"
+                                preload="mouseover"
                                 hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
                             <i class="fa-solid fa-stethoscope me-2"></i>Diagnostics
                         </button>

--- a/templates/pages/studio.html
+++ b/templates/pages/studio.html
@@ -25,6 +25,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/studio"
+                                preload="mouseover"
                                 hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
                                 hx-on::before-request="if(window.isUploading){event.preventDefault();}">
                             <i class="fa-solid fa-photo-film me-2"></i>Media
@@ -36,6 +37,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/upload"
+                                preload="mouseover"
                                 hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
                             <i class="fa-solid fa-upload me-2"></i>Upload
                         </button>
@@ -46,6 +48,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/studio/concepts"
+                                preload="mouseover"
                                 hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
                                 hx-on::before-request="if(window.isUploading){event.preventDefault();}">
                             <i class="fa-solid fa-wand-magic-sparkles me-2"></i>Concepts
@@ -57,6 +60,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/studio/lists"
+                                preload="mouseover"
                                 hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
                                 hx-on::before-request="if(window.isUploading){event.preventDefault();}">
                             <i class="fa-solid fa-list me-2"></i>Lists
@@ -68,6 +72,7 @@
                                 hx-target="#tab-content"
                                 hx-swap="innerHTML"
                                 hx-push-url="/studio/groups"
+                                preload="mouseover"
                                 hx-on:click="if(window.isUploading){alert('Please wait for the upload to complete before switching tabs.');return;} document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');"
                                 hx-on::before-request="if(window.isUploading){event.preventDefault();}">
                             <i class="fa-solid fa-users me-2"></i>Groups


### PR DESCRIPTION
## Summary
This PR adds the `preload="mouseover"` attribute to all navigation tab buttons across the settings, studio, and channel pages. This HTMX feature enables preloading of tab content when users hover over navigation buttons, improving perceived performance and responsiveness.

## Changes Made
- Added `preload="mouseover"` attribute to 5 navigation buttons in `templates/pages/settings.html`:
  - Channel Name tab
  - Password tab
  - Profile Picture tab
  - Channel Picture tab
  - Diagnostics tab

- Added `preload="mouseover"` attribute to 5 navigation buttons in `templates/pages/studio.html`:
  - Media tab
  - Upload tab
  - Concepts tab
  - Lists tab
  - Groups tab

- Added `preload="mouseover"` attribute to 2 navigation buttons in `templates/pages/channel.html`:
  - Media tab
  - Lists tab

## Implementation Details
The `preload="mouseover"` attribute is an HTMX feature that triggers the AJAX request specified by `hx-get` when the user hovers over the element, rather than waiting for a click. This allows the content to be fetched and ready before the user actually clicks, reducing perceived latency and improving the user experience when navigating between tabs.

https://claude.ai/code/session_01CMTaegdPjLzoCur2EkAyBk