### PR TITLE
Add automatic TTF to WOFF2 conversion for subtitle fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ argon2 = "0.5"
 rand = "0.10"
 meilisearch-sdk = "0.32"
 redis = { version = "1.0", features = ["tokio-comp", "connection-manager"] }
+ttf2woff2 = { version = "0.10", default-features = false }

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -307,8 +307,11 @@ async fn studio_subtitle_font_upload(
     }
 
     let mut font_content = Vec::new();
+    let mut is_ttf = false;
     while let Ok(Some(field)) = multipart.next_field().await {
         if field.name().unwrap_or("") == "file" {
+            let filename = field.file_name().unwrap_or("").to_lowercase();
+            is_ttf = filename.ends_with(".ttf");
             font_content = field.bytes().await.unwrap_or_default().to_vec();
             break;
         }
@@ -322,11 +325,26 @@ async fn studio_subtitle_font_upload(
             .unwrap();
     }
 
+    let woff2_content = if is_ttf {
+        match ttf2woff2::encode(&font_content, ttf2woff2::BrotliQuality::default()) {
+            Ok(converted) => converted,
+            Err(_) => {
+                return Response::builder()
+                    .status(StatusCode::UNPROCESSABLE_ENTITY)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"TTF to WOFF2 conversion failed\"}"))
+                    .unwrap();
+            }
+        }
+    } else {
+        font_content
+    };
+
     let captions_dir = format!("source/{}/captions", mediumid);
     let _ = tokio::fs::create_dir_all(&captions_dir).await;
 
     let font_path = format!("{}/font.woff2", captions_dir);
-    if let Err(_) = tokio::fs::write(&font_path, &font_content).await {
+    if let Err(_) = tokio::fs::write(&font_path, &woff2_content).await {
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header(axum::http::header::CONTENT_TYPE, "application/json")

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -393,7 +393,7 @@
                         </div>
                         <div class="border rounded p-3 mt-3">
                             <h6><i class="fa-solid fa-font"></i>&nbsp;Custom Subtitle Font</h6>
-                            <p class="text-secondary mb-2">Upload a custom font (.woff2) to override the subtitle font for this media.</p>
+                            <p class="text-secondary mb-2">Upload a custom font (.woff2 or .ttf — TTF files are automatically converted to WOFF2) to override the subtitle font for this media.</p>
                             <div id="font-current" class="mb-2" style="display:none">
                                 <span class="text-success"><i class="fa-solid fa-check"></i> Custom font active</span>
                                 <button type="button" class="btn btn-sm btn-outline-danger ms-2" id="delete-font-btn">
@@ -402,8 +402,8 @@
                             </div>
                             <div id="font-upload-row" class="row g-2 align-items-end">
                                 <div class="col-sm-7">
-                                    <label for="font-file-input" class="form-label">WOFF2 Font File</label>
-                                    <input type="file" class="form-control form-control-sm" id="font-file-input" accept=".woff2" />
+                                    <label for="font-file-input" class="form-label">Font File (.woff2 or .ttf)</label>
+                                    <input type="file" class="form-control form-control-sm" id="font-file-input" accept=".woff2,.ttf" />
                                 </div>
                                 <div class="col-sm-3">
                                     <button type="button" class="btn btn-primary btn-sm w-100" id="upload-font-btn">
@@ -554,7 +554,7 @@
                             var btn = this;
                             var fileInput = document.getElementById('font-file-input');
                             if (!fileInput.files || fileInput.files.length === 0) {
-                                showFontStatus('danger', 'Please select a .woff2 file.');
+                                showFontStatus('danger', 'Please select a .woff2 or .ttf file.');
                                 return;
                             }
                             var formData = new FormData();


### PR DESCRIPTION
## Summary
This PR extends the subtitle font upload functionality to accept both WOFF2 and TTF font formats, automatically converting TTF files to WOFF2 format on the server side.

## Key Changes
- **Backend font conversion**: Added TTF to WOFF2 conversion logic in the `studio_subtitle_font_upload` handler
  - Detects uploaded file format by checking the filename extension
  - Uses the `ttf2woff2` crate to convert TTF files to WOFF2 format
  - Returns a 422 Unprocessable Entity error if conversion fails
  - Stores the converted (or original) font as WOFF2 in the captions directory

- **Frontend updates**: Updated the studio editor UI to reflect the new capability
  - Modified file input to accept both `.woff2` and `.ttf` file extensions
  - Updated form labels and help text to indicate both formats are supported
  - Updated validation error messages to mention both supported formats

## Implementation Details
- The conversion only occurs if the uploaded file has a `.ttf` extension; WOFF2 files are stored as-is
- TTF to WOFF2 conversion uses default Brotli compression quality settings
- Conversion errors are handled gracefully with appropriate HTTP error responses
- The final stored font file is always in WOFF2 format regardless of input format

https://claude.ai/code/session_01BqRTd2f2AriiCp9EehyWgF