### PR TITLE
Improve medium player transition timing and expand link support

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -143,8 +143,10 @@ window.addEventListener('resize', fitMediumTitle);
 
 // Cross-document view transition: mark the clicked thumbnail so it morphs into the player.
 // Uses event delegation so it works for HTMX-loaded cards too.
+// Handles /m/ links (regular medium pages), /l/ links (list item pages),
+// and sidebar/recommended items which also use .thumbnail-container.
 document.addEventListener('click', function (e) {
-    const link = e.target.closest('a[href^="/m/"]');
+    const link = e.target.closest('a[href^="/m/"], a[href^="/l/"]');
     if (!link || e.defaultPrevented) return;
     // hx-mediumcard cards use .thumbnail-container; search cards use .search-card-thumbnail
     const thumb = link.querySelector('.thumbnail-container, .search-card-thumbnail');

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16534,18 +16534,18 @@ body.sidebar-collapsed .sidebarbackground {
 /* The group handles geometry (position + size) morphing automatically.
    We just tune the duration and easing. */
 ::view-transition-group(medium-player) {
-    animation-duration: 380ms;
+    animation-duration: 560ms;
     animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Fade out the thumbnail snapshot */
 ::view-transition-old(medium-player) {
-    animation: 200ms ease-out both fade-out-vt;
+    animation: 280ms ease-out both fade-out-vt;
 }
 
 /* Fade in the player snapshot, slightly delayed so the morph leads */
 ::view-transition-new(medium-player) {
-    animation: 220ms 160ms ease-in both fade-in-vt;
+    animation: 300ms 240ms ease-in both fade-in-vt;
 }
 
 @keyframes fade-out-vt {


### PR DESCRIPTION
This PR enhances the medium player view transition experience and extends link handling to support additional page types.

**Key changes:**

- **Increased view transition durations** for smoother animations:
  - Medium player group animation: 380ms → 560ms
  - Thumbnail fade-out: 200ms → 280ms
  - Player fade-in: 220ms → 300ms with increased delay (160ms → 240ms)
  
- **Extended link selector** to handle list item pages:
  - Now captures both `/m/` (regular medium pages) and `/l/` (list item pages) links
  - Maintains support for sidebar and recommended items via `.thumbnail-container`

- **Improved code documentation** with clarifying comments about supported link types and event delegation

These changes provide a more polished transition animation while ensuring the view transition effect works consistently across all medium-related page types.

https://claude.ai/code/session_01XYFGQF5frs5CWh85WRWrus