### PR TITLE
Use cached sprite positions instead of computing them dynamically

### DIFF
--- a/src/trending.rs
+++ b/src/trending.rs
@@ -61,8 +61,6 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
         .await
         .ok()
         .flatten();
-    let sprite_width = 352;
-    let sprite_height = 198;
 
     // Pipeline: fetch metadata for all IDs in a single round-trip
     let mut pipe = redis::pipe();
@@ -78,8 +76,9 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
         if info.is_empty() {
             continue;
         }
-        let index = media.len() as i32;
-        let columns = 5;
+        // Read sprite positions from cache (set by indexer based on actual sprite layout).
+        // Only assign sprite_filename if positions are present (item is in the sprite).
+        let has_sprite = info.contains_key("sprite_x");
         media.push(Medium {
             id,
             name: info.get("name").cloned().unwrap_or_default(),
@@ -89,9 +88,9 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(0),
             r#type: info.get("type").cloned().unwrap_or_default(),
-            sprite_filename: sprite_filename.clone(),
-            sprite_x: -((index % columns) * sprite_width),
-            sprite_y: -((index / columns) * sprite_height),
+            sprite_filename: if has_sprite { sprite_filename.clone() } else { None },
+            sprite_x: info.get("sprite_x").and_then(|v| v.parse().ok()).unwrap_or(0),
+            sprite_y: info.get("sprite_y").and_then(|v| v.parse().ok()).unwrap_or(0),
         });
     }
 


### PR DESCRIPTION
## Summary
This change refactors sprite positioning logic to use pre-computed values from the cache instead of calculating positions dynamically based on item index and grid layout.

## Key Changes
- Removed hardcoded sprite dimensions (`sprite_width: 352`, `sprite_height: 198`) that were used for dynamic position calculation
- Removed dynamic sprite position calculation based on item index and grid columns (5-column layout)
- Updated sprite positioning to read `sprite_x` and `sprite_y` directly from Redis cache metadata
- Made `sprite_filename` conditional: only assigned if sprite position data exists in cache (checked via `sprite_x` presence)
- Added clarifying comments explaining that sprite positions are set by the indexer based on actual sprite layout

## Implementation Details
- Sprite positions are now sourced from cache entries set by the indexer, allowing for more flexible sprite layouts
- The `has_sprite` flag determines whether to include a sprite filename, ensuring consistency between position data and filename assignment
- Default values of 0 are used for sprite coordinates if parsing fails, maintaining backward compatibility

https://claude.ai/code/session_01NqdcYQTTkK5mVuUa9ks1SP