### PR TITLE
Refactor media permissions into separate tab

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,8 @@ async fn main() {
         .route("/hx/studio/edit/{mediumid}/chapters", get(hx_studio_edit_chapters_tab))
         .route("/hx/studio/edit/{mediumid}/subtitles", get(hx_studio_edit_subtitles_tab))
         .route("/hx/studio/edit/{mediumid}/thumbnail", get(hx_studio_edit_thumbnail_tab))
+        .route("/hx/studio/edit/{mediumid}/permissions", get(hx_studio_edit_permissions_tab))
+        .route("/studio/edit/{mediumid}/permissions", post(studio_edit_permissions_save))
         .route("/hx/studio/edit/{mediumid}/danger", get(hx_studio_edit_danger_tab))
         .route("/studio/lists", get(studio_lists))
         .route("/hx/studio/lists", get(hx_studio_lists))

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -227,7 +227,6 @@ struct StudioEditTemplate {
 #[template(path = "pages/hx-studio-edit-description.html", escape = "none")]
 struct HXStudioEditDescriptionTemplate {
     medium: MediumEdit,
-    owner_groups: Vec<UserGroup>,
 }
 
 #[derive(Template)]
@@ -253,6 +252,13 @@ struct HXStudioEditThumbnailTemplate {
 struct HXStudioEditDangerTemplate {
     medium_id: String,
     medium_name: String,
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-studio-edit-permissions.html", escape = "none")]
+struct HXStudioEditPermissionsTemplate {
+    medium: MediumEdit,
+    owner_groups: Vec<UserGroup>,
 }
 async fn studio_edit(
     Extension(config): Extension<Config>,
@@ -313,6 +319,10 @@ async fn studio_edit(
 struct EditForm {
     medium_name: String,
     medium_description: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct PermissionsEditForm {
     medium_visibility: String,
     medium_restricted_group: Option<String>,
 }
@@ -344,27 +354,14 @@ async fn studio_edit_save(
         }
     }
 
-    let visibility = match form.medium_visibility.as_str() {
-        "public" | "hidden" | "restricted" => form.medium_visibility.clone(),
-        _ => "hidden".to_owned(),
-    };
-    let ispublic = visibility == "public";
-    let restricted_to_group = if visibility == "restricted" {
-        form.medium_restricted_group.clone().filter(|g| !g.is_empty())
-    } else {
-        None
-    };
     let description: serde_json::Value =
         serde_json::from_str(&form.medium_description).unwrap_or(serde_json::Value::Null);
 
     let update_result = sqlx::query(
-        "UPDATE media SET name=$1, description=$2, public=$3, visibility=$4, restricted_to_group=$5 WHERE id=$6;"
+        "UPDATE media SET name=$1, description=$2 WHERE id=$3;"
     )
     .bind(&form.medium_name)
     .bind(&description)
-    .bind(ispublic)
-    .bind(&visibility)
-    .bind(&restricted_to_group)
     .bind(&mediumid)
     .execute(&pool)
     .await;
@@ -462,21 +459,6 @@ async fn hx_studio_edit_description(
                 return Html(minifi_html("".to_owned()));
             }
 
-            let mut owner_groups = system_groups_for_owner(&user_info.login);
-            let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-                .bind(&user_info.login)
-                .map(|row: sqlx::postgres::PgRow| {
-                    UserGroup {
-                        id: row.get("id"),
-                        name: row.get("name"),
-                        owner: row.get("owner"),
-                    }
-                })
-                .fetch_all(&pool)
-                .await
-                .unwrap_or_default();
-            owner_groups.extend(user_groups);
-
             let template = HXStudioEditDescriptionTemplate {
                 medium: MediumEdit {
                     id: record.get("id"),
@@ -485,7 +467,6 @@ async fn hx_studio_edit_description(
                     restricted_to_group: record.get::<Option<String>, _>("restricted_to_group").unwrap_or_default(),
                     medium_type: record.get("type"),
                 },
-                owner_groups,
             };
             Html(minifi_html(template.render().unwrap()))
         }
@@ -602,4 +583,124 @@ async fn hx_studio_edit_danger_tab(
         }
         None => Html(minifi_html("".to_owned())),
     }
+}
+
+async fn hx_studio_edit_permissions_tab(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+) -> axum::response::Html<Vec<u8>> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html(minifi_html("".to_owned()));
+    }
+    let user_info = user_info.unwrap();
+
+    let medium = sqlx::query(
+        "SELECT id,name,owner,visibility,restricted_to_group,type FROM media WHERE id=$1;"
+    )
+    .bind(&mediumid)
+    .fetch_one(&pool)
+    .await;
+
+    match medium {
+        Ok(record) => {
+            use sqlx::Row;
+            let owner: String = record.get("owner");
+            if owner != user_info.login {
+                return Html(minifi_html("".to_owned()));
+            }
+
+            let mut owner_groups = system_groups_for_owner(&user_info.login);
+            let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
+                .bind(&user_info.login)
+                .map(|row: sqlx::postgres::PgRow| {
+                    UserGroup {
+                        id: row.get("id"),
+                        name: row.get("name"),
+                        owner: row.get("owner"),
+                    }
+                })
+                .fetch_all(&pool)
+                .await
+                .unwrap_or_default();
+            owner_groups.extend(user_groups);
+
+            let template = HXStudioEditPermissionsTemplate {
+                medium: MediumEdit {
+                    id: record.get("id"),
+                    name: record.get("name"),
+                    visibility: record.get("visibility"),
+                    restricted_to_group: record.get::<Option<String>, _>("restricted_to_group").unwrap_or_default(),
+                    medium_type: record.get("type"),
+                },
+                owner_groups,
+            };
+            Html(minifi_html(template.render().unwrap()))
+        }
+        Err(_) => Html(minifi_html("".to_owned())),
+    }
+}
+
+async fn studio_edit_permissions_save(
+    Extension(pool): Extension<PgPool>,
+    Extension(redis): Extension<RedisConn>,
+    headers: HeaderMap,
+    Path(mediumid): Path<String>,
+    Form(form): Form<PermissionsEditForm>,
+) -> axum::response::Html<String> {
+    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    if !is_logged(user_info.clone()).await {
+        return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
+    }
+    let user_info = user_info.unwrap();
+
+    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
+        .fetch_one(&pool)
+        .await;
+
+    match media_owner {
+        Ok(record) => {
+            if record.owner != user_info.login {
+                return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
+            }
+        }
+        Err(_) => {
+            return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
+        }
+    }
+
+    let visibility = match form.medium_visibility.as_str() {
+        "public" | "hidden" | "restricted" => form.medium_visibility.clone(),
+        _ => "hidden".to_owned(),
+    };
+    let ispublic = visibility == "public";
+    let restricted_to_group = if visibility == "restricted" {
+        form.medium_restricted_group.clone().filter(|g| !g.is_empty())
+    } else {
+        None
+    };
+
+    let update_result = sqlx::query(
+        "UPDATE media SET public=$1, visibility=$2, restricted_to_group=$3 WHERE id=$4;"
+    )
+    .bind(ispublic)
+    .bind(&visibility)
+    .bind(&restricted_to_group)
+    .bind(&mediumid)
+    .execute(&pool)
+    .await;
+
+    if update_result.is_err() {
+        return Html(format!(
+            "<b class=\"text-danger\">Failed to save changes.</b><script>setTimeout(function(){{window.location.replace(\"/studio/edit/{}\");}},2000);</script>",
+            mediumid
+        ));
+    }
+
+    Html(format!(
+        "<script>window.location.replace(\"/studio/edit/{}\");</script>",
+        mediumid
+    ))
 }

--- a/templates/pages/hx-studio-edit-description.html
+++ b/templates/pages/hx-studio-edit-description.html
@@ -48,52 +48,6 @@
         })();
         </script>
         <div class="form-group row my-3">
