### PR TITLE
Add native ASS/SSA subtitle support with LibASS rendering

### DIFF
--- a/src/lists.rs
+++ b/src/lists.rs
@@ -213,6 +213,7 @@ async fn medium_in_list(
         medium_captions_exist = false;
     }
 
+    let medium_has_ass_captions = medium_captions_list.iter().any(|c| c.is_ass);
     let medium_custom_font =
         std::path::Path::new(&format!("source/{}/captions/font.woff2", medium_id)).exists();
 
@@ -250,6 +251,7 @@ async fn medium_in_list(
         medium_type: medium.get("type"),
         medium_captions_exist,
         medium_captions_list,
+        medium_has_ass_captions,
         medium_custom_font,
         medium_chapters_exist,
         medium_previews_exist,

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -1,19 +1,23 @@
 struct CaptionEntry {
     label: String,
     filename: String,
+    is_ass: bool,
 }
 
 fn parse_caption_entry(entry: &str) -> CaptionEntry {
     let entry = entry.trim();
+    let is_ass = entry.ends_with(".ass") || entry.ends_with(".ssa");
     if let Some(dot_pos) = entry.rfind('.') {
         CaptionEntry {
             label: entry[..dot_pos].to_string(),
             filename: entry.to_string(),
+            is_ass,
         }
     } else {
         CaptionEntry {
             label: entry.to_string(),
             filename: format!("{}.vtt", entry),
+            is_ass: false,
         }
     }
 }
@@ -32,6 +36,7 @@ struct MediumTemplate {
     medium_type: String,
     medium_captions_exist: bool,
     medium_captions_list: Vec<CaptionEntry>,
+    medium_has_ass_captions: bool,
     medium_custom_font: bool,
     medium_chapters_exist: bool,
     medium_previews_exist: bool,
@@ -107,6 +112,7 @@ async fn medium(
         medium_captions_exist = false;
     }
 
+    let medium_has_ass_captions = medium_captions_list.iter().any(|c| c.is_ass);
     let medium_custom_font =
         std::path::Path::new(&format!("source/{}/captions/font.woff2", medium_id)).exists();
 
@@ -144,6 +150,7 @@ async fn medium(
         medium_type: medium.get("type"),
         medium_captions_exist,
         medium_captions_list,
+        medium_has_ass_captions,
         medium_custom_font,
         medium_chapters_exist,
         medium_previews_exist,

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -60,12 +60,13 @@ async fn studio_subtitles_get(
             .filter(|l| !l.trim().is_empty())
             .map(|l| {
                 let entry = l.trim();
+                let is_ass = entry.ends_with(".ass") || entry.ends_with(".ssa");
                 let label = if let Some(dot) = entry.rfind('.') {
                     entry[..dot].to_string()
                 } else {
                     entry.to_string()
                 };
-                serde_json::json!({ "label": label })
+                serde_json::json!({ "label": label, "format": if is_ass { "ass" } else { "vtt" } })
             })
             .collect();
         Json(serde_json::Value::Array(labels))
@@ -117,6 +118,7 @@ async fn studio_subtitles_add(
     let mut label = String::new();
     let mut file_content = Vec::new();
     let mut input_format = "webvtt";
+    let mut is_ass_upload = false;
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let name = field.name().unwrap_or("").to_string();
@@ -128,8 +130,9 @@ async fn studio_subtitles_add(
                 let filename = field.file_name().unwrap_or("").to_lowercase();
                 if filename.ends_with(".srt") {
                     input_format = "srt";
-                } else if filename.ends_with(".ass") {
+                } else if filename.ends_with(".ass") || filename.ends_with(".ssa") {
                     input_format = "ass";
+                    is_ass_upload = true;
                 }
                 file_content = field.bytes().await.unwrap_or_default().to_vec();
             }
@@ -166,10 +169,12 @@ async fn studio_subtitles_add(
             .unwrap();
     }
 
-    // Convert to WebVTT via ffmpeg if needed
-    let vtt_content = if input_format != "webvtt" {
+    // ASS/SSA files are stored natively to preserve styling; SRT is converted to VTT
+    let (final_content, file_ext) = if is_ass_upload {
+        (file_content, "ass")
+    } else if input_format != "webvtt" {
         match convert_subtitle_to_vtt(file_content, input_format).await {
-            Some(converted) => converted,
+            Some(converted) => (converted, "vtt"),
             None => {
                 return Response::builder()
                     .status(StatusCode::UNPROCESSABLE_ENTITY)
@@ -179,13 +184,13 @@ async fn studio_subtitles_add(
             }
         }
     } else {
-        file_content
+        (file_content, "vtt")
     };
 
     let captions_dir = format!("source/{}/captions", mediumid);
     let _ = tokio::fs::create_dir_all(&captions_dir).await;
 
-    let new_list_entry = format!("{}.vtt", sanitized_label);
+    let new_list_entry = format!("{}.{}", sanitized_label, file_ext);
     let subtitle_path = format!("{}/{}", captions_dir, new_list_entry);
 
     let list_path = format!("{}/list.txt", captions_dir);
@@ -217,7 +222,7 @@ async fn studio_subtitles_add(
     existing.retain(|e| e.as_str() != sanitized_label && !e.starts_with(&label_prefix));
     existing.push(new_list_entry);
 
-    if let Err(_) = tokio::fs::write(&subtitle_path, &vtt_content).await {
+    if let Err(_) = tokio::fs::write(&subtitle_path, &final_content).await {
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -497,8 +502,16 @@ async fn studio_subtitles_translate(
             .unwrap();
     }
 
-    // Verify source subtitle exists
+    // Verify source subtitle exists (only VTT subtitles can be used as translation source)
     let source_path = format!("source/{}/captions/{}.vtt", mediumid, source_label);
+    let source_ass_path = format!("source/{}/captions/{}.ass", mediumid, source_label);
+    if std::path::Path::new(&source_ass_path).exists() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(Body::from("{\"error\":\"ASS/SSA subtitles cannot be used as translation source\"}"))
+            .unwrap();
+    }
     if !std::path::Path::new(&source_path).exists() {
         return Response::builder()
             .status(StatusCode::NOT_FOUND)

--- a/templates/pages/hx-studio-edit-subtitles.html
+++ b/templates/pages/hx-studio-edit-subtitles.html
@@ -1,6 +1,6 @@
 <div class="col-12 mx-3">
     <h5><i class="fa-solid fa-closed-captioning"></i>&nbsp;Subtitles</h5>
-    <p class="text-secondary">Upload subtitle files (.vtt, .srt, .ass) — SRT and ASS files are automatically converted to WebVTT. Each subtitle track needs a label (e.g. "English", "Spanish").</p>
+    <p class="text-secondary">Upload subtitle files (.vtt, .srt, .ass, .ssa). SRT files are converted to WebVTT. ASS/SSA files are kept in their original format to preserve styling and rendered via LibASS. Each subtitle track needs a label (e.g. "English", "Spanish").</p>
     <div id="subtitles-editor">
         <div class="table-responsive">
             <table class="table table-hover text-white" id="subtitles-table">
@@ -23,8 +23,8 @@
                     <input type="text" class="form-control form-control-sm" id="subtitle-label-input" />
                 </div>
                 <div class="col-sm-5">
-                    <label for="subtitle-file-input" class="form-label">Subtitle File (.vtt, .srt, .ass → WebVTT)</label>
-                    <input type="file" class="form-control form-control-sm" id="subtitle-file-input" accept=".vtt,.srt,.ass" />
+                    <label for="subtitle-file-input" class="form-label">Subtitle File (.vtt, .srt, .ass, .ssa)</label>
+                    <input type="file" class="form-control form-control-sm" id="subtitle-file-input" accept=".vtt,.srt,.ass,.ssa" />
                 </div>
                 <div class="col-sm-3">
                     <button type="button" class="btn btn-primary btn-sm w-100" id="upload-subtitle-btn">
@@ -143,6 +143,13 @@
 
             var tdLabel = document.createElement('td');
             tdLabel.textContent = sub.label;
+            if (sub.format === 'ass') {
+                var badge = document.createElement('span');
+                badge.className = 'badge bg-info ms-2';
+                badge.textContent = 'ASS';
+                badge.title = 'Substation Alpha — rendered via LibASS';
+                tdLabel.appendChild(badge);
+            }
             tr.appendChild(tdLabel);
 
             var tdActions = document.createElement('td');
@@ -199,6 +206,7 @@
         var currentVal = sel.value;
         sel.innerHTML = '<option value="">-- Select source --</option>';
         subtitles.forEach(function(sub) {
+            if (sub.format === 'ass') return; // ASS subtitles cannot be used as translation source
             var opt = document.createElement('option');
             opt.value = sub.label;
             opt.textContent = sub.label;

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -88,7 +88,7 @@
                 object-fit: cover;
             }
         </style>
-        {% endif %} {% if medium_custom_font %}
+        {% endif %} {% if medium_custom_font && !medium_has_ass_captions %}
         <style>
             @font-face {
                 font-family: "SubtitleFont";
@@ -100,6 +100,8 @@
                     "SubtitleFont", var(--bs-font-sans-serif) !important;
             }
         </style>
+        {% endif %} {% if medium_has_ass_captions %}
+        <script src="https://cdn.jsdelivr.net/npm/jassub/dist/jassub.umd.js"></script>
         {% endif %}
     </head>
 
@@ -141,14 +143,15 @@
                                     type="application/dash+xml"
                                 />
                                 {% endif %} {% if medium_captions_exist %} {%
-                                for caption in medium_captions_list %}
+                                for caption in medium_captions_list %} {% if
+                                !caption.is_ass %}
                                 <track
                                     src="{{ config.source_server_url }}/source/{{ medium_id }}/captions/{{ caption.filename }}"
                                     kind="subtitles"
                                     label="{{ caption.label }}"
                                     lang="{{ caption.label }}"
                                 />
-                                {% endfor %} {% endif %} {% if
+                                {% endif %} {% endfor %} {% endif %} {% if
                                 medium_chapters_exist %}
                                 <track
                                     src="{{ config.source_server_url }}/source/{{ medium_id }}/chapters.vtt"
@@ -172,6 +175,136 @@
                                 %}
                             ></media-video-layout>
                         </media-player>
+                        {% if medium_has_ass_captions %}
+                        <script>
+                            document.addEventListener("DOMContentLoaded", function () {
+                                var player = document.querySelector("media-player");
+                                if (!player || typeof JASSUB === "undefined") return;
+
+                                var assSubtitles = [
+                                    {% for caption in medium_captions_list %}{% if caption.is_ass %}
+                                    { label: "{{ caption.label }}", url: "{{ config.source_server_url }}/source/{{ medium_id }}/captions/{{ caption.filename }}" },
+                                    {% endif %}{% endfor %}
+                                ];
+
+                                if (assSubtitles.length === 0) return;
+
+                                var jassubInstance = null;
+                                var currentAssTrack = null;
+
+                                function getVideoElement() {
+                                    var provider = player.querySelector("media-provider");
+                                    if (provider) {
+                                        var video = provider.querySelector("video");
+                                        if (video) return video;
+                                    }
+                                    return player.querySelector("video");
+                                }
+
+                                function initJassub(trackUrl) {
+                                    var video = getVideoElement();
+                                    if (!video) {
+                                        setTimeout(function() { initJassub(trackUrl); }, 200);
+                                        return;
+                                    }
+
+                                    if (jassubInstance) {
+                                        jassubInstance.setTrackByUrl(trackUrl);
+                                    } else {
+                                        var options = {
+                                            video: video,
+                                            subUrl: trackUrl,
+                                            workerUrl: "https://cdn.jsdelivr.net/npm/jassub/dist/jassub-worker.js",
+                                            wasmUrl: "https://cdn.jsdelivr.net/npm/jassub/dist/jassub-worker.wasm",
+                                            availableFonts: {},
+                                            prescaleFactor: 0.8,
+                                            onDemandRender: false
+                                        };
+
+                                        {% if medium_custom_font %}
+                                        options.availableFonts = { "default": "{{ config.source_server_url }}/source/{{ medium_id }}/captions/font.woff2" };
+                                        options.fallbackFont = "default";
+                                        {% endif %}
+
+                                        jassubInstance = new JASSUB(options);
+                                    }
+                                    currentAssTrack = trackUrl;
+                                }
+
+                                function destroyJassub() {
+                                    if (jassubInstance) {
+                                        jassubInstance.destroy();
+                                        jassubInstance = null;
+                                        currentAssTrack = null;
+                                    }
+                                }
+
+                                // Listen for Vidstack text track changes
+                                player.addEventListener("text-track-change", function (event) {
+                                    var track = event.detail;
+                                    if (!track || track.mode !== "showing") {
+                                        // Track was disabled
+                                        destroyJassub();
+                                        return;
+                                    }
+
+                                    // Check if the selected track matches an ASS subtitle
+                                    var matchedAss = null;
+                                    for (var i = 0; i < assSubtitles.length; i++) {
+                                        if (assSubtitles[i].label === track.label) {
+                                            matchedAss = assSubtitles[i];
+                                            break;
+                                        }
+                                    }
+
+                                    if (matchedAss) {
+                                        initJassub(matchedAss.url);
+                                    } else {
+                                        destroyJassub();
+                                    }
+                                });
+
+                                // Add ASS tracks to Vidstack's text track list so they appear in the subtitle menu
+                                player.addEventListener("can-play", function () {
+                                    for (var i = 0; i < assSubtitles.length; i++) {
+                                        var textTrack = new TextTrack({
+                                            kind: "subtitles",
+                                            label: assSubtitles[i].label,
+                                            language: assSubtitles[i].label,
+                                            type: "ass"
+                                        });
+                                        textTrack._assUrl = assSubtitles[i].url;
+                                        player.textTracks.add(textTrack);
+                                    }
+                                }, { once: true });
+
+                                // Also listen on textTracks mode changes for ASS tracks
+                                player.addEventListener("can-play", function () {
+                                    var tracks = player.textTracks;
+                                    if (!tracks) return;
+
+                                    var observer = new MutationObserver(function() {});
+
+                                    setInterval(function() {
+                                        var activeAss = null;
+                                        for (var i = 0; i < tracks.length; i++) {
+                                            var t = tracks[i];
+                                            if (t.mode === "showing" && t._assUrl) {
+                                                activeAss = t._assUrl;
+                                                break;
+                                            }
+                                        }
+
+                                        if (activeAss && activeAss !== currentAssTrack) {
+                                            initJassub(activeAss);
+                                        } else if (!activeAss && currentAssTrack) {
+                                            destroyJassub();
+                                        }
+                                    }, 500);
+                                }, { once: true });
+                            });
+                        </script>
+                        {% endif %}
                         {% else if medium_type == "audio" %}
                         <media-player
                             src="{{ config.source_server_url }}/source/{{ medium_id }}/audio.ogg"
@@ -188,14 +321,14 @@
                         >
                             <media-provider>
                                 {% if medium_captions_exist %} {% for caption in
-                                medium_captions_list %}
+                                medium_captions_list %} {% if !caption.is_ass %}
                                 <track
                                     src="{{ config.source_server_url }}/source/{{ medium_id }}/captions/{{ caption.filename }}"
                                     kind="subtitles"
                                     label="{{ caption.label }}"
                                     lang="{{ caption.label }}"
                                 />
-                                {% endfor %} {% endif %} {% if
+                                {% endif %} {% endfor %} {% endif %} {% if
                                 medium_chapters_exist %}
                                 <track
                                     src="{{ config.source_server_url }}/source/{{ medium_id }}/chapters.vtt"


### PR DESCRIPTION
## Summary
This PR adds native support for ASS/SSA subtitle files with client-side rendering via LibASS (JASSUB), while maintaining existing WebVTT and SRT support. ASS/SSA files are now preserved in their original format to maintain styling and advanced formatting features.

## Key Changes

- **Subtitle Format Detection**: Updated subtitle handling to detect and differentiate between ASS/SSA and VTT formats
  - Modified `parse_caption_entry()` to identify ASS/SSA files by extension
  - Added `is_ass` field to `CaptionEntry` struct to track subtitle format

- **Backend Processing**:
  - ASS/SSA files are now stored natively instead of being converted to WebVTT
  - SRT files continue to be converted to WebVTT for compatibility
  - Added validation to prevent ASS/SSA subtitles from being used as translation sources (only VTT supported)
  - Updated subtitle list API to include format information

- **Frontend Rendering**:
  - Integrated JASSUB library for client-side ASS/SSA rendering
  - ASS subtitle tracks are excluded from native HTML5 `<track>` elements
  - Implemented dynamic JASSUB instance management with track switching support
  - Added custom font support for ASS subtitles when available
  - ASS tracks appear in the subtitle menu alongside standard VTT tracks

- **UI Updates**:
  - Updated subtitle upload interface to accept `.ass` and `.ssa` files
  - Added visual badge indicator for ASS format subtitles in the studio editor
  - Updated help text to clarify format handling and LibASS rendering
  - Prevented ASS subtitles from appearing in translation source dropdown

- **Template Changes**:
  - Conditional loading of JASSUB library only when ASS captions are present
  - Custom font stylesheet now skipped when ASS captions exist (font handled by JASSUB)
  - Added comprehensive JavaScript for JASSUB initialization and lifecycle management

## Implementation Details

The JASSUB integration uses event listeners on the Vidstack player to:
- Detect when ASS subtitle tracks are selected
- Initialize/destroy JASSUB instances as needed
- Synchronize track selection between the player UI and renderer
- Support custom fonts via WOFF2 files when configured

https://claude.ai/code/session_019LXTk7JkPheQr8zky9innJ