### PR TITLE
Fix HTML ID naming conventions in 2FA settings templates

### DIFF
--- a/templates/pages/hx-settings-2fa-totp-setup.html
+++ b/templates/pages/hx-settings-2fa-totp-setup.html
@@ -14,7 +14,7 @@
     <hr>
     <h6>Verify Setup</h6>
     <p class="text-muted small">Enter the 6-digit code from your authenticator to confirm setup.</p>
-    <form hx-post="/hx/settings/2fa/totp/verify-setup" hx-target="#2fa-totp-setup-area" hx-swap="innerHTML">
+    <form hx-post="/hx/settings/2fa/totp/verify-setup" hx-target="#totp-setup-area" hx-swap="innerHTML">
         <input type="hidden" name="setup_token" value="{{ setup_token }}">
         <div class="d-flex gap-2">
             <input class="form-control text-center" type="text" name="totp_code"

--- a/templates/pages/hx-settings-2fa.html
+++ b/templates/pages/hx-settings-2fa.html
@@ -6,19 +6,19 @@
         <h6 class="mb-2"><i class="fa-solid fa-mobile-screen me-2"></i>Authenticator App (TOTP)</h6>
         {% if totp_enabled %}
         <p class="text-success mb-2"><i class="fa-solid fa-circle-check me-1"></i>TOTP is <strong>enabled</strong>.</p>
-        <form hx-post="/hx/settings/2fa/totp/disable" hx-target="#2fa-result" hx-swap="innerHTML">
+        <form hx-post="/hx/settings/2fa/totp/disable" hx-target="#twofa-result" hx-swap="innerHTML">
             <button type="submit" class="btn btn-sm btn-danger">
                 <i class="fa-solid fa-ban me-1"></i>Disable TOTP
             </button>
         </form>
         {% else %}
         <p class="mb-2">Use any TOTP authenticator app (Google Authenticator, Aegis, Bitwarden, etc.) to add a second factor to your login.</p>
-        <form hx-post="/hx/settings/2fa/totp/setup" hx-target="#2fa-totp-setup-area" hx-swap="innerHTML">
+        <form hx-post="/hx/settings/2fa/totp/setup" hx-target="#totp-setup-area" hx-swap="innerHTML">
             <button type="submit" class="btn btn-sm btn-primary">
                 <i class="fa-solid fa-qrcode me-1"></i>Set Up TOTP
             </button>
         </form>
-        <div id="2fa-totp-setup-area" class="mt-3"></div>
+        <div id="totp-setup-area" class="mt-3"></div>
         {% endif %}
     </div>
 
@@ -132,5 +132,5 @@
     </div>
     {% endif %}
 
-    <div id="2fa-result" class="mt-2"></div>
+    <div id="twofa-result" class="mt-2"></div>
 </div>


### PR DESCRIPTION
## Summary
Updated HTML element IDs in the two-factor authentication settings templates to follow consistent naming conventions by removing hyphens from numeric prefixes.

## Changes Made
- Renamed `#2fa-result` to `#twofa-result` in the main 2FA settings template
- Renamed `#2fa-totp-setup-area` to `#totp-setup-area` in both the main settings template and the TOTP setup template
- Updated all corresponding `hx-target` attributes to reference the new ID names

## Details
These changes improve HTML ID naming by avoiding IDs that start with numbers (which can cause issues in CSS selectors and JavaScript) and make the naming more semantic. The IDs now follow standard web conventions where numeric characters are avoided at the start of identifiers. All HTMX target references have been updated to maintain functionality.

https://claude.ai/code/session_019wTGzU4nWL1gpGfWffuvWt