-            <label for="medium_visibility" class="col-4 col-form-label">Visibility</label>
-            <div class="col-8">
-                <select id="medium_visibility" name="medium_visibility" class="form-select" required>
-                    <option value="public" {% if medium.visibility == "public" %}selected{% endif %}>Public</option>
-                    <option value="hidden" {% if medium.visibility == "hidden" %}selected{% endif %}>Hidden</option>
-                    <option value="restricted" {% if medium.visibility == "restricted" %}selected{% endif %}>Restricted to Group</option>
-                </select>
-                <select id="medium_restricted_group" name="medium_restricted_group" class="form-select mt-2" style="display:none">
-                    <option value="">-- Select a group --</option>
-                    {% for group in owner_groups %}
-                    <option value="{{ group.id }}">{{ group.name }}</option>
-                    {% endfor %}
-                </select>
-                {% if owner_groups.is_empty() %}
-                <small class="text-secondary mt-1" id="no-groups-hint" style="display:none">
-                    You have no groups yet. <a href="/studio/groups" class="text-primary">Create one</a> to use restricted visibility.
-                </small>
-                {% endif %}
-            </div>
-        </div>
-        <script>
-        (function() {
-            var visTomSelect = new TomSelect('#medium_visibility', { create: false });
-            var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true });
-            var noGroupsHint = document.getElementById('no-groups-hint');
-
-            var currentGroup = '{{ medium.restricted_to_group }}';
-            if (currentGroup) {
-                groupTomSelect.setValue(currentGroup);
-            }
-
-            function updateGroupVisibility() {
-                var wrapper = groupTomSelect.wrapper;
-                if (visTomSelect.getValue() === 'restricted') {
-                    wrapper.style.display = '';
-                    if (noGroupsHint) noGroupsHint.style.display = '';
-                } else {
-                    wrapper.style.display = 'none';
-                    if (noGroupsHint) noGroupsHint.style.display = 'none';
-                }
-            }
-            updateGroupVisibility();
-            document.getElementById('medium_visibility').addEventListener('change', updateGroupVisibility);
-        })();
-        </script>
-        <div class="form-group row my-3">
             <div class="offset-4 col-8">
                 <button name="submit" type="submit" class="btn btn-primary">
                     <i class="fa-solid fa-floppy-disk"></i>&nbsp;Save Changes

