### PR TITLE
Replace manual HX-Redirect headers with Axum Redirect response

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use axum::{
     extract::{DefaultBodyLimit, Form, Multipart, Path},
     http::header::HeaderMap,
     http::header::{ACCEPT_LANGUAGE, COOKIE, HOST, USER_AGENT},
-    response::{Html, IntoResponse, Response},
+    response::{Html, IntoResponse, Redirect, Response},
     routing::get,
     routing::post,
     Extension, Json, Router,

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -374,7 +374,7 @@ async fn hx_delete_video(
 ) -> impl IntoResponse {
     let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
-        return ([("HX-Redirect", "/login")], "");
+        return Redirect::to("/login");
     }
     let user_info = user_info.unwrap();
 
@@ -385,11 +385,11 @@ async fn hx_delete_video(
     match media_owner {
         Ok(record) => {
             if record.owner != user_info.login {
-                return ([("HX-Redirect", "/studio")], "");
+                return Redirect::to("/studio");
             }
         }
         Err(_) => {
-            return ([("HX-Redirect", "/studio")], "");
+            return Redirect::to("/studio");
         }
     }
 
@@ -409,12 +409,12 @@ async fn hx_delete_video(
         .await;
 
     if delete_result.is_err() {
-        return ([("HX-Redirect", "/studio")], "<meta http-equiv=\"refresh\" content=\"0;url=/studio\"><script>window.location.replace('/studio');</script>");
+        return Redirect::to("/studio");
     }
 
     // Delete the source directory
     let source_path = format!("source/{}", mediumid);
     let _ = fs::remove_dir_all(&source_path).await;
 
-    ([("HX-Redirect", "/studio")], "<meta http-equiv=\"refresh\" content=\"0;url=/studio\"><script>window.location.replace('/studio');</script>")
+    Redirect::to("/studio")
 }


### PR DESCRIPTION
## Summary
Refactored the `hx_delete_video` endpoint to use Axum's built-in `Redirect` response type instead of manually constructing HX-Redirect headers. This improves code clarity and leverages the framework's proper redirect handling.

## Key Changes
- Replaced manual `[("HX-Redirect", "/login")]` header tuples with `Redirect::to("/login")`
- Replaced manual `[("HX-Redirect", "/studio")]` header tuples with `Redirect::to("/studio")`
- Removed unnecessary HTML meta refresh and JavaScript fallback code that was paired with manual redirect headers
- Added `Redirect` to the imports in `main.rs`

## Implementation Details
The changes simplify redirect logic by using Axum's `Redirect` response type, which properly handles HTTP redirects. This eliminates the need for:
- Manual header construction
- Redundant HTML meta refresh tags
- JavaScript fallback code for client-side redirects

The endpoint now returns consistent, framework-idiomatic redirect responses across all code paths (login required, unauthorized access, deletion errors, and successful deletion).

https://claude.ai/code/session_01BZTD2XQctsNDYxfAZHCoDb