### PR TITLE
Add MP4 composition endpoint for video streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ Cargo.lock
 /source
 /node_modules
 /assets/processed
-./package-lock.json
+package-lock.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ lto = true
 
 [dependencies]
 mimalloc = { version = "*", features = ["secure"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "process", "io-util"] }
+tokio-util = { version = "0.7", features = ["io"] }
 axum = { version = "0.8", features = ["multipart", "json"] }
 tower = "*"
 tower-http = { version = "*", features = ["fs"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN cd /src/rustvideoplatform && npm install --ignore-scripts && cargo build --r
 
 
 FROM alpine:latest
+RUN apk add --no-cache ffmpeg
 COPY --from=builder /src/rustvideoplatform/target/release/rustvideoplatform /opt/rustvideoplatform
 
 EXPOSE 8080

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ async fn main() {
             "/m/{mediumid}/description.json",
             get(medium_description_prepare),
         )
+        .route("/m/{mediumid}/video.mp4", get(compose_mp4))
         .route("/hx/comments/{mediumid}", get(hx_comments))
         .route("/hx/comments/{mediumid}/add", post(hx_add_comment))
         .route("/hx/comment/{commentid}/delta.json", get(comment_delta))
@@ -228,6 +229,7 @@ include!("subtitles.rs");
 include!("upload.rs");
 include!("concept.rs");
 include!("serve.rs");
+include!("mp4_compose.rs");
 include!("lists.rs");
 include!("groups.rs");
 include!("settings.rs");

--- a/src/mp4_compose.rs
+++ b/src/mp4_compose.rs
@@ -1,0 +1,121 @@
+async fn compose_mp4(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> Response<Body> {
+    let medium_id = mediumid.to_ascii_lowercase();
+
+    // Verify the medium exists and is a video, and that the user has access
+    let medium_row = sqlx::query(
+        "SELECT m.id, m.name, m.type, m.visibility, m.restricted_to_group, m.owner FROM media m WHERE m.id=$1;"
+    )
+    .bind(&medium_id)
+    .fetch_optional(&pool)
+    .await;
+
+    let medium = match medium_row {
+        Ok(Some(row)) => row,
+        _ => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Body::empty())
+                .unwrap();
+        }
+    };
+
+    use sqlx::Row;
+    let medium_type: String = medium.get("type");
+    if medium_type != "video" {
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .unwrap();
+    }
+
+    let visibility: String = medium.get("visibility");
+    let restricted_to_group: Option<String> = medium.get("restricted_to_group");
+    let owner: String = medium.get("owner");
+    let user = get_user_login(headers, &pool, redis.clone()).await;
+
+    if !can_access_restricted(&pool, &visibility, restricted_to_group.as_deref(), &owner, &user, redis.clone()).await {
+        return Response::builder()
+            .status(StatusCode::FORBIDDEN)
+            .body(Body::empty())
+            .unwrap();
+    }
+
+    // Determine input source: prefer HLS (m3u8), fall back to DASH (mpd)
+    let m3u8_path = format!("source/{}/video/video.m3u8", medium_id);
+    let mpd_path = format!("source/{}/video/video.mpd", medium_id);
+
+    let (input_path, is_hls) = if std::path::Path::new(&m3u8_path).exists() {
+        (m3u8_path, true)
+    } else if std::path::Path::new(&mpd_path).exists() {
+        (mpd_path, false)
+    } else {
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .unwrap();
+    };
+
+    // Build ffmpeg command to remux DASH/HLS CMAF segments into a streamable MP4
+    let mut cmd = tokio::process::Command::new("ffmpeg");
+    cmd.arg("-hide_banner")
+        .arg("-loglevel").arg("error");
+
+    if is_hls {
+        cmd.arg("-protocol_whitelist").arg("file,pipe,crypto,data")
+            .arg("-allowed_extensions").arg("ALL");
+    }
+
+    cmd.arg("-i").arg(&input_path)
+        .arg("-c").arg("copy")
+        .arg("-movflags").arg("frag_keyframe+empty_moov")
+        .arg("-f").arg("mp4")
+        .arg("pipe:1")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::from("Failed to start video composition"))
+                .unwrap();
+        }
+    };
+
+    let stdout = child.stdout.take().unwrap();
+    let stream = tokio_util::io::ReaderStream::new(stdout);
+    let body = Body::from_stream(stream);
+
+    // Wait for the child process in the background to avoid zombies
+    tokio::spawn(async move {
+        let _ = child.wait().await;
+    });
+
+    // Build a safe filename from the medium name
+    let medium_name: String = medium.get("name");
+    let safe_filename: String = medium_name
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == ' ' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    Response::builder()
+        .header("Content-Type", "video/mp4")
+        .header(
+            "Content-Disposition",
+            format!("inline; filename=\"{}.mp4\"", safe_filename),
+        )
+        .body(body)
+        .unwrap()
+}

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -26,13 +26,13 @@
         <meta property="og:type" content="video.movie" />
         <meta
             property="og:video"