--- a/templates/pages/hx-studio-edit-permissions.html
+++ b/templates/pages/hx-studio-edit-permissions.html
@@ -1,0 +1,57 @@
+<div class="col-12">
+    <form action="/studio/edit/{{ medium.id }}/permissions" method="post" class="mx-3">
+        <div class="form-group row my-3">
+            <label for="medium_visibility" class="col-4 col-form-label">Visibility</label>
+            <div class="col-8">
+                <select id="medium_visibility" name="medium_visibility" class="form-select" required>
+                    <option value="public" {% if medium.visibility == "public" %}selected{% endif %}>Public</option>
+                    <option value="hidden" {% if medium.visibility == "hidden" %}selected{% endif %}>Hidden</option>
+                    <option value="restricted" {% if medium.visibility == "restricted" %}selected{% endif %}>Restricted to Group</option>
+                </select>
+                <select id="medium_restricted_group" name="medium_restricted_group" class="form-select mt-2" style="display:none">
+                    <option value="">-- Select a group --</option>
+                    {% for group in owner_groups %}
+                    <option value="{{ group.id }}">{{ group.name }}</option>
+                    {% endfor %}
+                </select>
+                {% if owner_groups.is_empty() %}
+                <small class="text-secondary mt-1" id="no-groups-hint" style="display:none">
+                    You have no groups yet. <a href="/studio/groups" class="text-primary">Create one</a> to use restricted visibility.
+                </small>
+                {% endif %}
+            </div>
+        </div>
+        <script>
+        (function() {
+            var visTomSelect = new TomSelect('#medium_visibility', { create: false });
+            var groupTomSelect = new TomSelect('#medium_restricted_group', { create: false, allowEmptyOption: true });
+            var noGroupsHint = document.getElementById('no-groups-hint');
+
+            var currentGroup = '{{ medium.restricted_to_group }}';
+            if (currentGroup) {
+                groupTomSelect.setValue(currentGroup);
+            }
+
+            function updateGroupVisibility() {
+                var wrapper = groupTomSelect.wrapper;
+                if (visTomSelect.getValue() === 'restricted') {
+                    wrapper.style.display = '';
+                    if (noGroupsHint) noGroupsHint.style.display = '';
+                } else {
+                    wrapper.style.display = 'none';
+                    if (noGroupsHint) noGroupsHint.style.display = 'none';
+                }
+            }
+            updateGroupVisibility();
+            document.getElementById('medium_visibility').addEventListener('change', updateGroupVisibility);
+        })();
+        </script>
+        <div class="form-group row my-3">
+            <div class="offset-4 col-8">
+                <button name="submit" type="submit" class="btn btn-primary">
+                    <i class="fa-solid fa-floppy-disk"></i>&nbsp;Save Changes
+                </button>
+            </div>
+        </div>
+    </form>
+</div>

