### PR TITLE
Add translation status check to prevent concurrent subtitle translations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ async fn main() {
         .route("/studio/edit/{mediumid}/chapters", post(studio_chapters_save))
         .route("/studio/edit/{mediumid}/subtitles.json", get(studio_subtitles_get))
         .route("/studio/edit/{mediumid}/subtitles/add", post(studio_subtitles_add))
+        .route("/studio/edit/{mediumid}/subtitles/translate/status", get(studio_subtitles_translate_status))
         .route("/studio/edit/{mediumid}/subtitles/translate", post(studio_subtitles_translate))
         .route("/studio/edit/{mediumid}/subtitles/delete", post(studio_subtitles_delete))
         .route("/studio/edit/{mediumid}/subtitles/font.json", get(studio_subtitle_font_get))

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -406,6 +406,40 @@ async fn studio_subtitle_font_delete(
         .unwrap()
 }
 
+async fn studio_subtitles_translate_status(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> Json<serde_json::Value> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Json(serde_json::json!({ "in_progress": false }));
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) if record.owner == user_info.login => {}
+        _ => return Json(serde_json::json!({ "in_progress": false })),
+    }
+
+    let concept_id = format!("{}_translate", mediumid);
+    let result = sqlx::query!("SELECT processed FROM media_concepts WHERE id=$1;", concept_id)
+        .fetch_optional(&pool)
+        .await;
+
+    let in_progress = match result {
+        Ok(Some(row)) => !row.processed,
+        _ => false,
+    };
+
+    Json(serde_json::json!({ "in_progress": in_progress }))
+}
+
 #[derive(Deserialize)]
 struct SubtitleTranslateForm {
     source_label: String,

--- a/templates/pages/hx-studio-edit-subtitles.html
+++ b/templates/pages/hx-studio-edit-subtitles.html
@@ -35,10 +35,14 @@
         </div>
         <div id="subtitles-status" class="mt-2"></div>
     </div>
-    <div class="border rounded p-3 mt-3">
+    <div class="border rounded p-3 mt-3" id="translate-section">
         <h6><i class="fa-solid fa-language"></i>&nbsp;Translate Subtitle</h6>
         <p class="text-secondary mb-2">Request an AI translation of an existing subtitle track into another language. The translation will be queued and processed automatically.</p>
-        <div class="row g-2 align-items-end">
+        <div id="translate-locked" style="display:none" class="py-2">
+            <span class="text-warning"><i class="fa-solid fa-hourglass-half fa-bounce"></i>&nbsp;Translation in progress&hellip;</span>
+            <p class="text-secondary mb-0 mt-1" style="font-size:0.875em">Another translation is already queued for this media. Please wait until it finishes before requesting a new one.</p>
+        </div>
+        <div id="translate-inputs-row" class="row g-2 align-items-end">
             <div class="col-sm-4">
                 <label for="translate-source-select" class="form-label">Source Subtitle</label>
                 <select class="form-select form-select-sm" id="translate-source-select">
@@ -212,6 +216,17 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    function setTranslateLocked(locked) {
+        document.getElementById('translate-locked').style.display = locked ? '' : 'none';
+        document.getElementById('translate-inputs-row').style.display = locked ? 'none' : '';
+        document.getElementById('translate-subtitle-btn').disabled = locked;
+    }
+
+    fetch('/studio/edit/{{ medium_id }}/subtitles/translate/status')
+        .then(function(r) { return r.json(); })
+        .then(function(data) { setTranslateLocked(data.in_progress); })
+        .catch(function() {});
+
     document.getElementById('translate-subtitle-btn').addEventListener('click', function() {
         var btn = this;
         var sourceLabel = document.getElementById('translate-source-select').value;
@@ -235,10 +250,11 @@ document.addEventListener('DOMContentLoaded', function() {
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
-            btn.disabled = false;
             if (data.ok) {
-                showTranslateStatus('success', 'Translation queued! It will appear in the subtitle list when complete.');
+                setTranslateLocked(true);
+                document.getElementById('translate-status').innerHTML = '';
             } else {
+                btn.disabled = false;
                 showTranslateStatus('danger', data.error || 'Failed to queue translation.');
             }
         })


### PR DESCRIPTION
## Summary
This PR adds a status check mechanism to prevent users from queuing multiple concurrent subtitle translations for the same media. When a translation is in progress, the translation UI is locked and displays a message to the user.

## Key Changes
- **Backend**: Added `studio_subtitles_translate_status` endpoint that checks if a translation is already in progress by querying the `media_concepts` table for the `{mediumid}_translate` concept
- **Frontend**: Added status check on page load that disables the translation form inputs and displays a warning message when a translation is already queued
- **UI/UX**: 
  - Added a locked state message with hourglass icon and explanatory text
  - Hides the translation input form when locked
  - Automatically locks the form after successfully queuing a new translation
  - Clears the status message on successful submission
- **Routing**: Registered the new `/studio/edit/{mediumid}/subtitles/translate/status` GET endpoint

## Implementation Details
- The status check queries the `media_concepts` table where `processed=false` indicates an in-progress translation
- Authorization is enforced: only the media owner can check translation status
- The frontend polls the status endpoint on initial page load and updates the UI accordingly
- After a successful translation request, the form remains locked until the page is refreshed or the translation completes

https://claude.ai/code/session_01KnREwMoq9K42drTwTnvRfa