### PR TITLE
Auto-convert SRT/ASS subtitles to WebVTT format

### DIFF
--- a/src/medium.rs
+++ b/src/medium.rs
@@ -5,8 +5,7 @@ struct CaptionEntry {
 
 fn parse_caption_entry(entry: &str) -> CaptionEntry {
     let entry = entry.trim();
-    if entry.ends_with(".srt") || entry.ends_with(".ass") || entry.ends_with(".vtt") {
-        let dot_pos = entry.rfind('.').unwrap();
+    if let Some(dot_pos) = entry.rfind('.') {
         CaptionEntry {
             label: entry[..dot_pos].to_string(),
             filename: entry.to_string(),

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -1,3 +1,101 @@
+fn convert_srt_to_vtt(content: &[u8]) -> Vec<u8> {
+    let text = String::from_utf8_lossy(content);
+    let text = text.replace('\r', "");
+    let mut result = String::from("WEBVTT\n\n");
+    for line in text.lines() {
+        if line.contains(" --> ") {
+            result.push_str(&line.replace(',', "."));
+        } else {
+            result.push_str(line);
+        }
+        result.push('\n');
+    }
+    result.into_bytes()
+}
+
+fn ass_time_to_vtt(time: &str) -> String {
+    // ASS time: h:mm:ss.cs (centiseconds) → VTT: hh:mm:ss.mmm
+    let parts: Vec<&str> = time.splitn(3, ':').collect();
+    if parts.len() != 3 {
+        return "00:00:00.000".to_string();
+    }
+    let h: u32 = parts[0].parse().unwrap_or(0);
+    let m: u32 = parts[1].parse().unwrap_or(0);
+    let sec_parts: Vec<&str> = parts[2].splitn(2, '.').collect();
+    let s: u32 = sec_parts[0].parse().unwrap_or(0);
+    let cs: u32 = sec_parts.get(1).and_then(|v| v.parse().ok()).unwrap_or(0);
+    format!("{:02}:{:02}:{:02}.{:03}", h, m, s, cs * 10)
+}
+
+fn strip_ass_tags(text: &str) -> String {
+    let mut result = String::new();
+    let mut in_tag = false;
+    for ch in text.chars() {
+        match ch {
+            '{' => in_tag = true,
+            '}' => in_tag = false,
+            _ if !in_tag => result.push(ch),
+            _ => {}
+        }
+    }
+    result.replace("\\N", "\n").replace("\\n", "\n").replace("\\h", "\u{00A0}")
+}
+
+fn convert_ass_to_vtt(content: &[u8]) -> Vec<u8> {
+    let text = String::from_utf8_lossy(content);
+    let text = text.replace('\r', "");
+    let mut result = String::from("WEBVTT\n\n");
+
+    let mut in_events = false;
+    let mut start_idx: usize = 1;
+    let mut end_idx: usize = 2;
+    let mut text_idx: usize = 9;
+    let mut cue_number: u32 = 1;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[Events]" {
+            in_events = true;
+            continue;
+        }
+        if trimmed.starts_with('[') {
+            in_events = false;
+            continue;
+        }
+        if !in_events {
+            continue;
+        }
+        if trimmed.starts_with("Format:") {
+            let fields: Vec<&str> = trimmed["Format:".len()..].split(',').map(str::trim).collect();
+            for (i, &f) in fields.iter().enumerate() {
+                match f {
+                    "Start" => start_idx = i,
+                    "End" => end_idx = i,
+                    "Text" => text_idx = i,
+                    _ => {}
+                }
+            }
+            continue;
+        }
+        if trimmed.starts_with("Dialogue:") {
+            let rest = &trimmed["Dialogue:".len()..];
+            let parts: Vec<&str> = rest.splitn(text_idx + 1, ',').collect();
+            if parts.len() <= text_idx {
+                continue;
+            }
+            let start_vtt = ass_time_to_vtt(parts[start_idx].trim());
+            let end_vtt = ass_time_to_vtt(parts[end_idx].trim());
+            let clean_text = strip_ass_tags(parts[text_idx].trim());
+            if clean_text.trim().is_empty() {
+                continue;
+            }
+            result.push_str(&format!("{}\n{} --> {}\n{}\n\n", cue_number, start_vtt, end_vtt, clean_text));
+            cue_number += 1;
+        }
+    }
+    result.into_bytes()
+}
+
 async fn studio_subtitles_get(
     Extension(pool): Extension<PgPool>,
     Extension(redis): Extension<RedisConn>,
@@ -32,16 +130,12 @@ async fn studio_subtitles_get(
             .filter(|l| !l.trim().is_empty())
             .map(|l| {
                 let entry = l.trim();
-                let (label, format) = if entry.ends_with(".srt") {
-                    (entry.trim_end_matches(".srt").to_string(), "srt".to_string())
-                } else if entry.ends_with(".ass") {
-                    (entry.trim_end_matches(".ass").to_string(), "ass".to_string())
-                } else if entry.ends_with(".vtt") {
-                    (entry.trim_end_matches(".vtt").to_string(), "vtt".to_string())
+                let label = if let Some(dot) = entry.rfind('.') {
+                    entry[..dot].to_string()
                 } else {
-                    (entry.to_string(), "vtt".to_string())
+                    entry.to_string()
                 };
-                serde_json::json!({ "label": label, "format": format })
+                serde_json::json!({ "label": label })
             })
             .collect();
         Json(serde_json::Value::Array(labels))
@@ -92,7 +186,7 @@ async fn studio_subtitles_add(
 
     let mut label = String::new();
     let mut file_content = Vec::new();
-    let mut file_ext = String::from("vtt");
+    let mut input_ext = String::from("vtt");
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let name = field.name().unwrap_or("").to_string();
@@ -103,11 +197,9 @@ async fn studio_subtitles_add(
             "file" => {
                 let filename = field.file_name().unwrap_or("").to_lowercase();
                 if filename.ends_with(".srt") {
-                    file_ext = "srt".to_string();
+                    input_ext = "srt".to_string();
                 } else if filename.ends_with(".ass") {
-                    file_ext = "ass".to_string();
-                } else {
-                    file_ext = "vtt".to_string();
+                    input_ext = "ass".to_string();
                 }
                 file_content = field.bytes().await.unwrap_or_default().to_vec();
             }
@@ -123,7 +215,6 @@ async fn studio_subtitles_add(
             .unwrap();
     }
 
-    // Sanitize label: only allow alphanumeric, hyphens, underscores, spaces
     let sanitized_label: String = label
         .chars()
         .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_' || *c == ' ')
@@ -145,13 +236,19 @@ async fn studio_subtitles_add(
             .unwrap();
     }
 
+    // Convert to WebVTT if needed
+    let vtt_content = match input_ext.as_str() {
+        "srt" => convert_srt_to_vtt(&file_content),
+        "ass" => convert_ass_to_vtt(&file_content),
+        _ => file_content,
+    };
+
     let captions_dir = format!("source/{}/captions", mediumid);
     let _ = tokio::fs::create_dir_all(&captions_dir).await;
 
-    let new_list_entry = format!("{}.{}", sanitized_label, file_ext);
+    let new_list_entry = format!("{}.vtt", sanitized_label);
     let subtitle_path = format!("{}/{}", captions_dir, new_list_entry);
 
-    // Update list.txt - read existing entries
     let list_path = format!("{}/list.txt", captions_dir);
     let mut existing: Vec<String> = if std::path::Path::new(&list_path).exists() {
         read_lines_to_vec(&list_path)
@@ -163,38 +260,25 @@ async fn studio_subtitles_add(
         Vec::new()
     };
 
-    // Remove any existing entries for this label (old format or different extension)
+    // Remove any existing entries for this label
     let label_prefix = format!("{}.", sanitized_label);
     let old_entries: Vec<String> = existing
         .iter()
-        .filter(|e| {
-            let e_str = e.as_str();
-            e_str == sanitized_label || e_str.starts_with(&label_prefix)
-        })
+        .filter(|e| e.as_str() == sanitized_label || e.starts_with(&label_prefix))
         .cloned()
         .collect();
 
     for old_entry in &old_entries {
-        let old_filename = if old_entry.contains('.') {
-            old_entry.clone()
-        } else {
-            format!("{}.vtt", old_entry)
-        };
-        let old_file_path = format!("{}/{}", captions_dir, old_filename);
-        // Delete old file only if it differs from the new one
+        let old_file_path = format!("{}/{}", captions_dir, old_entry);
         if old_file_path != subtitle_path {
             let _ = tokio::fs::remove_file(&old_file_path).await;
         }
     }
 
-    existing.retain(|e| {
-        let e_str = e.as_str();
-        e_str != sanitized_label && !e_str.starts_with(&label_prefix)
-    });
+    existing.retain(|e| e.as_str() != sanitized_label && !e.starts_with(&label_prefix));
     existing.push(new_list_entry);
 
-    // Write the subtitle file
-    if let Err(_) = tokio::fs::write(&subtitle_path, &file_content).await {
+    if let Err(_) = tokio::fs::write(&subtitle_path, &vtt_content).await {
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -429,30 +513,17 @@ async fn studio_subtitles_delete(
             .map(|l| l.trim().to_string())
             .collect();
 
-        // Find the matching entry by label (with or without extension)
         let label_prefix = format!("{}.", label);
         let matched_entry = existing
             .iter()
-            .find(|e| {
-                let e_str = e.as_str();
-                e_str == label || e_str.starts_with(&label_prefix)
-            })
+            .find(|e| e.as_str() == label || e.starts_with(&label_prefix))
             .cloned();
 
         if let Some(entry) = matched_entry {
-            // Determine the actual filename to delete
-            let filename = if entry.contains('.') {
-                entry.clone()
-            } else {
-                format!("{}.vtt", entry)
-            };
-            let file_path = format!("{}/{}", captions_dir, filename);
+            let file_path = format!("{}/{}", captions_dir, entry);
             let _ = tokio::fs::remove_file(&file_path).await;
 
-            let remaining: Vec<String> = existing
-                .into_iter()
-                .filter(|e| e != &entry)
-                .collect();
+            let remaining: Vec<String> = existing.into_iter().filter(|e| e != &entry).collect();
 
             if remaining.is_empty() {
                 let _ = tokio::fs::remove_file(&list_path).await;

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -1,99 +1,29 @@
-fn convert_srt_to_vtt(content: &[u8]) -> Vec<u8> {
-    let text = String::from_utf8_lossy(content);
-    let text = text.replace('\r', "");
-    let mut result = String::from("WEBVTT\n\n");
-    for line in text.lines() {
-        if line.contains(" --> ") {
-            result.push_str(&line.replace(',', "."));
-        } else {
-            result.push_str(line);
-        }
-        result.push('\n');
+async fn convert_subtitle_to_vtt(content: Vec<u8>, input_format: &str) -> Option<Vec<u8>> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut child = tokio::process::Command::new("ffmpeg")
+        .arg("-hide_banner")
+        .arg("-loglevel").arg("error")
+        .arg("-f").arg(input_format)
+        .arg("-i").arg("pipe:0")
+        .arg("-f").arg("webvtt")
+        .arg("pipe:1")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(&content).await.ok()?;
     }
-    result.into_bytes()
-}
 
-fn ass_time_to_vtt(time: &str) -> String {
-    // ASS time: h:mm:ss.cs (centiseconds) → VTT: hh:mm:ss.mmm
-    let parts: Vec<&str> = time.splitn(3, ':').collect();
-    if parts.len() != 3 {
-        return "00:00:00.000".to_string();
+    let output = child.wait_with_output().await.ok()?;
+    if output.status.success() {
+        Some(output.stdout)
+    } else {
+        None
     }
-    let h: u32 = parts[0].parse().unwrap_or(0);
-    let m: u32 = parts[1].parse().unwrap_or(0);
-    let sec_parts: Vec<&str> = parts[2].splitn(2, '.').collect();
-    let s: u32 = sec_parts[0].parse().unwrap_or(0);
-    let cs: u32 = sec_parts.get(1).and_then(|v| v.parse().ok()).unwrap_or(0);
-    format!("{:02}:{:02}:{:02}.{:03}", h, m, s, cs * 10)
-}
-
-fn strip_ass_tags(text: &str) -> String {
-    let mut result = String::new();
-    let mut in_tag = false;
-    for ch in text.chars() {
-        match ch {
-            '{' => in_tag = true,
-            '}' => in_tag = false,
-            _ if !in_tag => result.push(ch),
-            _ => {}
-        }
-    }
-    result.replace("\\N", "\n").replace("\\n", "\n").replace("\\h", "\u{00A0}")
-}
-
-fn convert_ass_to_vtt(content: &[u8]) -> Vec<u8> {
-    let text = String::from_utf8_lossy(content);
-    let text = text.replace('\r', "");
-    let mut result = String::from("WEBVTT\n\n");
-
-    let mut in_events = false;
-    let mut start_idx: usize = 1;
-    let mut end_idx: usize = 2;
-    let mut text_idx: usize = 9;
-    let mut cue_number: u32 = 1;
-
-    for line in text.lines() {
-        let trimmed = line.trim();
-        if trimmed == "[Events]" {
-            in_events = true;
-            continue;
-        }
-        if trimmed.starts_with('[') {
-            in_events = false;
-            continue;
-        }
-        if !in_events {
-            continue;
-        }
-        if trimmed.starts_with("Format:") {
-            let fields: Vec<&str> = trimmed["Format:".len()..].split(',').map(str::trim).collect();
-            for (i, &f) in fields.iter().enumerate() {
-                match f {
-                    "Start" => start_idx = i,
-                    "End" => end_idx = i,
-                    "Text" => text_idx = i,
-                    _ => {}
-                }
-            }
-            continue;
-        }
-        if trimmed.starts_with("Dialogue:") {
-            let rest = &trimmed["Dialogue:".len()..];
-            let parts: Vec<&str> = rest.splitn(text_idx + 1, ',').collect();
-            if parts.len() <= text_idx {
-                continue;
-            }
-            let start_vtt = ass_time_to_vtt(parts[start_idx].trim());
-            let end_vtt = ass_time_to_vtt(parts[end_idx].trim());
-            let clean_text = strip_ass_tags(parts[text_idx].trim());
-            if clean_text.trim().is_empty() {
-                continue;
-            }
-            result.push_str(&format!("{}\n{} --> {}\n{}\n\n", cue_number, start_vtt, end_vtt, clean_text));
-            cue_number += 1;
-        }
-    }
-    result.into_bytes()
 }
 
 async fn studio_subtitles_get(
@@ -186,7 +116,7 @@ async fn studio_subtitles_add(
 
     let mut label = String::new();
     let mut file_content = Vec::new();
-    let mut input_ext = String::from("vtt");
+    let mut input_format = "webvtt";
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let name = field.name().unwrap_or("").to_string();
@@ -197,9 +127,9 @@ async fn studio_subtitles_add(
             "file" => {
                 let filename = field.file_name().unwrap_or("").to_lowercase();
                 if filename.ends_with(".srt") {
-                    input_ext = "srt".to_string();
+                    input_format = "srt";
                 } else if filename.ends_with(".ass") {
-                    input_ext = "ass".to_string();
+                    input_format = "ass";
                 }
                 file_content = field.bytes().await.unwrap_or_default().to_vec();
             }
@@ -236,11 +166,20 @@ async fn studio_subtitles_add(
             .unwrap();
     }
 
-    // Convert to WebVTT if needed
-    let vtt_content = match input_ext.as_str() {
-        "srt" => convert_srt_to_vtt(&file_content),
-        "ass" => convert_ass_to_vtt(&file_content),
-        _ => file_content,
+    // Convert to WebVTT via ffmpeg if needed
+    let vtt_content = if input_format != "webvtt" {
+        match convert_subtitle_to_vtt(file_content, input_format).await {
+            Some(converted) => converted,
+            None => {
+                return Response::builder()
+                    .status(StatusCode::UNPROCESSABLE_ENTITY)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"subtitle conversion failed\"}"))
+                    .unwrap();
+            }
+        }
+    } else {
+        file_content
     };
 
     let captions_dir = format!("source/{}/captions", mediumid);

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -356,7 +356,7 @@
                     <hr />
                     <div class="mx-3">
                         <h5><i class="fa-solid fa-closed-captioning"></i>&nbsp;Subtitles</h5>
-                        <p class="text-secondary">Upload subtitle files (.vtt, .srt, .ass). Each subtitle track needs a label (e.g. "English", "Spanish").</p>
+                        <p class="text-secondary">Upload subtitle files (.vtt, .srt, .ass) — SRT and ASS files are automatically converted to WebVTT. Each subtitle track needs a label (e.g. "English", "Spanish").</p>
                         <div id="subtitles-editor">
                             <div class="table-responsive">
                                 <table class="table table-hover text-white" id="subtitles-table">
@@ -379,7 +379,7 @@
                                         <input type="text" class="form-control form-control-sm" id="subtitle-label-input" />
                                     </div>
                                     <div class="col-sm-5">
-                                        <label for="subtitle-file-input" class="form-label">Subtitle File (.vtt, .srt, .ass)</label>
+                                        <label for="subtitle-file-input" class="form-label">Subtitle File (.vtt, .srt, .ass → WebVTT)</label>
                                         <input type="file" class="form-control form-control-sm" id="subtitle-file-input" accept=".vtt,.srt,.ass" />
                                     </div>
                                     <div class="col-sm-3">
@@ -435,7 +435,7 @@
                                 var tr = document.createElement('tr');
 
                                 var tdLabel = document.createElement('td');
-                                tdLabel.textContent = sub.label + ' (' + (sub.format || 'vtt') + ')';
+                                tdLabel.textContent = sub.label;
                                 tr.appendChild(tdLabel);
 
                                 var tdActions = document.createElement('td');
@@ -515,11 +515,8 @@
                             .then(function(data) {
                                 btn.disabled = false;
                                 if (data.ok) {
-                                    var fileEl = fileInput.files[0];
-                                    var ext = fileEl ? fileEl.name.split('.').pop().toLowerCase() : 'vtt';
-                                    if (ext !== 'srt' && ext !== 'ass') ext = 'vtt';
                                     subtitles = subtitles.filter(function(s) { return s.label !== label; });
-                                    subtitles.push({ label: label, format: ext });
+                                    subtitles.push({ label: label });
                                     renderSubtitles();
                                     labelInput.value = '';
                                     fileInput.value = '';


### PR DESCRIPTION
## Summary
This PR implements automatic conversion of SRT and ASS subtitle formats to WebVTT using ffmpeg, simplifying subtitle handling and ensuring consistent format storage.

## Key Changes

- **Added subtitle format conversion**: New `convert_subtitle_to_vtt()` async function that uses ffmpeg to convert SRT and ASS files to WebVTT format via stdin/stdout pipes
- **Unified subtitle storage**: All subtitle files are now stored as `.vtt` files regardless of input format, eliminating the need to track multiple format types
- **Simplified subtitle metadata**: Removed `format` field from subtitle entries in both backend and frontend, as all stored files are now WebVTT
- **Updated subtitle listing**: Modified `studio_subtitles_get()` to extract only the label from filenames (everything before the extension)
- **Improved file handling**: Cleaned up subtitle add/delete logic by removing format-specific branching and file extension handling
- **Updated UI**: Modified studio editor to indicate that SRT/ASS files are automatically converted to WebVTT, and removed format display from subtitle track listings

## Implementation Details

- Conversion happens server-side during subtitle upload via ffmpeg with error handling
- If conversion fails, returns a 422 Unprocessable Entity error
- Old subtitle files with different extensions are properly cleaned up when replacing a subtitle track
- All subtitle operations now assume `.vtt` extension, reducing complexity in path handling and file management

https://claude.ai/code/session_01RoxDhEDNHqsp3BEj6HCMDV