### PR TITLE
Add custom thumbnail upload and management for media

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,9 @@ async fn main() {
         .route("/studio/edit/{mediumid}/subtitles/font.json", get(studio_subtitle_font_get))
         .route("/studio/edit/{mediumid}/subtitles/font", post(studio_subtitle_font_upload))
         .route("/studio/edit/{mediumid}/subtitles/font/delete", post(studio_subtitle_font_delete))
+        .route("/studio/edit/{mediumid}/thumbnail.json", get(studio_thumbnail_get))
+        .route("/studio/edit/{mediumid}/thumbnail", post(studio_thumbnail_upload))
+        .route("/studio/edit/{mediumid}/thumbnail/delete", post(studio_thumbnail_delete))
         .route("/hx/studio/delete/{mediumid}", get(hx_delete_video))
         .route("/studio/lists", get(studio_lists))
         .route("/hx/studio/lists", get(hx_studio_lists))
@@ -229,6 +232,7 @@ include!("channel.rs");
 include!("studio.rs");
 include!("chapters.rs");
 include!("subtitles.rs");
+include!("thumbnail.rs");
 include!("upload.rs");
 include!("concept.rs");
 include!("serve.rs");

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -1,0 +1,219 @@
+async fn studio_thumbnail_get(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> Json<serde_json::Value> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Json(serde_json::json!({ "exists": false }));
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) if record.owner == user_info.login => {}
+        _ => return Json(serde_json::json!({ "exists": false })),
+    }
+
+    let avif_path = format!("source/{}/thumbnail.avif", mediumid);
+    let exists = std::path::Path::new(&avif_path).exists();
+    Json(serde_json::json!({ "exists": exists }))
+}
+
+async fn studio_thumbnail_upload(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    mut multipart: Multipart,
+) -> Response<Body> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"not logged in\"}"))
+            .unwrap();
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"not authorized\"}"))
+                    .unwrap();
+            }
+        }
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"media not found\"}"))
+                .unwrap();
+        }
+    }
+
+    let mut image_content = Vec::new();
+    while let Ok(Some(field)) = multipart.next_field().await {
+        if field.name().unwrap_or("") == "file" {
+            image_content = field.bytes().await.unwrap_or_default().to_vec();
+            break;
+        }
+    }
+
+    if image_content.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"image file is required\"}"))
+            .unwrap();
+    }
+
+    // Write the uploaded image to a temp file
+    let temp_path = format!("source/{}/.tmp_thumbnail_upload", mediumid);
+    let source_dir = format!("source/{}", mediumid);
+    let _ = tokio::fs::create_dir_all(&source_dir).await;
+
+    if let Err(_) = tokio::fs::write(&temp_path, &image_content).await {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"failed to write temp file\"}"))
+            .unwrap();
+    }
+
+    // Convert to thumbnail.jpg and thumbnail.avif at 1280x720 using FFmpeg
+    let avif_path = format!("source/{}/thumbnail.avif", mediumid);
+    let jpg_path = format!("source/{}/thumbnail.jpg", mediumid);
+    let temp_path_clone = temp_path.clone();
+    let avif_path_clone = avif_path.clone();
+    let jpg_path_clone = jpg_path.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        use std::process::Command;
+
+        let jpg_status = Command::new("ffmpeg")
+            .args([
+                "-nostdin", "-y",
+                "-i", &temp_path_clone,
+                "-vf", "scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:black",
+                "-frames:v", "1",
+                "-update", "1",
+                &jpg_path_clone,
+            ])
+            .status();
+
+        let avif_status = Command::new("ffmpeg")
+            .args([
+                "-nostdin", "-y",
+                "-i", &temp_path_clone,
+                "-vf", "scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:black,format=yuv420p",
+                "-frames:v", "1",
+                "-c:v", "libsvtav1",
+                "-svtav1-params", "avif=1",
+                "-crf", "28",
+                "-update", "1",
+                &avif_path_clone,
+            ])
+            .status();
+
+        let jpg_ok = jpg_status.map(|s| s.success()).unwrap_or(false);
+        let avif_ok = avif_status.map(|s| s.success()).unwrap_or(false);
+        (jpg_ok, avif_ok)
+    }).await;
+
+    // Clean up temp file
+    let _ = tokio::fs::remove_file(&temp_path).await;
+
+    match result {
+        Ok((true, true)) => {
+            Response::builder()
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"ok\":true}"))
+                .unwrap()
+        }
+        Ok((jpg_ok, avif_ok)) => {
+            let msg = if !jpg_ok && !avif_ok {
+                "{\"error\":\"thumbnail conversion failed\"}"
+            } else if !jpg_ok {
+                "{\"error\":\"JPG thumbnail conversion failed\"}"
+            } else {
+                "{\"error\":\"AVIF thumbnail conversion failed\"}"
+            };
+            // Clean up any partial output
+            if !jpg_ok { let _ = tokio::fs::remove_file(&jpg_path).await; }
+            if !avif_ok { let _ = tokio::fs::remove_file(&avif_path).await; }
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(msg))
+                .unwrap()
+        }
+        Err(_) => {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"processing error\"}"))
+                .unwrap()
+        }
+    }
+}
+
+async fn studio_thumbnail_delete(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> Response<Body> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"not logged in\"}"))
+            .unwrap();
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"not authorized\"}"))
+                    .unwrap();
+            }
+        }
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"media not found\"}"))
+                .unwrap();
+        }
+    }
+
+    let _ = tokio::fs::remove_file(format!("source/{}/thumbnail.avif", mediumid)).await;
+    let _ = tokio::fs::remove_file(format!("source/{}/thumbnail.jpg", mediumid)).await;
+
+    Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{\"ok\":true}"))
+        .unwrap()
+}

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -602,6 +602,101 @@
                     {% endif %}
                     <hr />
                     <div class="mx-3">
