### PR TITLE
Refactor navbar layout to use CSS Grid for centered search

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16412,10 +16412,11 @@ body.sidebar-collapsed .sidebarbackground {
     flex-direction: column;
 }
 
+/* Desktop: 3-column grid keeps search always centered regardless of page title width */
 .navbar-top-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
-    flex-wrap: nowrap;
 }
 
 .navbar-instance-name {
@@ -16426,15 +16427,24 @@ body.sidebar-collapsed .sidebarbackground {
     display: none;
 }
 
-/* Desktop: search centered at 25vw */
+/* Override Bootstrap me-auto — grid handles spacing */
+.navbar-page-title {
+    margin-right: 0 !important;
+}
+
+/* Desktop: search centered in its auto-width column */
 .navbar-search-form {
     width: 35vw;
-    margin: 0 auto;
     position: relative;
 }
 
 .navbar-search-form .input-group {
     width: 100%;
+}
+
+/* Right-align user nav section in its grid cell */
+.navbar-top-row > div:last-child {
+    justify-self: end;
 }
 
 /* Mobile layout */
@@ -16444,7 +16454,9 @@ body.sidebar-collapsed .sidebarbackground {
         flex-direction: column;
     }
 
+    /* Revert to flex for mobile so order/wrap work */
     .navbar-top-row {
+        display: flex;
         flex-wrap: wrap;
     }
 
@@ -16459,20 +16471,16 @@ body.sidebar-collapsed .sidebarbackground {
         display: none !important;
     }
 
-    /* User button */
-    .navbar-top-row > div[hx-get="/hx/usernav"] {
-        order: 2;
-        margin-left: auto !important;
-    }
-
-    /* Sidebar toggle */
+    /* Sidebar toggle + usernav wrapper: push to right, after instance name */
     .navbar-top-row > div:last-child {
-        order: 3;
+        order: 2;
+        justify-self: auto;
+        margin-left: auto;
     }
 
     /* Search form takes full width on its own line */
     .navbar-search-form {
-        order: 4;
+        order: 3;
         width: 100%;
         flex-basis: 100%;
     }

--- a/templates/pages/component-navbar.html
+++ b/templates/pages/component-navbar.html
@@ -1,5 +1,5 @@
 <div class="navbar-container mx-1">
-    <div class="navbar-top-row d-flex align-items-center">
+    <div class="navbar-top-row align-items-center">
         <a href="/" class="navbar-instance-name text-white text-decoration-none ms-3 me-auto fs-3 fw-semibold">
             {{ config.instancename }}
         </a>
@@ -29,7 +29,7 @@
         </form>
         <div class="my-1 mx-4 text-white d-flex align-items-center gap-3">
             <div hx-get="/hx/usernav" hx-trigger="load" style="width:120px;height:40px;" class="mx-3" preload="always">
-                <a href="/login" preload="mouseover"><button class="btn text-white"><i class="fa-solid fa-user mx-2"></i>Log in</button></a>
+                <a href="/login" preload="mouseover" style="visibility:hidden;"><button class="btn text-white"><i class="fa-solid fa-user mx-2"></i>Log in</button></a>
             </div>
             <button class="btn btn-primary d-flex align-items-center" onclick="toggleSidebar()"><i class="fa-solid fa-bars fa-xl mx-2"></i></button>
         </div>


### PR DESCRIPTION
## Summary
Refactored the navbar top row layout from flexbox to CSS Grid to ensure the search bar remains centered regardless of page title width variations. This provides a more robust and maintainable solution for the navbar's three-column layout.

## Key Changes
- **Layout System**: Changed `.navbar-top-row` from `display: flex` to `display: grid` with `grid-template-columns: 1fr auto 1fr` for desktop, creating three equal-width columns with the search bar naturally centered in the middle column
- **Search Bar Centering**: Removed `margin: 0 auto` from `.navbar-search-form` as the grid layout now handles centering automatically
- **Title Spacing**: Added override rule to remove Bootstrap's `me-auto` margin from `.navbar-page-title` since grid handles spacing
- **Right Alignment**: Added `justify-self: end` rule for the last grid cell (user nav section) to right-align it within its column
- **Mobile Responsiveness**: Reverted `.navbar-top-row` back to `display: flex` in the mobile media query to preserve flex-based ordering and wrapping behavior
- **Mobile Order Simplification**: Consolidated mobile selectors and simplified order values (user nav + sidebar toggle now share one rule with `order: 2`, search form uses `order: 3`)
- **Login Button**: Added `visibility:hidden` style to the fallback login button to hide it while the HTMX-loaded user nav loads

## Implementation Details
The grid approach provides several advantages:
- The search bar stays centered in its column regardless of title width
- No need for margin-based centering tricks
- Cleaner separation of concerns between desktop (grid) and mobile (flex) layouts
- The three-column structure (title | search | user nav) is now explicit in the CSS

https://claude.ai/code/session_012hKno76385k41EjWSq74e6