### PR TITLE
Add view transitions for smooth thumbnail-to-player morphing

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -136,3 +136,15 @@ function fitMediumTitle() {
 }
 
 window.addEventListener('resize', fitMediumTitle);
+
+// Cross-document view transition: mark the clicked thumbnail so it morphs into the player.
+// Uses event delegation so it works for HTMX-loaded cards too.
+document.addEventListener('click', function (e) {
+    const link = e.target.closest('a[href^="/m/"]');
+    if (!link || e.defaultPrevented) return;
+    // hx-mediumcard cards use .thumbnail-container; search cards use .search-card-thumbnail
+    const thumb = link.querySelector('.thumbnail-container, .search-card-thumbnail');
+    if (thumb) {
+        thumb.style.viewTransitionName = 'medium-player';
+    }
+});

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16527,6 +16527,45 @@ body.sidebar-collapsed .sidebarbackground {
     align-self: center;
 }
 
+/* Cross-document view transitions: thumbnail card → media player */
+@view-transition {
+    navigation: auto;
+}
+
+/* The group handles geometry (position + size) morphing automatically.
+   We just tune the duration and easing. */
+::view-transition-group(medium-player) {
+    animation-duration: 380ms;
+    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Fade out the thumbnail snapshot */
+::view-transition-old(medium-player) {
+    animation: 200ms ease-out both fade-out-vt;
+}
+
+/* Fade in the player snapshot, slightly delayed so the morph leads */
+::view-transition-new(medium-player) {
+    animation: 220ms 160ms ease-in both fade-in-vt;
+}
+
+@keyframes fade-out-vt {
+    to { opacity: 0; }
+}
+
+@keyframes fade-in-vt {
+    from { opacity: 0; }
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+    ::view-transition-group(medium-player),
+    ::view-transition-old(medium-player),
+    ::view-transition-new(medium-player) {
+        animation-duration: 0.01ms !important;
+    }
+}
+
 /* User display name - always single line, max 150px, responsive font size */
 .user-name-clamp {
     max-width: 150px;

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -77,7 +77,7 @@
         <div class="row maincontentrow g-3 py-2 ps-2 w-100">
             <div class="col-12 col-sm-12 col-md-12 col-lg-9">
                 <div class="card py-3 px-3 text-white" style="min-height: 85vh">
-                    <div class="d-flex justify-content-center player-container">
+                    <div class="d-flex justify-content-center player-container" style="view-transition-name: medium-player">
                         {% if medium_type == "video" %}
                         <media-player
                             view-type="video"


### PR DESCRIPTION
## Summary
Implements CSS view transitions to create a smooth morphing animation when navigating from a thumbnail card to the media player page. The thumbnail animates into the player container with automatic geometry morphing and coordinated fade animations.

## Key Changes
- **CSS animations**: Added `@view-transition` rule with auto navigation and custom animations for the `medium-player` transition group
  - Geometry morphing handled automatically with 380ms duration and cubic-bezier easing
  - Thumbnail fades out (200ms) while player fades in (220ms with 160ms delay) for a layered effect
  - Respects `prefers-reduced-motion` by disabling animations for accessibility
- **JavaScript event delegation**: Added click handler to mark clicked thumbnails with `view-transition-name: medium-player`
  - Works with both static cards (`.thumbnail-container`) and HTMX-loaded cards (`.search-card-thumbnail`)
  - Uses event delegation to handle dynamically loaded content
- **HTML template**: Applied `view-transition-name: medium-player` inline style to the player container to match the transition group name

## Implementation Details
The transition uses a staggered fade approach where the old thumbnail snapshot fades out quickly while the new player snapshot fades in with a delay, allowing the automatic geometry morphing to be the visual focus of the animation. The implementation gracefully handles both pre-rendered and dynamically loaded thumbnail cards through CSS class selectors.

https://claude.ai/code/session_01TpmpeHWwTjCPBHZ6WJPG9x