### PR TITLE
Improve Tom-select dropdown styling and behavior

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -416,8 +416,8 @@ document.body.addEventListener('htmx:afterSettle', function (e) {
     if (!visEl || !groupEl || typeof TomSelect === 'undefined') return;
     if (visEl.tomselect) visEl.tomselect.destroy();
     if (groupEl.tomselect) groupEl.tomselect.destroy();
-    var visTomSelect = new TomSelect(visEl, { create: false });
-    var groupTomSelect = new TomSelect(groupEl, { create: false, allowEmptyOption: true });
+    var visTomSelect = new TomSelect(visEl, { create: false, onFocus: function() { this.clear(true); } });
+    var groupTomSelect = new TomSelect(groupEl, { create: false, allowEmptyOption: true, onFocus: function() { this.clear(true); } });
     groupTomSelect.wrapper.style.width = 'auto';
     function updateGroupVisibility() {
         groupTomSelect.wrapper.style.display = visTomSelect.getValue() === 'restricted' ? '' : 'none';
@@ -483,8 +483,8 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!visSelect || !groupSelect || !publishForm) return;
     // Avoid re-init if already done (studio-edit also uses these ids)
     if (visSelect.tomselect) return;
-    var visTomSelect = new TomSelect('#medium_visibility', { create: false });
-    var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true });
+    var visTomSelect = new TomSelect('#medium_visibility', { create: false, onFocus: function() { this.clear(true); } });
+    var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true, onFocus: function() { this.clear(true); } });
     var noGroupsHint = document.getElementById('no-groups-hint');
 
     function updateGroupVisibility() {
@@ -546,8 +546,8 @@ document.addEventListener('DOMContentLoaded', function () {
     var editPageConfig = document.getElementById('edit-page-config');
     var currentGroup = editPageConfig ? editPageConfig.dataset.restrictedGroup : '';
 
-    var visTomSelect = new TomSelect('#medium_visibility', { create: false });
-    var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true });
+    var visTomSelect = new TomSelect('#medium_visibility', { create: false, onFocus: function() { this.clear(true); } });
+    var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true, onFocus: function() { this.clear(true); } });
     var noGroupsHint = document.getElementById('no-groups-hint');
 
     if (currentGroup) {

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16605,3 +16605,16 @@ media-poster img {
 /* Medium select card (moved from hx-settings-channel-picture.html and hx-settings-profile-picture.html) */
 .medium-select-card { border: 2px solid transparent; }
 input[type="radio"]:checked + .medium-select-card { border-color: var(--bs-primary); }
+
+/* Tom-select: hover/active color for dropdown options */
+.ts-dropdown .option:hover,
+.ts-dropdown .option.active {
+    background-color: var(--bs-primary) !important;
+    color: #fff !important;
+}
+
+/* Tom-select: dropdown floats above content to avoid layout shift */
+.ts-dropdown {
+    position: absolute !important;
+    z-index: 9999 !important;
+}


### PR DESCRIPTION
## Summary
Enhanced the Tom-select dropdown component with improved visual styling and user interaction behavior across the application.

## Key Changes
- **Dropdown Styling**: Added CSS rules to style Tom-select dropdown options with primary color background and white text on hover/active states
- **Dropdown Positioning**: Set Tom-select dropdowns to use absolute positioning with high z-index to prevent layout shifts and ensure dropdowns float above other content
- **Focus Behavior**: Added `onFocus` callback to all Tom-select instances that clears the current selection when the dropdown is focused, providing a cleaner interaction pattern for users
  - Applied to visibility selectors in 3 locations: HTMX afterSettle handler, DOMContentLoaded publish form initialization, and page edit initialization
  - Applied to restricted group selectors in the same 3 locations

## Implementation Details
- Used CSS `!important` flags for Tom-select overrides to ensure styles take precedence over library defaults
- The `clear(true)` method is called on focus to reset selections, improving UX for dropdown interactions
- Changes maintain backward compatibility with existing Tom-select configurations (create: false, allowEmptyOption: true)

https://claude.ai/code/session_01SLHo9L17VqguUkfwzn3dLB