### PR TITLE
Update profile picture thumbnail references to use smaller variant

### DIFF
--- a/templates/pages/hx-comment-single.html
+++ b/templates/pages/hx-comment-single.html
@@ -2,7 +2,7 @@
     <div class="d-flex align-items-center mb-2 gap-2">
         <a href="/channel/{{ comment.user }}" class="text-decoration-none d-flex align-items-center gap-2">
             {% if comment.user_picture.is_some() %}
-            <img src="{{ config.source_server_url }}/source/{{ comment.user_picture.clone().unwrap() }}/thumbnail.avif"
+            <img src="{{ config.source_server_url }}/source/{{ comment.user_picture.clone().unwrap() }}/thumbnail-small.avif"
                  class="user-avatar" />
             {% else %}
             <div class="user-avatar-placeholder">

--- a/templates/pages/hx-comments.html
+++ b/templates/pages/hx-comments.html
@@ -3,7 +3,7 @@
     <div class="d-flex align-items-center mb-2 gap-2">
         <a href="/channel/{{ comment.user }}" class="text-decoration-none d-flex align-items-center gap-2">
             {% if comment.user_picture.is_some() %}
-            <img src="{{ config.source_server_url }}/source/{{ comment.user_picture.clone().unwrap() }}/thumbnail.avif"
+            <img src="{{ config.source_server_url }}/source/{{ comment.user_picture.clone().unwrap() }}/thumbnail-small.avif"
                  class="user-avatar" />
             {% else %}
             <div class="user-avatar-placeholder">

--- a/templates/pages/hx-settings-profile-picture.html
+++ b/templates/pages/hx-settings-profile-picture.html
@@ -2,7 +2,7 @@
     <form hx-post="/hx/settings/profile-picture" hx-target="#settings-result" hx-swap="innerHTML">
         <div class="d-flex align-items-center gap-3 mb-3">
             {% if current_picture.is_some() %}
-            <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail.avif" style="width:88px;height:88px;border-radius:50%;object-fit:cover;" class="border flex-shrink-0">
+            <img src="{{ config.source_server_url }}/source/{{ current_picture.clone().unwrap() }}/thumbnail-small.avif" style="width:88px;height:88px;border-radius:50%;object-fit:cover;" class="border flex-shrink-0">
             {% else %}
             <p class="text-secondary mb-0">No profile picture set.</p>
             {% endif %}

--- a/templates/pages/hx-usernav.html
+++ b/templates/pages/hx-usernav.html
@@ -1,7 +1,7 @@
 <div class="dropdown">
     <button class="btn d-flex align-items-center gap-2 p-1">
         {% if user.profile_picture.is_some() %}
-        <img src="{{ config.source_server_url }}/source/{{ user.profile_picture.clone().unwrap() }}/thumbnail.avif"
+        <img src="{{ config.source_server_url }}/source/{{ user.profile_picture.clone().unwrap() }}/thumbnail-small.avif"
              class="user-avatar" />
         {% else %}
         <div class="user-avatar-placeholder">

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -207,7 +207,7 @@
                                 preload="mouseover"
                             >
                                 {% if medium_owner_picture.is_some() %}
-                                <img src="{{ config.source_server_url }}/source/{{ medium_owner_picture.clone().unwrap() }}/thumbnail.avif"
+                                <img src="{{ config.source_server_url }}/source/{{ medium_owner_picture.clone().unwrap() }}/thumbnail-small.avif"
                                      style="width:36px;height:36px;border-radius:50%;object-fit:cover;" />
                                 {% else %}
                                 <div style="width:36px;height:36px;border-radius:50%;background:var(--bs-secondary);display:flex;align-items:center;justify-content:center;">


### PR DESCRIPTION
## Summary
Updated all profile picture image references across templates to use the `thumbnail-small.avif` variant instead of `thumbnail.avif` for improved performance and faster loading times.

## Changes
- **hx-comment-single.html**: Updated user picture thumbnail reference in single comment display
- **hx-comments.html**: Updated user picture thumbnail reference in comments list
- **hx-settings-profile-picture.html**: Updated current profile picture preview in settings
- **hx-usernav.html**: Updated user profile picture in navigation dropdown
- **medium.html**: Updated medium owner picture thumbnail in medium detail view

## Details
All changes consistently replace the image source path from `/thumbnail.avif` to `/thumbnail-small.avif` across five template files. This optimization reduces the file size of profile picture thumbnails displayed throughout the application while maintaining visual quality for these small avatar-sized images.

https://claude.ai/code/session_01UKpBcbvgsjo1nU3LUZbDDL