### PR TITLE
Add subtitle translation feature with AI processing queue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ async fn main() {
         .route("/studio/edit/{mediumid}/chapters", post(studio_chapters_save))
         .route("/studio/edit/{mediumid}/subtitles.json", get(studio_subtitles_get))
         .route("/studio/edit/{mediumid}/subtitles/add", post(studio_subtitles_add))
+        .route("/studio/edit/{mediumid}/subtitles/translate", post(studio_subtitles_translate))
         .route("/studio/edit/{mediumid}/subtitles/delete", post(studio_subtitles_delete))
         .route("/studio/edit/{mediumid}/subtitles/font.json", get(studio_subtitle_font_get))
         .route("/studio/edit/{mediumid}/subtitles/font", post(studio_subtitle_font_upload))

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -407,6 +407,123 @@ async fn studio_subtitle_font_delete(
 }
 
 #[derive(Deserialize)]
+struct SubtitleTranslateForm {
+    source_label: String,
+    target_language: String,
+}
+
+async fn studio_subtitles_translate(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    Json(form): Json<SubtitleTranslateForm>,
+) -> Response<Body> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"not logged in\"}"))
+            .unwrap();
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{\"error\":\"not authorized\"}"))
+                    .unwrap();
+            }
+        }
+        Err(_) => {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{\"error\":\"media not found\"}"))
+                .unwrap();
+        }
+    }
+
+    let source_label = form.source_label.trim().to_string();
+    let target_language = form.target_language.trim().to_lowercase();
+
+    if source_label.is_empty() || target_language.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"source_label and target_language are required\"}"))
+            .unwrap();
+    }
+
+    // Verify source subtitle exists
+    let source_path = format!("source/{}/captions/{}.vtt", mediumid, source_label);
+    if !std::path::Path::new(&source_path).exists() {
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"source subtitle not found\"}"))
+            .unwrap();
+    }
+
+    // Create a concept entry of type vtt_translate with metadata as the upload file
+    let concept_id = format!("{}_translate", mediumid);
+
+    let metadata = serde_json::json!({
+        "medium_id": mediumid,
+        "source_label": source_label,
+        "target_language": target_language,
+    });
+
+    let upload_dir = std::path::Path::new("upload");
+    let _ = tokio::fs::create_dir_all(upload_dir).await;
+    let meta_path = upload_dir.join(&concept_id);
+
+    if let Err(_) = tokio::fs::write(&meta_path, metadata.to_string()).await {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"failed to create translation job\"}"))
+            .unwrap();
+    }
+
+    // Upsert concept: delete any existing translation job for this medium, then insert new one
+    let _ = sqlx::query("DELETE FROM media_concepts WHERE id=$1;")
+        .bind(&concept_id)
+        .execute(&pool)
+        .await;
+
+    let concept_name = format!("Translate {} -> {}", source_label, target_language);
+    if let Err(_) = sqlx::query(
+        "INSERT INTO media_concepts (id, name, owner, type, processed) VALUES ($1, $2, $3, 'vtt_translate', false)"
+    )
+    .bind(&concept_id)
+    .bind(&concept_name)
+    .bind(&user_info.login)
+    .execute(&pool)
+    .await
+    {
+        return Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"failed to queue translation job\"}"))
+            .unwrap();
+    }
+
+    Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{\"ok\":true}"))
+        .unwrap()
+}
+
+#[derive(Deserialize)]
 struct SubtitleDeleteForm {
     label: String,
 }

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -396,6 +396,63 @@
                             <div id="subtitles-status" class="mt-2"></div>
                         </div>
                         <div class="border rounded p-3 mt-3">
+                            <h6><i class="fa-solid fa-language"></i>&nbsp;Translate Subtitle</h6>
+                            <p class="text-secondary mb-2">Request an AI translation of an existing subtitle track into another language. The translation will be queued and processed automatically.</p>
+                            <div class="row g-2 align-items-end">
+                                <div class="col-sm-4">
+                                    <label for="translate-source-select" class="form-label">Source Subtitle</label>
+                                    <select class="form-select form-select-sm" id="translate-source-select">
+                                        <option value="">-- Select source --</option>
+                                    </select>
+                                </div>
+                                <div class="col-sm-4">
+                                    <label for="translate-target-select" class="form-label">Target Language</label>
+                                    <select class="form-select form-select-sm" id="translate-target-select">
+                                        <option value="">-- Select language --</option>
+                                        <option value="en">English</option>
+                                        <option value="cs">Czech</option>
+                                        <option value="de">German</option>
+                                        <option value="fr">French</option>
+                                        <option value="es">Spanish</option>
+                                        <option value="it">Italian</option>
+                                        <option value="pt">Portuguese</option>
+                                        <option value="ru">Russian</option>
+                                        <option value="ja">Japanese</option>
+                                        <option value="ko">Korean</option>
+                                        <option value="zh">Chinese</option>
+                                        <option value="ar">Arabic</option>
+                                        <option value="hi">Hindi</option>
+                                        <option value="pl">Polish</option>
+                                        <option value="nl">Dutch</option>
+                                        <option value="sv">Swedish</option>
+                                        <option value="da">Danish</option>
+                                        <option value="no">Norwegian</option>
+                                        <option value="fi">Finnish</option>
+                                        <option value="hu">Hungarian</option>
+                                        <option value="tr">Turkish</option>
+                                        <option value="el">Greek</option>
+                                        <option value="he">Hebrew</option>
+                                        <option value="th">Thai</option>
+                                        <option value="vi">Vietnamese</option>
+                                        <option value="id">Indonesian</option>
+                                        <option value="uk">Ukrainian</option>
+                                        <option value="ro">Romanian</option>
+                                        <option value="bg">Bulgarian</option>
+                                        <option value="hr">Croatian</option>
+                                        <option value="sk">Slovak</option>
+                                        <option value="sl">Slovenian</option>
+                                        <option value="sr">Serbian</option>
+                                    </select>
+                                </div>
+                                <div class="col-sm-4">
+                                    <button type="button" class="btn btn-primary btn-sm w-100" id="translate-subtitle-btn">
+                                        <i class="fa-solid fa-language"></i>&nbsp;Translate
+                                    </button>
+                                </div>
+                            </div>
+                            <div id="translate-status" class="mt-2"></div>
+                        </div>
+                        <div class="border rounded p-3 mt-3">
                             <h6><i class="fa-solid fa-font"></i>&nbsp;Custom Subtitle Font</h6>
                             <p class="text-secondary mb-2">Upload a custom font (.woff2 or .ttf — TTF files are automatically converted to WOFF2) to override the subtitle font for this media.</p>
                             <div id="font-current" class="mb-2" style="display:none">