-            content="https://{{ common_headers.host }}/source/{{ medium_id }}/video/video.webm"
+            content="https://{{ common_headers.host }}/m/{{ medium_id }}/video.mp4"
         />
         <meta
             property="og:video:secure_url"
-            content="https://{{ common_headers.host }}/source/{{ medium_id }}/video/video.webm"
+            content="https://{{ common_headers.host }}/m/{{ medium_id }}/video.mp4"
         />
-        <meta property="og:video:type" content="video/webm" />
+        <meta property="og:video:type" content="video/mp4" />
         <meta property="og:video:width" content="1280" />
         <meta property="og:video:height" content="720" />
         {% else if medium_type == "audio" %}
@@ -232,7 +232,7 @@
                                 ></li>
                                 <li class="mx-4">
                                     {% if medium_type == "video" %}
-                                    <a href="{{ config.source_server_url }}/source/{{ medium_id }}/video/video.webm" class="text-white text-decoration-none" download="{{ medium_id }}.webm"><i class="fa-solid fa-download fa-xl"></i></a>
+                                    <a href="/m/{{ medium_id }}/video.mp4" class="text-white text-decoration-none" download="{{ medium_name }}.mp4"><i class="fa-solid fa-download fa-xl"></i></a>
                                     {% else if medium_type == "audio" %}
                                     <a href="{{ config.source_server_url }}/source/{{ medium_id }}/audio.ogg" class="text-white text-decoration-none" download="{{ medium_id }}.ogg"><i class="fa-solid fa-download fa-xl"></i></a>
                                     {% else if medium_type == "picture" %}


### PR DESCRIPTION
## Summary
This PR adds a new MP4 composition endpoint that dynamically remuxes HLS/DASH video streams into streamable MP4 format on-demand, replacing direct WebM file downloads with a more compatible format.

## Key Changes
- **New `compose_mp4` handler** (`src/mp4_compose.rs`): 
  - Accepts video requests at `/m/{mediumid}/video.mp4`
  - Verifies medium exists, is a video type, and user has access permissions
  - Intelligently selects input source (prefers HLS `.m3u8`, falls back to DASH `.mpd`)
  - Uses FFmpeg to remux CMAF segments into fragmented MP4 with `frag_keyframe+empty_moov` flags for streaming compatibility
  - Streams output directly to client via `tokio_util::io::ReaderStream`
  - Spawns child process cleanup in background to prevent zombies
  - Generates safe filenames from medium metadata

- **Updated video download/sharing**:
  - Changed OG meta tags from WebM to MP4 format for better social media compatibility
  - Updated download link from direct WebM file to new MP4 composition endpoint
  - Download filename now uses medium name instead of ID

- **Dependencies**:
  - Added `tokio` features: `process` and `io-util` for subprocess and stream handling
  - Added `tokio-util` with `io` feature for `ReaderStream` adapter

- **Infrastructure**:
  - Added FFmpeg to Docker image for MP4 composition capability
  - Registered new route in main router

## Implementation Details
- Access control is enforced before composition begins (visibility, group restrictions, ownership)
- FFmpeg command includes protocol whitelisting for HLS to safely handle local file references
- Response includes proper `Content-Type` and `Content-Disposition` headers for browser handling
- Filename sanitization replaces unsafe characters with underscores while preserving alphanumerics, hyphens, underscores, spaces, and dots

https://claude.ai/code/session_0115TyDyxsJDrncqc9KZxwnf