### PR TITLE
Add favicon to component dependencies page

### DIFF
--- a/templates/pages/component-dependencies.html
+++ b/templates/pages/component-dependencies.html
@@ -18,7 +18,7 @@ html.sidebar-will-collapse .sidebarbackground { transform: translateX(-100%); }
 <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/fontawesome.min.css" rel="stylesheet">
 <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/solid.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@600&family=Nunito:wght@600&family=Source+Serif+4:opsz,wght@8..60,600&display=swap" rel="stylesheet">
-<link rel="icon" type="image/svg+xml" href="/source/favicon.svg" />
+<link rel="icon" type="image/svg+xml" href="{{ config.source_server_url }}/source/favicon.svg" />
 <link rel="stylesheet" href="/style.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <script src="https://cdn.jsdelivr.net/npm/htmx.org/dist/htmx.min.js"></script>

--- a/templates/pages/component-dependencies.html
+++ b/templates/pages/component-dependencies.html
@@ -18,6 +18,7 @@ html.sidebar-will-collapse .sidebarbackground { transform: translateX(-100%); }
 <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/fontawesome.min.css" rel="stylesheet">
 <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free/css/solid.min.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@600&family=Nunito:wght@600&family=Source+Serif+4:opsz,wght@8..60,600&display=swap" rel="stylesheet">
+<link rel="icon" type="image/svg+xml" href="/source/favicon.svg" />
 <link rel="stylesheet" href="/style.css" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <script src="https://cdn.jsdelivr.net/npm/htmx.org/dist/htmx.min.js"></script>


### PR DESCRIPTION
## Summary
Added a favicon link to the component-dependencies.html template to display a custom icon in the browser tab.

## Changes
- Added SVG favicon reference (`/source/favicon.svg`) to the document head
- Favicon is positioned after the Google Fonts import and before the main stylesheet

## Details
The favicon link uses the SVG format and is placed in the appropriate location within the HTML head section, following standard favicon implementation practices.

https://claude.ai/code/session_017tawmhKgB33dbSN8XGEoDK