@@ -426,6 +483,8 @@
                             var tbody = document.getElementById('subtitles-tbody');
                             var noMsg = document.getElementById('no-subtitles-msg');
                             tbody.innerHTML = '';
+
+                            updateTranslateSourceSelect();
 
                             if (subtitles.length === 0) {
                                 noMsg.style.display = '';
@@ -490,6 +549,64 @@
                                 renderSubtitles();
                             })
                             .catch(function(err) { console.error('Failed to load subtitles:', err); });
+
+                        function updateTranslateSourceSelect() {
+                            var sel = document.getElementById('translate-source-select');
+                            var currentVal = sel.value;
+                            sel.innerHTML = '<option value="">-- Select source --</option>';
+                            subtitles.forEach(function(sub) {
+                                var opt = document.createElement('option');
+                                opt.value = sub.label;
+                                opt.textContent = sub.label;
+                                sel.appendChild(opt);
+                            });
+                            if (currentVal) sel.value = currentVal;
+                        }
+
+                        function showTranslateStatus(type, msg) {
+                            var el = document.getElementById('translate-status');
+                            var icon = type === 'success' ? 'fa-check' : (type === 'warning' ? 'fa-spinner fa-spin' : 'fa-xmark');
+                            el.innerHTML = '<span class="text-' + type + '"><i class="fa-solid ' + icon + '"></i> ' + msg + '</span>';
+                            if (type !== 'warning') {
+                                setTimeout(function() { el.innerHTML = ''; }, 6000);
+                            }
+                        }
+
+                        document.getElementById('translate-subtitle-btn').addEventListener('click', function() {
+                            var btn = this;
+                            var sourceLabel = document.getElementById('translate-source-select').value;
+                            var targetLang = document.getElementById('translate-target-select').value;
+
+                            if (!sourceLabel) {
+                                showTranslateStatus('danger', 'Please select a source subtitle.');
+                                return;
+                            }
+                            if (!targetLang) {
+                                showTranslateStatus('danger', 'Please select a target language.');
+                                return;
+                            }
+
+                            btn.disabled = true;
+                            showTranslateStatus('warning', 'Queueing translation...');
+                            fetch('/studio/edit/{{ medium.id }}/subtitles/translate', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ source_label: sourceLabel, target_language: targetLang })
+                            })
+                            .then(function(r) { return r.json(); })
+                            .then(function(data) {
+                                btn.disabled = false;
+                                if (data.ok) {
+                                    showTranslateStatus('success', 'Translation queued! It will appear in the subtitle list when complete.');
+                                } else {
+                                    showTranslateStatus('danger', data.error || 'Failed to queue translation.');
+                                }
+                            })
+                            .catch(function() {
+                                btn.disabled = false;
+                                showTranslateStatus('danger', 'Failed to queue translation.');
+                            });
+                        });
 
                         document.getElementById('upload-subtitle-btn').addEventListener('click', function() {
                             var btn = this;


### PR DESCRIPTION
## Summary
This PR adds a new subtitle translation feature that allows users to request AI translations of existing subtitle tracks into different languages. The translation requests are queued for asynchronous processing.

## Key Changes
- **Backend API endpoint** (`studio_subtitles_translate`): New POST endpoint that validates user ownership of media, accepts source subtitle label and target language, and queues translation jobs in the database
- **Translation job queueing**: Creates `media_concepts` entries with type `vtt_translate` to track translation requests with metadata (medium ID, source label, target language)
- **Frontend UI**: Added a new "Translate Subtitle" section in the studio editor with:
  - Dropdown to select source subtitle from available tracks
  - Dropdown with 30+ supported target languages
  - Translate button to submit requests
  - Status messages for user feedback
- **Dynamic source selection**: The source subtitle dropdown is automatically populated from the list of available subtitles and updates when subtitles are loaded
- **Route registration**: Added the new `/studio/edit/{mediumid}/subtitles/translate` POST route to the router

## Implementation Details
- Authorization checks ensure only media owners can request translations
- Input validation trims and validates both source label and target language
- Metadata is persisted to the filesystem before database insertion for job tracking
- Existing translation jobs for the same medium are replaced (upsert pattern)
- User-friendly error handling with appropriate HTTP status codes (401, 403, 404, 400, 500)
- Frontend uses fetch API with loading states and auto-clearing success messages

https://claude.ai/code/session_018puZEEj34XMK85KAt3EKtc