### PR TITLE
Preserve Vidstack player CSS variables in PurgeCSS config

### DIFF
--- a/purgecss.config.cjs
+++ b/purgecss.config.cjs
@@ -28,6 +28,9 @@ module.exports = {
       /^htmx-/,
     ],
     greedy: [],
+    // Vidstack player CSS variables (player loaded from CDN, so vars aren't
+    // seen in scanned content but are consumed by vidstack's own stylesheets)
+    variables: [/^--video-/, /^--media-/],
   },
   // Preserve CSS variables and keyframes
   variables: true,


### PR DESCRIPTION
## Summary
Updated the PurgeCSS configuration to preserve Vidstack player CSS variables that are consumed by the player's stylesheets but not detected during content scanning.

## Changes
- Added `variables` safelist configuration to preserve CSS custom properties matching `--video-*` and `--media-*` patterns
- These variables are used by Vidstack's own stylesheets when the player is loaded from CDN, making them invisible to PurgeCSS's content scanner

## Details
The Vidstack player is loaded from a CDN, so its CSS variable usage isn't present in the scanned source files. Without this safelist, PurgeCSS would incorrectly purge these variables, breaking the player's styling. This configuration ensures they are preserved during the CSS purging process.

https://claude.ai/code/session_01B3ndqakDZMEq5RTrykuEUr