### PR TITLE
Increase trending media grid columns from 4 to 5

### DIFF
--- a/src/trending.rs
+++ b/src/trending.rs
@@ -79,7 +79,7 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
             continue;
         }
         let index = media.len() as i32;
-        let columns = 4;
+        let columns = 5;
         media.push(Medium {
             id,
             name: info.get("name").cloned().unwrap_or_default(),


### PR DESCRIPTION
## Summary
Updated the trending media grid layout to display 5 columns instead of 4, allowing for more items to be shown per row.

## Changes
- Modified the `columns` variable in `try_trending_from_cache()` from 4 to 5 in `src/trending.rs`

## Details
This change affects the layout of trending media items in the cache retrieval function. The grid will now accommodate 5 items per row instead of 4, which may improve space utilization and content visibility depending on the display context.

https://claude.ai/code/session_016MtNQAxyreSSobPdeMDw6G