### PR TITLE
Move media type badges to thumbnail overlay

### DIFF
--- a/templates/pages/hx-listitems.html
+++ b/templates/pages/hx-listitems.html
@@ -4,21 +4,37 @@
         <table>
             <tr>
                 <td class="d-flex justify-content-center">
-                    <img src="{{ config.source_server_url }}/source/{{ item.id }}/thumbnail.avif" width="176" height="99" class="mx-2 rounded">
+                    <div
+                        class="thumbnail-container"
+                        style="position: relative; width: 176px; height: 99px"
+                    >
+                        <img src="{{ config.source_server_url }}/source/{{ item.id }}/thumbnail.avif" width="176" height="99" class="rounded">
+                        <div class="search-card-type-badge">
+                            {% if item.type == "video" %}
+                            <i class="fa-solid fa-video"></i>
+                            {% else if item.type == "audio" %}
+                            <i class="fa-solid fa-music"></i>
+                            {% else if item.type == "picture" %}
+                            <i class="fa-solid fa-image"></i>
+                            {% else if item.type == "document_pdf" %}
+                            <i class="fa-solid fa-file-pdf"></i>
+                            {% else if item.type == "document_writer" %}
+                            <i class="fa-solid fa-file-word"></i>
+                            {% else if item.type == "document_spreadsheet" %}
+                            <i class="fa-solid fa-file-excel"></i>
+                            {% else if item.type == "document_presentation" %}
+                            <i class="fa-solid fa-file-powerpoint"></i>
+                            {% else %}
+                            <i class="fa-solid fa-file"></i>
+                            {% endif %}
+                        </div>
+                    </div>
                 </td>
             </tr>
             <tr>
                 <td class="text-center">
                     <b class="text-white font-weight-bold">{{ item.name }}</b>
-                    <p class="text-secondary">{{ item.views }} views
-                        {% if item.type == "video" %}
-                        <i class="fa-solid fa-video fa-sm ms-1"></i>
-                        {% else if item.type == "audio" %}
-                        <i class="fa-solid fa-music fa-sm ms-1"></i>
-                        {% else if item.type == "picture" %}
-                        <i class="fa-solid fa-image fa-sm ms-1"></i>
-                        {% endif %}
-                    </p>
+                    <p class="text-secondary">{{ item.views }} views</p>
                 </td>
             </tr>
         </table>

--- a/templates/pages/hx-studio.html
+++ b/templates/pages/hx-studio.html
@@ -8,12 +8,36 @@
         <table>
             <tr>
                 <td class="d-flex justify-content-center">
-                    <img
-                        src="{{ config.source_server_url }}/source/{{ medium.id }}/thumbnail.avif"
-                        width="176"
-                        height="99"
-                        class="mx-2 rounded"
-                    />
+                    <div
+                        class="thumbnail-container"
+                        style="position: relative; width: 176px; height: 99px"
+                    >
+                        <img
+                            src="{{ config.source_server_url }}/source/{{ medium.id }}/thumbnail.avif"
+                            width="176"
+                            height="99"
+                            class="rounded"
+                        />
+                        <div class="search-card-type-badge">
+                            {% if medium.type == "video" %}
+                            <i class="fa-solid fa-video"></i>
+                            {% else if medium.type == "audio" %}
+                            <i class="fa-solid fa-music"></i>
+                            {% else if medium.type == "picture" %}
+                            <i class="fa-solid fa-image"></i>
+                            {% else if medium.type == "document_pdf" %}
+                            <i class="fa-solid fa-file-pdf"></i>
+                            {% else if medium.type == "document_writer" %}
+                            <i class="fa-solid fa-file-word"></i>
+                            {% else if medium.type == "document_spreadsheet" %}
+                            <i class="fa-solid fa-file-excel"></i>
+                            {% else if medium.type == "document_presentation" %}
+                            <i class="fa-solid fa-file-powerpoint"></i>
+                            {% else %}
+                            <i class="fa-solid fa-file"></i>
+                            {% endif %}
+                        </div>
+                    </div>
                 </td>
                 <td></td>
             </tr>
@@ -21,13 +45,7 @@
                 <td class="text-center">
                     <b class="text-white font-weight-bold medium-name">{{ medium.name }}</b>
                     <p class="text-secondary">
-                        {{ medium.views }} views {% if medium.type == "video" %}
-                        <i class="fa-solid fa-video fa-sm ms-1"></i>
-                        {% else if medium.type == "audio" %}
-                        <i class="fa-solid fa-music fa-sm ms-1"></i>
-                        {% else if medium.type == "picture" %}
-                        <i class="fa-solid fa-image fa-sm ms-1"></i>
-                        {% endif %}
+                        {{ medium.views }} views
                     </p>
                     <span class="text-secondary m-0" style="font-size: 0.8em;">
                         <i class="fa-solid fa-pen-to-square fa-sm"></i> Edit


### PR DESCRIPTION
## Summary
Refactored media type indicators to display as overlaid badges on thumbnails instead of inline icons in the views text. This improves visual hierarchy and provides better context for media type identification.

## Key Changes
- **Thumbnail restructuring**: Wrapped thumbnail images in a positioned container (`thumbnail-container`) to enable badge overlay positioning
- **Badge implementation**: Added `search-card-type-badge` div overlaid on thumbnails with comprehensive media type icon support (video, audio, picture, PDF, Word, Excel, PowerPoint, and generic file)
- **Simplified metadata display**: Removed inline media type icons from the views text, leaving only the view count
- **Consistent styling**: Applied changes across both `hx-studio.html` and `hx-listitems.html` templates for uniform appearance
- **Extended type coverage**: Added support for document types (PDF, Writer, Spreadsheet, Presentation) in addition to existing media types

## Implementation Details
- Used relative positioning on the container with fixed dimensions (176px × 99px) to properly position the badge overlay
- Removed `mx-2` margin class from images as spacing is now handled by the container
- Maintained all existing image attributes (src, width, height, rounded corners)
- Badge styling is delegated to the `search-card-type-badge` CSS class for centralized styling management

https://claude.ai/code/session_011BiNAxfom6j6auoCnc2sCp