### PR TITLE
Fix event listeners to use document instead of document.body

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    document.body.addEventListener('htmx:afterSwap', (event) => {
+    document.addEventListener('htmx:afterSwap', (event) => {
         const target = event.detail.target;
         if (target.id === 'suggestions' && document.getElementById('searchInput') === document.activeElement) {
             target.style.display = target.children.length > 0 ? '' : 'none';
@@ -183,7 +183,7 @@ function beginupload() {
 }
 
 // --- hx-studio-upload.html: upload progress (studio tab) ---
-document.body.addEventListener('htmx:afterSettle', function (e) {
+document.addEventListener('htmx:afterSettle', function (e) {
     var uploadForm = document.getElementById('upload-form');
     if (!uploadForm) return;
     if (uploadForm._studioUploadBound) return;
@@ -399,7 +399,7 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 // HTMX: init comment deltas after comments-list is swapped
-document.body.addEventListener('htmx:afterSettle', function (e) {
+document.addEventListener('htmx:afterSettle', function (e) {
     var target = e.detail.target;
     if (target && target.id === 'comments-list') {
         initCommentDeltas(target);
@@ -412,7 +412,7 @@ document.body.addEventListener('htmx:afterSettle', function (e) {
 });
 
 // --- hx-listmodal.html: TomSelect for list visibility ---
-document.body.addEventListener('htmx:afterSettle', function (e) {
+document.addEventListener('htmx:afterSettle', function (e) {
     var visEl = document.getElementById('listmodal-visibility');
     var groupEl = document.getElementById('listmodal-group-select');
     if (!visEl || !groupEl || typeof TomSelect === 'undefined') return;
@@ -429,7 +429,7 @@ document.body.addEventListener('htmx:afterSettle', function (e) {
 });
 
 // --- hx-settings-diagnostics.html: codec support detection ---
-document.body.addEventListener('htmx:afterSettle', function (e) {
+document.addEventListener('htmx:afterSettle', function (e) {
     if (!document.getElementById('codec-av1')) return;
     function checkMediaSource(codec) {
         if (typeof MediaSource === 'undefined') return false;


### PR DESCRIPTION
## Summary
Changed multiple HTMX event listeners from `document.body` to `document` for better event handling consistency and reliability.

## Key Changes
- Updated 6 `htmx:afterSwap` and `htmx:afterSettle` event listeners to attach to `document` instead of `document.body`
- Affected listeners:
  - Search suggestions display handler
  - Studio upload progress handler
  - Comment deltas initialization handler
  - List modal TomSelect initialization handler
  - Codec support detection handler

## Implementation Details
This change ensures that HTMX events are captured at the document level rather than the body element level. This is more reliable as it:
- Guarantees event listeners are attached before any body manipulation occurs
- Follows HTMX best practices for event delegation
- Prevents potential issues where body-level listeners might miss events during DOM swaps

https://claude.ai/code/session_018FrHC8akSC47pizWqtt6La