### PR TITLE
Add list context to medium list navigation links

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -338,6 +338,7 @@ async fn hx_list_sidebar(
     let template = HXMediumListTemplate {
         media,
         current_medium_id: mediumid,
+        list_id: listid,
         config
     };
     Html(minifi_html(template.render().unwrap()))

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -243,6 +243,7 @@ struct HXMediumCardTemplate {
 #[template(path = "pages/hx-mediumlist.html", escape = "none")]
 struct HXMediumListTemplate {
     current_medium_id: String,
+    list_id: String,
     media: Vec<Medium>,
     config: Config,
 }

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -33,6 +33,7 @@ async fn hx_recommended(
 
     let template = HXMediumListTemplate {
         current_medium_id: mediumid,
+        list_id: String::new(),
         media,
         config
     };

--- a/src/search.rs
+++ b/src/search.rs
@@ -143,6 +143,7 @@ async fn hx_search_suggestions(
 
             let template = HXMediumListTemplate {
                 current_medium_id: String::new(),
+                list_id: String::new(),
                 media,
                 config
             };

--- a/templates/pages/hx-mediumlist.html
+++ b/templates/pages/hx-mediumlist.html
@@ -1,6 +1,6 @@
 {% for item in media %}
 <a
-    href="/m/{{ item.id }}"
+    href="{% if list_id.is_empty() %}/m/{{ item.id }}{% else %}/l/{{ list_id }}/{{ item.id }}{% endif %}"
     class="text-decoration-none rounded {% if item.id == current_medium_id %}list-sidebar-active{% endif %}"
     preload="mouseover"
     title="{{ item.name }}"


### PR DESCRIPTION
## Summary
This PR adds support for navigating within a list context when viewing media items. Previously, all medium links pointed directly to the medium detail page. Now, when viewing a medium within a list, the navigation links preserve the list context.

## Key Changes
- **Template Update**: Modified `hx-mediumlist.html` to conditionally generate links based on whether a list context exists
  - If no list context: links point to `/m/{item.id}` (direct medium view)
  - If list context exists: links point to `/l/{list_id}/{item.id}` (medium within list view)

- **Data Structure**: Added `list_id` field to `HXMediumListTemplate` struct to pass list context to the template

- **Route Handlers**: Updated all route handlers that use `HXMediumListTemplate` to provide the `list_id`:
  - `hx_list_sidebar` in `lists.rs`: passes the actual `listid` from the route
  - `hx_recommended` in `reccomendations.rs`: passes empty string (no list context)
  - `hx_search_suggestions` in `search.rs`: passes empty string (no list context)

## Implementation Details
The solution uses a conditional check in the template (`list_id.is_empty()`) to determine which URL pattern to generate. This allows the same template to work in both list and non-list contexts without requiring separate templates or complex conditional logic in the route handlers.

https://claude.ai/code/session_01VX4fFdEqhnWVRzGw8VA3Cj