+                        <h5><i class="fa-solid fa-image"></i>&nbsp;Thumbnail</h5>
+                        <p class="text-secondary">Upload a custom thumbnail image. It will be converted to AVIF and JPEG at 1280×720 resolution.</p>
+                        <div id="thumbnail-current" class="mb-2" style="display:none">
+                            <img id="thumbnail-preview" src="/source/{{ medium.id }}/thumbnail.jpg" alt="Current thumbnail" style="max-width:320px;max-height:180px;border-radius:4px;border:1px solid #444;" class="mb-2 d-block" />
+                            <button type="button" class="btn btn-sm btn-outline-danger" id="delete-thumbnail-btn">
+                                <i class="fa-solid fa-trash"></i>&nbsp;Remove Custom Thumbnail
+                            </button>
+                        </div>
+                        <div id="thumbnail-upload-row" class="row g-2 align-items-end">
+                            <div class="col-sm-7">
+                                <label for="thumbnail-file-input" class="form-label">Image File (PNG, JPG, WEBP, etc.)</label>
+                                <input type="file" class="form-control form-control-sm" id="thumbnail-file-input" accept="image/*" />
+                            </div>
+                            <div class="col-sm-3">
+                                <button type="button" class="btn btn-primary btn-sm w-100" id="upload-thumbnail-btn">
+                                    <i class="fa-solid fa-upload"></i>&nbsp;Upload
+                                </button>
+                            </div>
+                        </div>
+                        <div id="thumbnail-status" class="mt-2"></div>
+                    </div>
+                    <script>
+                    document.addEventListener('DOMContentLoaded', function() {
+                        function showThumbStatus(type, msg) {
+                            var el = document.getElementById('thumbnail-status');
+                            var icon = type === 'success' ? 'fa-check' : 'fa-xmark';
+                            el.innerHTML = '<span class="text-' + type + '"><i class="fa-solid ' + icon + '"></i> ' + msg + '</span>';
+                            setTimeout(function() { el.innerHTML = ''; }, 4000);
+                        }
+
+                        function setThumbnailExists(exists) {
+                            document.getElementById('thumbnail-current').style.display = exists ? '' : 'none';
+                            if (exists) {
+                                var img = document.getElementById('thumbnail-preview');
+                                img.src = '/source/{{ medium.id }}/thumbnail.jpg?' + Date.now();
+                            }
+                        }
+
+                        fetch('/studio/edit/{{ medium.id }}/thumbnail.json')
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) { setThumbnailExists(data.exists); })
+                            .catch(function() {});
+
+                        document.getElementById('upload-thumbnail-btn').addEventListener('click', function() {
+                            var btn = this;
+                            var fileInput = document.getElementById('thumbnail-file-input');
+                            if (!fileInput.files || fileInput.files.length === 0) {
+                                showThumbStatus('danger', 'Please select an image file.');
+                                return;
+                            }
+                            var formData = new FormData();
+                            formData.append('file', fileInput.files[0]);
+                            btn.disabled = true;
+                            showThumbStatus('warning', 'Uploading and converting...');
+                            fetch('/studio/edit/{{ medium.id }}/thumbnail', {
+                                method: 'POST',
+                                body: formData
+                            })
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                btn.disabled = false;
+                                if (data.ok) {
+                                    fileInput.value = '';
+                                    setThumbnailExists(true);
+                                    showThumbStatus('success', 'Thumbnail uploaded and converted!');
+                                } else {
+                                    showThumbStatus('danger', data.error || 'Upload failed.');
+                                }
+                            })
+                            .catch(function() {
+                                btn.disabled = false;
+                                showThumbStatus('danger', 'Upload failed.');
+                            });
+                        });
+
+                        document.getElementById('delete-thumbnail-btn').addEventListener('click', function() {
+                            if (!confirm('Remove custom thumbnail?')) return;
+                            fetch('/studio/edit/{{ medium.id }}/thumbnail/delete', {
+                                method: 'POST'
+                            })
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                if (data.ok) {
+                                    setThumbnailExists(false);
+                                    showThumbStatus('success', 'Thumbnail removed.');
+                                } else {
+                                    showThumbStatus('danger', data.error || 'Failed to remove thumbnail.');
+                                }
+                            })
+                            .catch(function() { showThumbStatus('danger', 'Failed to remove thumbnail.'); });
+                        });
+                    });
+                    </script>
+                    <hr />
+                    <div class="mx-3">
                         <h5 class="text-danger">Danger Zone</h5>
                         <button
                             class="btn btn-outline-danger mt-2"