--- a/templates/pages/studio-edit.html
+++ b/templates/pages/studio-edit.html
@@ -77,6 +77,16 @@
                             </button>
                         </li>
                         <li class="nav-item">
+                            <button class="nav-link {% if active_tab == "permissions" %}active {% endif %}text-white"
+                                    hx-get="/hx/studio/edit/{{ medium.id }}/permissions"
+                                    hx-target="#tab-content"
+                                    hx-swap="innerHTML"
+                                    preload="mouseover"
+                                    hx-on:click="document.querySelectorAll('.nav-tabs .nav-link').forEach(t=>t.classList.remove('active'));this.classList.add('active');">
+                                <i class="fa-solid fa-lock me-2"></i>Permissions
+                            </button>
+                        </li>
+                        <li class="nav-item">
                             <button class="nav-link {% if active_tab == "danger" %}active {% endif %}text-white"
                                     hx-get="/hx/studio/edit/{{ medium.id }}/danger"
                                     hx-target="#tab-content"
@@ -94,6 +104,8 @@
                         <div hx-get="/hx/studio/edit/{{ medium.id }}/subtitles" hx-trigger="load" class="mb-3 hx-placeholder"></div>
                         {% else if active_tab == "thumbnail" %}
                         <div hx-get="/hx/studio/edit/{{ medium.id }}/thumbnail" hx-trigger="load" class="mb-3 hx-placeholder"></div>
+                        {% else if active_tab == "permissions" %}
+                        <div hx-get="/hx/studio/edit/{{ medium.id }}/permissions" hx-trigger="load" class="mb-3 hx-placeholder"></div>
                         {% else if active_tab == "danger" %}
                         <div hx-get="/hx/studio/edit/{{ medium.id }}/danger" hx-trigger="load" class="mb-3 hx-placeholder"></div>
                         {% else %}


### PR DESCRIPTION
## Summary
This PR refactors the media editing interface by extracting permissions management (visibility and group restrictions) into a dedicated tab, separate from the description editing tab.

## Key Changes
- **New Permissions Tab**: Created a new "Permissions" tab in the studio edit interface with its own form and handler
- **Separated Forms**: Split `EditForm` into two forms:
  - `EditForm`: Now handles only name and description
  - `PermissionsEditForm`: New form for visibility and group restriction settings
- **New Template**: Added `hx-studio-edit-permissions.html` template with visibility and group selection controls
- **New Handler Functions**:
  - `hx_studio_edit_permissions_tab()`: Renders the permissions tab content
  - `studio_edit_permissions_save()`: Handles permissions form submission
- **Removed Duplication**: Removed permissions-related code from `hx_studio_edit_description()` and the description template
- **Updated Routes**: Added new routes for the permissions tab GET and POST endpoints
- **UI Updates**: Added permissions tab button to the studio edit navigation with lock icon

## Implementation Details
- The permissions tab is loaded dynamically via HTMX, consistent with other edit tabs
- Group selection visibility is controlled by JavaScript based on the selected visibility option
- Permissions are now saved independently from description changes
- Both handlers include proper ownership validation to ensure only media owners can modify permissions

https://claude.ai/code/session_01ScaVHu2zabzywcCHzknv3s