### PR TITLE
Use platform-specific runners for Docker image builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-          - linux/ppc64le
-          - linux/riscv64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/ppc64le
+            runner: ubuntu-latest
+          - platform: linux/riscv64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  build-primary:
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +16,50 @@ jobs:
             runner: ubuntu-latest
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prepare platform name
+        run: echo "PLATFORM_PAIR=$(echo ${{ matrix.platform }} | tr '/' '-')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-secondary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - platform: linux/ppc64le
             runner: ubuntu-latest
           - platform: linux/riscv64
@@ -62,10 +106,36 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  merge-primary:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
-    needs: build
+    needs: build-primary
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-linux-{amd64,arm64}
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin
+
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            --tag panmourovaty/rustvideoplatform:latest \
+            $(printf 'panmourovaty/rustvideoplatform@sha256:%s ' *)
+
+  merge-full:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs: [build-primary, build-secondary]
 
     steps:
       - name: Download digests


### PR DESCRIPTION
## Summary
Updated the Docker image build workflow to use platform-specific GitHub Actions runners instead of building all architectures on a single ubuntu-latest runner.

## Key Changes
- Converted the `platform` matrix to an `include` matrix that pairs each platform with an appropriate runner
- Added native ARM64 runner (`ubuntu-24.04-arm`) for linux/arm64 builds
- Kept `ubuntu-latest` for amd64, ppc64le, and riscv64 platforms
- Changed job runner from static `ubuntu-latest` to dynamic `${{ matrix.runner }}` based on matrix configuration

## Implementation Details
This change enables more efficient cross-platform Docker builds by leveraging native runners for ARM64 architecture, which should improve build performance and reliability for that platform while maintaining compatibility with other architectures.

https://claude.ai/code/session_01Xn3CkX2PDg9bM4F3KrLdaY