### PR TITLE
Fix video deletion redirect to use HX-Redirect header

### DIFF
--- a/src/studio.rs
+++ b/src/studio.rs
@@ -409,12 +409,12 @@ async fn hx_delete_video(
         .await;
 
     if delete_result.is_err() {
-        return ([("Redirect", "/studio")], "");
+        return ([("HX-Redirect", "/studio")], "<meta http-equiv=\"refresh\" content=\"0;url=/studio\"><script>window.location.replace('/studio');</script>");
     }
 
     // Delete the source directory
     let source_path = format!("source/{}", mediumid);
     let _ = fs::remove_dir_all(&source_path).await;
 
-    ([("Redirect", "/studio")], "")
+    ([("HX-Redirect", "/studio")], "<meta http-equiv=\"refresh\" content=\"0;url=/studio\"><script>window.location.replace('/studio');</script>")
 }


### PR DESCRIPTION
## Summary
Updated the `hx_delete_video` endpoint to use the correct HTMX redirect header (`HX-Redirect`) instead of the non-standard `Redirect` header, and added fallback redirect mechanisms in the response body for better compatibility.

## Key Changes
- Changed response header from `"Redirect"` to `"HX-Redirect"` to properly signal HTMX to perform client-side navigation
- Added HTML meta refresh tag and JavaScript fallback in the response body to ensure redirect works even if the header is not processed
- Applied changes to both error case (line 412) and success case (line 420)

## Implementation Details
The response body now includes:
- `<meta http-equiv="refresh">` tag for standard HTML-based redirect
- `window.location.replace()` JavaScript call as a secondary fallback mechanism

This ensures the redirect to `/studio` works reliably across different client configurations and HTMX versions.

https://claude.ai/code/session_017EYwPgua68Z7W8DivgkkZz