### PR DESCRIPTION
## Summary
This PR adds functionality for users to upload, manage, and delete custom thumbnails for their media in the studio editor. Uploaded images are automatically converted to both JPEG and AVIF formats at 1280×720 resolution using FFmpeg.

## Key Changes
- **New thumbnail module** (`src/thumbnail.rs`): Implements three async handlers:
  - `studio_thumbnail_get`: Check if a custom thumbnail exists for a medium
  - `studio_thumbnail_upload`: Handle multipart file uploads, validate ownership, and convert images to JPEG and AVIF formats using FFmpeg
  - `studio_thumbnail_delete`: Remove custom thumbnail files with ownership validation

- **Route registration** (`src/main.rs`): Added three new routes:
  - `GET /studio/edit/{mediumid}/thumbnail.json` - Check thumbnail existence
  - `POST /studio/edit/{mediumid}/thumbnail` - Upload and convert thumbnail
  - `POST /studio/edit/{mediumid}/thumbnail/delete` - Delete thumbnail

- **UI implementation** (`templates/pages/studio-edit.html`): Added thumbnail management section with:
  - File input for selecting image files
  - Upload button with progress feedback
  - Preview of current thumbnail (if exists)
  - Delete button with confirmation
  - Real-time status messages for user feedback

## Implementation Details
- All endpoints include authentication checks and ownership validation to ensure users can only manage thumbnails for their own media
- Uploaded images are temporarily stored, then processed with FFmpeg to create both JPG and AVIF versions
- FFmpeg scaling uses `force_original_aspect_ratio=decrease` with padding to maintain aspect ratio at 1280×720
- AVIF encoding uses libsvtav1 codec with CRF 28 for quality/size balance
- Temporary files are cleaned up after processing
- Partial conversions are handled gracefully with appropriate error messages
- Frontend provides real-time feedback with status messages that auto-dismiss after 4 seconds

https://claude.ai/code/session_01UaXbMv4JKRR3T8iLwfvb98