### PR TITLE
Add search support for lists and users in addition to media

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,17 +88,19 @@ async fn main() {
         }
     }
 
-    // Verify the 'media' index exists
-    match meilisearch_client.get_index("media").await {
-        Ok(index) => {
-            println!("Meilisearch 'media' index found: uid={}", index.uid);
-        }
-        Err(e) => {
-            eprintln!(
-                "WARNING: Meilisearch 'media' index not accessible: {:?}",
-                e
-            );
-            eprintln!("Ensure the 'media' index is created and populated by the indexer.");
+    // Verify the Meilisearch indexes exist
+    for index_name in &["media", "lists", "users"] {
+        match meilisearch_client.get_index(index_name).await {
+            Ok(index) => {
+                println!("Meilisearch '{}' index found: uid={}", index_name, index.uid);
+            }
+            Err(e) => {
+                eprintln!(
+                    "WARNING: Meilisearch '{}' index not accessible: {:?}",
+                    index_name, e
+                );
+                eprintln!("Ensure the '{}' index is created and populated by the indexer.", index_name);
+            }
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -195,10 +195,28 @@ struct HXSearchTemplate {
 
 // --- List search ---
 
+/// Meilisearch document shape for the "lists" index.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct MeiliList {
+    id: String,
+    name: String,
+    owner: String,
+    #[serde(default)]
+    visibility: String,
+    #[serde(default)]
+    restricted_to_group: Option<String>,
+    #[serde(default)]
+    item_count: i64,
+    #[serde(default)]
+    created: i64,
+}
+
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct ListSearchHit {
     id: String,
     name: String,
+    highlighted_name: String,
     owner: String,
     item_count: i64,
 }
@@ -209,7 +227,8 @@ struct HXSearchListsTemplate {
     search_results: Vec<ListSearchHit>,
     next_page: usize,
     search_term: String,
-    total_hits: i64,
+    total_hits: usize,
+    query_time_ms: usize,
     is_first_page: bool,
     has_more: bool,
     config: Config,
@@ -217,10 +236,21 @@ struct HXSearchListsTemplate {
 
 // --- User search ---
 
+/// Meilisearch document shape for the "users" index.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct MeiliUser {
+    login: String,
+    name: String,
+    #[serde(default)]
+    profile_picture: Option<String>,
+}
+
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct UserSearchHit {
     login: String,
     name: String,
+    highlighted_name: String,
     profile_picture: Option<String>,
 }
 
@@ -230,7 +260,8 @@ struct HXSearchUsersTemplate {
     search_results: Vec<UserSearchHit>,
     next_page: usize,
     search_term: String,
-    total_hits: i64,
+    total_hits: usize,
+    query_time_ms: usize,
     is_first_page: bool,
     has_more: bool,
     config: Config,
@@ -267,10 +298,10 @@ async fn hx_search(
 
     match search_in.as_str() {
         "lists" => {
-            return hx_search_lists_inner(config, pool, user, pageid, form.search).await;
+            return hx_search_lists_inner(config, pool, meili, user, pageid, form.search).await;
         }
         "users" => {
-            return hx_search_users_inner(config, pool, pageid, form.search).await;
+            return hx_search_users_inner(config, meili, pageid, form.search).await;
         }
         _ => {} // "media" or empty — fall through to Meilisearch
     }
@@ -410,169 +441,196 @@ async fn hx_search(
     }
 }
 
-// --- List search inner ---
+// --- List search inner (Meilisearch) ---
 
 async fn hx_search_lists_inner(
     config: Config,
     pool: PgPool,
+    meili: Arc<MeilisearchClient>,
     user: Option<User>,
     pageid: usize,
     search_term: String,
 ) -> axum::response::Html<String> {
-    let user_login = user.map(|u| u.login).unwrap_or_default();
-    let hits_per_page: i64 = 41;
-    let offset = (pageid * 40) as i64;
-    let search_pattern = format!("%{}%", search_term.replace('%', "\\%").replace('_', "\\_"));
+    let hits_per_page: usize = 41;
+    let offset = pageid * 40;
 
-    let total: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM lists l \
-         WHERE (l.name ILIKE $1 OR l.owner ILIKE $1) \
-         AND (l.visibility = 'public' \
-             OR (l.visibility = 'restricted' AND ( \
-                 l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) \
-                 OR (l.restricted_to_group = '__all_registered__' AND $2 != '') \
-                 OR (l.restricted_to_group = '__subscribers__' AND $2 != '' AND l.owner IN (SELECT target FROM subscriptions WHERE subscriber = $2)) \
-             )) \
-         )",
-    )
-    .bind(&search_pattern)
-    .bind(&user_login)
-    .fetch_one(&pool)
-    .await
-    .unwrap_or(0);
+    // Reuse the same visibility filter logic as media search
+    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let filter_str = format!("({})", visibility_filter);
 
-    let mut results: Vec<ListSearchHit> = sqlx::query(
-        "SELECT l.id, l.name, l.owner, \
-         COALESCE((SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id), 0)::bigint AS item_count \
-         FROM lists l \
-         WHERE (l.name ILIKE $1 OR l.owner ILIKE $1) \
-         AND (l.visibility = 'public' \
-             OR (l.visibility = 'restricted' AND ( \
-                 l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) \
-                 OR (l.restricted_to_group = '__all_registered__' AND $2 != '') \
-                 OR (l.restricted_to_group = '__subscribers__' AND $2 != '' AND l.owner IN (SELECT target FROM subscriptions WHERE subscriber = $2)) \
-             )) \
-         ) \
-         ORDER BY l.name ASC LIMIT $3 OFFSET $4",
-    )
-    .bind(&search_pattern)
-    .bind(&user_login)
-    .bind(hits_per_page)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        ListSearchHit {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            item_count: row.get("item_count"),
+    let index = meili.index("lists");
+    let results = index
+        .search()
+        .with_query(&search_term)
+        .with_filter(&filter_str)
+        .with_offset(offset)
+        .with_limit(hits_per_page)
+        .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
+        .with_highlight_pre_tag("<mark>")
+        .with_highlight_post_tag("</mark>")
+        .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+            "id", "name", "owner", "item_count",
+        ]))
+        .execute::<MeiliList>()
+        .await;
+
+    match results {
+        Ok(search_results) => {
+            let total_hits = search_results.estimated_total_hits.unwrap_or(0);
+            let query_time_ms = search_results.processing_time_ms;
+
+            let mut hits: Vec<ListSearchHit> = search_results
+                .hits
+                .into_iter()
+                .map(|hit| {
+                    let highlighted_name = hit
+                        .formatted_result
+                        .as_ref()
+                        .and_then(|f| f.get("name"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&hit.result.name)
+                        .to_owned();
+                    ListSearchHit {
+                        id: hit.result.id,
+                        name: hit.result.name,
+                        highlighted_name,
+                        owner: hit.result.owner,
+                        item_count: hit.result.item_count,
+                    }
+                })
+                .collect();
+
+            let has_more = hits.len() == 41;
+            if has_more {
+                hits.truncate(40);
+            }
+
+            if hits.is_empty() && pageid == 0 {
+                return Html(
+                    "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords</p></div>"
+                        .to_owned(),
+                );
+            }
+
+            if hits.is_empty() {
+                return Html(
+                    "<div class=\"col-12 text-center my-4\"><p class=\"text-secondary\"><i class=\"fa-solid fa-circle-check me-2\"></i>You have reached the end.</p></div>"
+                        .to_owned(),
+                );
+            }
+
+            let template = HXSearchListsTemplate {
+                search_results: hits,
+                next_page: pageid + 1,
+                search_term,
+                total_hits,
+                query_time_ms,
+                is_first_page: pageid == 0,
+                has_more,
+                config,
+            };
+            Html(template.render().unwrap())
         }
-    })
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
-
-    let has_more = results.len() == 41;
-    if has_more {
-        results.truncate(40);
+        Err(e) => {
+            eprintln!("Meilisearch list search error: {:?}", e);
+            Html(
+                "<div class=\"search-empty\"><i class=\"fa-solid fa-triangle-exclamation fa-3x mb-3\"></i><h4>Search unavailable</h4><p class=\"text-secondary\">Please try again later</p></div>"
+                    .to_owned(),
+            )
+        }
     }
-
-    if results.is_empty() && pageid == 0 {
-        return Html(
-            "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords</p></div>"
-                .to_owned(),
-        );
-    }
-
-    if results.is_empty() {
-        return Html(
-            "<div class=\"col-12 text-center my-4\"><p class=\"text-secondary\"><i class=\"fa-solid fa-circle-check me-2\"></i>You have reached the end.</p></div>"
-                .to_owned(),
-        );
-    }
-
-    let template = HXSearchListsTemplate {
-        search_results: results,
-        next_page: pageid + 1,
-        search_term,
-        total_hits: total,
-        is_first_page: pageid == 0,
-        has_more,
-        config,
-    };
-    Html(template.render().unwrap())
 }
 
-// --- User search inner ---
+// --- User search inner (Meilisearch) ---
 
 async fn hx_search_users_inner(
     config: Config,
-    pool: PgPool,
+    meili: Arc<MeilisearchClient>,
     pageid: usize,
     search_term: String,
 ) -> axum::response::Html<String> {
-    let hits_per_page: i64 = 41;
-    let offset = (pageid * 40) as i64;
-    let search_pattern = format!("%{}%", search_term.replace('%', "\\%").replace('_', "\\_"));
+    let hits_per_page: usize = 41;
+    let offset = pageid * 40;
 
-    let total: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM users WHERE name ILIKE $1 OR login ILIKE $1",
-    )
-    .bind(&search_pattern)
-    .fetch_one(&pool)
-    .await
-    .unwrap_or(0);
+    let index = meili.index("users");
+    let results = index
+        .search()
+        .with_query(&search_term)
+        .with_offset(offset)
+        .with_limit(hits_per_page)
+        .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name", "login"]))
+        .with_highlight_pre_tag("<mark>")
+        .with_highlight_post_tag("</mark>")
+        .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+            "login", "name", "profile_picture",
+        ]))
+        .execute::<MeiliUser>()
+        .await;
 
-    let mut results: Vec<UserSearchHit> = sqlx::query(
-        "SELECT u.login, u.name, u.profile_picture \
-         FROM users u \
-         WHERE u.name ILIKE $1 OR u.login ILIKE $1 \
-         ORDER BY u.name ASC LIMIT $2 OFFSET $3",
-    )
-    .bind(&search_pattern)
-    .bind(hits_per_page)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        UserSearchHit {
-            login: row.get("login"),
-            name: row.get("name"),
-            profile_picture: row.get("profile_picture"),
+    match results {
+        Ok(search_results) => {
+            let total_hits = search_results.estimated_total_hits.unwrap_or(0);
+            let query_time_ms = search_results.processing_time_ms;
+
+            let mut hits: Vec<UserSearchHit> = search_results
+                .hits
+                .into_iter()
+                .map(|hit| {
+                    let highlighted_name = hit
+                        .formatted_result
+                        .as_ref()
+                        .and_then(|f| f.get("name"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&hit.result.name)
+                        .to_owned();
+                    UserSearchHit {
+                        login: hit.result.login,
+                        name: hit.result.name,
+                        highlighted_name,
+                        profile_picture: hit.result.profile_picture,
+                    }
+                })
+                .collect();
+
+            let has_more = hits.len() == 41;
+            if has_more {
+                hits.truncate(40);
+            }
+
+            if hits.is_empty() && pageid == 0 {
+                return Html(
+                    "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords</p></div>"
+                        .to_owned(),
+                );
+            }
+
+            if hits.is_empty() {
+                return Html(
+                    "<div class=\"col-12 text-center my-4\"><p class=\"text-secondary\"><i class=\"fa-solid fa-circle-check me-2\"></i>You have reached the end.</p></div>"
+                        .to_owned(),
+                );
+            }
+
+            let template = HXSearchUsersTemplate {
+                search_results: hits,
+                next_page: pageid + 1,
+                search_term,
+                total_hits,
+                query_time_ms,
+                is_first_page: pageid == 0,
+                has_more,
+                config,
+            };
+            Html(template.render().unwrap())
         }
-    })
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
-
-    let has_more = results.len() == 41;
-    if has_more {
-        results.truncate(40);
+        Err(e) => {
+            eprintln!("Meilisearch user search error: {:?}", e);
+            Html(
+                "<div class=\"search-empty\"><i class=\"fa-solid fa-triangle-exclamation fa-3x mb-3\"></i><h4>Search unavailable</h4><p class=\"text-secondary\">Please try again later</p></div>"
+                    .to_owned(),
+            )
+        }
     }
-
-    if results.is_empty() && pageid == 0 {
-        return Html(
-            "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords</p></div>"
-                .to_owned(),
-        );
-    }
-
-    if results.is_empty() {
-        return Html(
-            "<div class=\"col-12 text-center my-4\"><p class=\"text-secondary\"><i class=\"fa-solid fa-circle-check me-2\"></i>You have reached the end.</p></div>"
-                .to_owned(),
-        );
-    }
-
-    let template = HXSearchUsersTemplate {
-        search_results: results,
-        next_page: pageid + 1,
-        search_term,
-        total_hits: total,
-        is_first_page: pageid == 0,
-        has_more,
-        config,
-    };
-    Html(template.render().unwrap())
 }
 
 // --- Search page ---

--- a/src/search.rs
+++ b/src/search.rs
@@ -173,6 +173,8 @@ struct HXSearchForm {
     sort_by: Option<String>,
     #[serde(default)]
     date_range: Option<String>,
+    #[serde(default)]
+    search_in: Option<String>,
 }
 
 #[derive(Template)]
@@ -186,6 +188,49 @@ struct HXSearchTemplate {
     date_range: String,
     total_hits: usize,
     query_time_ms: usize,
+    is_first_page: bool,
+    has_more: bool,
+    config: Config,
+}
+
+// --- List search ---
+
+#[derive(Debug, Clone)]
+struct ListSearchHit {
+    id: String,
+    name: String,
+    owner: String,
+    item_count: i64,
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-search-lists.html", escape = "none")]
+struct HXSearchListsTemplate {
+    search_results: Vec<ListSearchHit>,
+    next_page: usize,
+    search_term: String,
+    total_hits: i64,
+    is_first_page: bool,
+    has_more: bool,
+    config: Config,
+}
+
+// --- User search ---
+
+#[derive(Debug, Clone)]
+struct UserSearchHit {
+    login: String,
+    name: String,
+    profile_picture: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-search-users.html", escape = "none")]
+struct HXSearchUsersTemplate {
+    search_results: Vec<UserSearchHit>,
+    next_page: usize,
+    search_term: String,
+    total_hits: i64,
     is_first_page: bool,
     has_more: bool,
     config: Config,
@@ -217,6 +262,19 @@ async fn hx_search(
         return Html("".to_owned());
     }
 
+    let search_in = form.search_in.clone().unwrap_or_default();
+    let user = get_user_login(headers.clone(), &pool, redis.clone()).await;
+
+    match search_in.as_str() {
+        "lists" => {
+            return hx_search_lists_inner(config, pool, user, pageid, form.search).await;
+        }
+        "users" => {
+            return hx_search_users_inner(config, pool, pageid, form.search).await;
+        }
+        _ => {} // "media" or empty — fall through to Meilisearch
+    }
+
     let hits_per_page: usize = 41;
     let offset = pageid * 40;
     let next_page = pageid + 1;
@@ -226,7 +284,6 @@ async fn hx_search(
     let date_range = form.date_range.clone().unwrap_or_default();
 
     // Build filter string with visibility-aware access control
-    let user = get_user_login(headers, &pool, redis).await;
     let visibility_filter = build_visibility_filter(&pool, &user).await;
     let mut filters: Vec<String> = vec![format!("({})", visibility_filter)];
 
@@ -351,6 +408,171 @@ async fn hx_search(
             )
         }
     }
+}
+
+// --- List search inner ---
+
+async fn hx_search_lists_inner(
+    config: Config,
+    pool: PgPool,
+    user: Option<User>,
+    pageid: usize,
+    search_term: String,
+) -> axum::response::Html<String> {
+    let user_login = user.map(|u| u.login).unwrap_or_default();
+    let hits_per_page: i64 = 41;
+    let offset = (pageid * 40) as i64;
+    let search_pattern = format!("%{}%", search_term.replace('%', "\\%").replace('_', "\\_"));
+
+    let total: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM lists l \
+         WHERE (l.name ILIKE $1 OR l.owner ILIKE $1) \
+         AND (l.visibility = 'public' \
+             OR (l.visibility = 'restricted' AND ( \
+                 l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) \
+                 OR (l.restricted_to_group = '__all_registered__' AND $2 != '') \
+                 OR (l.restricted_to_group = '__subscribers__' AND $2 != '' AND l.owner IN (SELECT target FROM subscriptions WHERE subscriber = $2)) \
+             )) \
+         )",
+    )
+    .bind(&search_pattern)
+    .bind(&user_login)
+    .fetch_one(&pool)
+    .await
+    .unwrap_or(0);
+
+    let mut results: Vec<ListSearchHit> = sqlx::query(
+        "SELECT l.id, l.name, l.owner, \
+         COALESCE((SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id), 0)::bigint AS item_count \
+         FROM lists l \
+         WHERE (l.name ILIKE $1 OR l.owner ILIKE $1) \
+         AND (l.visibility = 'public' \
+             OR (l.visibility = 'restricted' AND ( \
+                 l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) \
+                 OR (l.restricted_to_group = '__all_registered__' AND $2 != '') \
+                 OR (l.restricted_to_group = '__subscribers__' AND $2 != '' AND l.owner IN (SELECT target FROM subscriptions WHERE subscriber = $2)) \
+             )) \
+         ) \
+         ORDER BY l.name ASC LIMIT $3 OFFSET $4",
+    )
+    .bind(&search_pattern)
+    .bind(&user_login)
+    .bind(hits_per_page)
+    .bind(offset)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        ListSearchHit {
+            id: row.get("id"),
+            name: row.get("name"),
+            owner: row.get("owner"),
+            item_count: row.get("item_count"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .unwrap_or_default();
+
+    let has_more = results.len() == 41;
+    if has_more {
+        results.truncate(40);
+    }
+
+    if results.is_empty() && pageid == 0 {
+        return Html(
+            "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords</p></div>"
+                .to_owned(),
+        );
+    }
+
+    if results.is_empty() {
+        return Html(
+            "<div class=\"col-12 text-center my-4\"><p class=\"text-secondary\"><i class=\"fa-solid fa-circle-check me-2\"></i>You have reached the end.</p></div>"
+                .to_owned(),
+        );
+    }
+
+    let template = HXSearchListsTemplate {
+        search_results: results,
+        next_page: pageid + 1,
+        search_term,
+        total_hits: total,
+        is_first_page: pageid == 0,
+        has_more,
+        config,
+    };
+    Html(template.render().unwrap())
+}
+
+// --- User search inner ---
+
+async fn hx_search_users_inner(
+    config: Config,
+    pool: PgPool,
+    pageid: usize,
+    search_term: String,
+) -> axum::response::Html<String> {
+    let hits_per_page: i64 = 41;
+    let offset = (pageid * 40) as i64;
+    let search_pattern = format!("%{}%", search_term.replace('%', "\\%").replace('_', "\\_"));
+
+    let total: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM users WHERE name ILIKE $1 OR login ILIKE $1",
+    )
+    .bind(&search_pattern)
+    .fetch_one(&pool)
+    .await
+    .unwrap_or(0);
+
+    let mut results: Vec<UserSearchHit> = sqlx::query(
+        "SELECT u.login, u.name, u.profile_picture \
+         FROM users u \
+         WHERE u.name ILIKE $1 OR u.login ILIKE $1 \
+         ORDER BY u.name ASC LIMIT $2 OFFSET $3",
+    )
+    .bind(&search_pattern)
+    .bind(hits_per_page)
+    .bind(offset)
+    .map(|row: sqlx::postgres::PgRow| {
+        use sqlx::Row;
+        UserSearchHit {
+            login: row.get("login"),
+            name: row.get("name"),
+            profile_picture: row.get("profile_picture"),
+        }
+    })
+    .fetch_all(&pool)
+    .await
+    .unwrap_or_default();
+
+    let has_more = results.len() == 41;
+    if has_more {
+        results.truncate(40);
+    }
+
+    if results.is_empty() && pageid == 0 {
+        return Html(
+            "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords</p></div>"
+                .to_owned(),
+        );
+    }
+
+    if results.is_empty() {
+        return Html(
+            "<div class=\"col-12 text-center my-4\"><p class=\"text-secondary\"><i class=\"fa-solid fa-circle-check me-2\"></i>You have reached the end.</p></div>"
+                .to_owned(),
+        );
+    }
+
+    let template = HXSearchUsersTemplate {
+        search_results: results,
+        next_page: pageid + 1,
+        search_term,
+        total_hits: total,
+        is_first_page: pageid == 0,
+        has_more,
+        config,
+    };
+    Html(template.render().unwrap())
 }
 
 // --- Search page ---

--- a/templates/pages/hx-search-lists.html
+++ b/templates/pages/hx-search-lists.html
@@ -1,6 +1,7 @@
 {% if is_first_page %}
 <div class="search-meta">
     <span class="search-meta-count"><i class="fa-solid fa-hashtag me-1"></i>{{ total_hits }} results</span>
+    <span class="search-meta-time"><i class="fa-solid fa-bolt me-1"></i>{{ query_time_ms }}ms</span>
 </div>
 {% endif %}
 {% for hit in search_results %}
@@ -9,7 +10,7 @@
         <i class="fa-solid fa-list fa-3x text-secondary"></i>
     </div>
     <div class="search-card-info">
-        <h5 class="search-card-title">{{ hit.name }}</h5>
+        <h5 class="search-card-title">{{ hit.highlighted_name }}</h5>
         <div class="search-card-meta">
             <span class="search-card-owner"><i class="fa-solid fa-user me-1"></i>{{ hit.owner }}</span>
             <span class="search-card-views"><i class="fa-solid fa-film me-1"></i>{{ hit.item_count }} items</span>

--- a/templates/pages/hx-search-lists.html
+++ b/templates/pages/hx-search-lists.html
@@ -1,0 +1,32 @@
+{% if is_first_page %}
+<div class="search-meta">
+    <span class="search-meta-count"><i class="fa-solid fa-hashtag me-1"></i>{{ total_hits }} results</span>
+</div>
+{% endif %}
+{% for hit in search_results %}
+<a href="/l/{{ hit.id }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
+    <div class="search-card-thumbnail" style="display:flex;align-items:center;justify-content:center;">
+        <i class="fa-solid fa-list fa-3x text-secondary"></i>
+    </div>
+    <div class="search-card-info">
+        <h5 class="search-card-title">{{ hit.name }}</h5>
+        <div class="search-card-meta">
+            <span class="search-card-owner"><i class="fa-solid fa-user me-1"></i>{{ hit.owner }}</span>
+            <span class="search-card-views"><i class="fa-solid fa-film me-1"></i>{{ hit.item_count }} items</span>
+        </div>
+    </div>
+</a>
+{% if loop.index == 15 && has_more %}
+<form style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-post="/hx/search/{{ next_page }}" hx-trigger="revealed" hx-target="#inf-scroll-sl-{{ next_page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()">
+    <input type="hidden" name="search" value="{{ search_term }}" />
+    <input type="hidden" name="search_in" value="lists" />
+</form>
+{% endif %}
+{% endfor %}
+{% if has_more %}
+<div id="inf-scroll-sl-{{ next_page }}" class="my-4 inf-scroll-placeholder"></div>
+{% else %}
+<div class="text-center my-4">
+    <p class="text-secondary"><i class="fa-solid fa-circle-check me-2"></i>You have reached the end.</p>
+</div>
+{% endif %}

--- a/templates/pages/hx-search-users.html
+++ b/templates/pages/hx-search-users.html
@@ -1,0 +1,35 @@
+{% if is_first_page %}
+<div class="search-meta">
+    <span class="search-meta-count"><i class="fa-solid fa-hashtag me-1"></i>{{ total_hits }} results</span>
+</div>
+{% endif %}
+{% for hit in search_results %}
+<a href="/u/{{ hit.login }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
+    <div class="search-card-thumbnail" style="display:flex;align-items:center;justify-content:center;">
+        {% if hit.profile_picture.is_some() %}
+        <img src="{{ config.source_server_url }}/source/{{ hit.profile_picture.clone().unwrap() }}/thumbnail-small.avif" loading="lazy" style="width:100%;height:100%;object-fit:cover;" />
+        {% else %}
+        <i class="fa-solid fa-user fa-3x text-secondary"></i>
+        {% endif %}
+    </div>
+    <div class="search-card-info">
+        <h5 class="search-card-title">{{ hit.name }}</h5>
+        <div class="search-card-meta">
+            <span class="search-card-owner"><i class="fa-solid fa-at me-1"></i>{{ hit.login }}</span>
+        </div>
+    </div>
+</a>
+{% if loop.index == 15 && has_more %}
+<form style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-post="/hx/search/{{ next_page }}" hx-trigger="revealed" hx-target="#inf-scroll-su-{{ next_page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()">
+    <input type="hidden" name="search" value="{{ search_term }}" />
+    <input type="hidden" name="search_in" value="users" />
+</form>
+{% endif %}
+{% endfor %}
+{% if has_more %}
+<div id="inf-scroll-su-{{ next_page }}" class="my-4 inf-scroll-placeholder"></div>
+{% else %}
+<div class="text-center my-4">
+    <p class="text-secondary"><i class="fa-solid fa-circle-check me-2"></i>You have reached the end.</p>
+</div>
+{% endif %}

--- a/templates/pages/hx-search-users.html
+++ b/templates/pages/hx-search-users.html
@@ -1,6 +1,7 @@
 {% if is_first_page %}
 <div class="search-meta">
     <span class="search-meta-count"><i class="fa-solid fa-hashtag me-1"></i>{{ total_hits }} results</span>
+    <span class="search-meta-time"><i class="fa-solid fa-bolt me-1"></i>{{ query_time_ms }}ms</span>
 </div>
 {% endif %}
 {% for hit in search_results %}
@@ -13,7 +14,7 @@
         {% endif %}
     </div>
     <div class="search-card-info">
-        <h5 class="search-card-title">{{ hit.name }}</h5>
+        <h5 class="search-card-title">{{ hit.highlighted_name }}</h5>
         <div class="search-card-meta">
             <span class="search-card-owner"><i class="fa-solid fa-at me-1"></i>{{ hit.login }}</span>
         </div>

--- a/templates/pages/hx-search.html
+++ b/templates/pages/hx-search.html
@@ -33,6 +33,7 @@
     <input type="hidden" name="media_type" value="{{ media_type }}" />
     <input type="hidden" name="sort_by" value="{{ sort_by }}" />
     <input type="hidden" name="date_range" value="{{ date_range }}" />
+    <input type="hidden" name="search_in" value="" />
 </form>
 {% endif %}
 {% endfor %}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -38,38 +38,50 @@
 
                             <div class="search-filters">
                                 <div class="filter-group">
-                                    <label class="filter-label"><i class="fa-solid fa-photo-film me-1"></i>Type</label>
-                                    <div class="filter-chips" id="typeFilter">
-                                        <button type="button" class="filter-chip active" data-value="">All</button>
-                                        <button type="button" class="filter-chip" data-value="video"><i class="fa-solid fa-video me-1"></i>Video</button>
-                                        <button type="button" class="filter-chip" data-value="audio"><i class="fa-solid fa-music me-1"></i>Audio</button>
-                                        <button type="button" class="filter-chip" data-value="picture"><i class="fa-solid fa-image me-1"></i>Picture</button>
+                                    <label class="filter-label"><i class="fa-solid fa-compass me-1"></i>Search in</label>
+                                    <div class="filter-chips" id="searchInFilter">
+                                        <button type="button" class="filter-chip active" data-value=""><i class="fa-solid fa-photo-film me-1"></i>Media</button>
+                                        <button type="button" class="filter-chip" data-value="lists"><i class="fa-solid fa-list me-1"></i>Lists</button>
+                                        <button type="button" class="filter-chip" data-value="users"><i class="fa-solid fa-users me-1"></i>Users</button>
                                     </div>
-                                    <input type="hidden" name="media_type" id="mediaTypeInput" value="" />
+                                    <input type="hidden" name="search_in" id="searchInInput" value="" />
                                 </div>
 
-                                <div class="filter-group">
-                                    <label class="filter-label"><i class="fa-solid fa-arrow-down-wide-short me-1"></i>Sort by</label>
-                                    <div class="filter-chips" id="sortFilter">
-                                        <button type="button" class="filter-chip active" data-value=""><i class="fa-solid fa-star me-1"></i>Relevance</button>
-                                        <button type="button" class="filter-chip" data-value="newest"><i class="fa-solid fa-clock me-1"></i>Newest</button>
-                                        <button type="button" class="filter-chip" data-value="oldest"><i class="fa-solid fa-clock-rotate-left me-1"></i>Oldest</button>
-                                        <button type="button" class="filter-chip" data-value="views"><i class="fa-solid fa-eye me-1"></i>Most viewed</button>
-                                        <button type="button" class="filter-chip" data-value="likes"><i class="fa-solid fa-heart me-1"></i>Most liked</button>
+                                <div id="mediaSpecificFilters">
+                                    <div class="filter-group">
+                                        <label class="filter-label"><i class="fa-solid fa-photo-film me-1"></i>Type</label>
+                                        <div class="filter-chips" id="typeFilter">
+                                            <button type="button" class="filter-chip active" data-value="">All</button>
+                                            <button type="button" class="filter-chip" data-value="video"><i class="fa-solid fa-video me-1"></i>Video</button>
+                                            <button type="button" class="filter-chip" data-value="audio"><i class="fa-solid fa-music me-1"></i>Audio</button>
+                                            <button type="button" class="filter-chip" data-value="picture"><i class="fa-solid fa-image me-1"></i>Picture</button>
+                                        </div>
+                                        <input type="hidden" name="media_type" id="mediaTypeInput" value="" />
                                     </div>
-                                    <input type="hidden" name="sort_by" id="sortByInput" value="" />
-                                </div>
 
-                                <div class="filter-group">
-                                    <label class="filter-label"><i class="fa-solid fa-calendar me-1"></i>Upload date</label>
-                                    <div class="filter-chips" id="dateFilter">
-                                        <button type="button" class="filter-chip active" data-value="">Any time</button>
-                                        <button type="button" class="filter-chip" data-value="today">Today</button>
-                                        <button type="button" class="filter-chip" data-value="week">This week</button>
-                                        <button type="button" class="filter-chip" data-value="month">This month</button>
-                                        <button type="button" class="filter-chip" data-value="year">This year</button>
+                                    <div class="filter-group">
+                                        <label class="filter-label"><i class="fa-solid fa-arrow-down-wide-short me-1"></i>Sort by</label>
+                                        <div class="filter-chips" id="sortFilter">
+                                            <button type="button" class="filter-chip active" data-value=""><i class="fa-solid fa-star me-1"></i>Relevance</button>
+                                            <button type="button" class="filter-chip" data-value="newest"><i class="fa-solid fa-clock me-1"></i>Newest</button>
+                                            <button type="button" class="filter-chip" data-value="oldest"><i class="fa-solid fa-clock-rotate-left me-1"></i>Oldest</button>
+                                            <button type="button" class="filter-chip" data-value="views"><i class="fa-solid fa-eye me-1"></i>Most viewed</button>
+                                            <button type="button" class="filter-chip" data-value="likes"><i class="fa-solid fa-heart me-1"></i>Most liked</button>
+                                        </div>
+                                        <input type="hidden" name="sort_by" id="sortByInput" value="" />
                                     </div>
-                                    <input type="hidden" name="date_range" id="dateRangeInput" value="" />
+
+                                    <div class="filter-group">
+                                        <label class="filter-label"><i class="fa-solid fa-calendar me-1"></i>Upload date</label>
+                                        <div class="filter-chips" id="dateFilter">
+                                            <button type="button" class="filter-chip active" data-value="">Any time</button>
+                                            <button type="button" class="filter-chip" data-value="today">Today</button>
+                                            <button type="button" class="filter-chip" data-value="week">This week</button>
+                                            <button type="button" class="filter-chip" data-value="month">This month</button>
+                                            <button type="button" class="filter-chip" data-value="year">This year</button>
+                                        </div>
+                                        <input type="hidden" name="date_range" id="dateRangeInput" value="" />
+                                    </div>
                                 </div>
                             </div>
                         </form>
@@ -100,6 +112,17 @@
                     var hiddenInput = group.nextElementSibling;
                     if (hiddenInput) {
                         hiddenInput.value = chip.getAttribute('data-value');
+                    }
+
+                    // Show/hide media-specific filters based on search_in
+                    if (group.id === 'searchInFilter') {
+                        var mediaFilters = document.getElementById('mediaSpecificFilters');
+                        var val = chip.getAttribute('data-value');
+                        if (val === 'lists' || val === 'users') {
+                            mediaFilters.style.display = 'none';
+                        } else {
+                            mediaFilters.style.display = '';
+                        }
                     }
 
                     // Auto-submit if there's a search query


### PR DESCRIPTION
## Summary
Extended the search functionality to support searching across three different entity types: media (existing), lists, and users. Users can now switch between search contexts using a new "Search in" filter, with each context having its own Meilisearch index and result templates.

## Key Changes

- **Added search context switching**: New `search_in` form field allows users to toggle between "Media", "Lists", and "Users" search modes
- **Implemented list search**: Added `MeiliList` document structure and `hx_search_lists_inner()` function to query the "lists" Meilisearch index with visibility-aware filtering
- **Implemented user search**: Added `MeiliUser` document structure and `hx_search_users_inner()` function to query the "users" Meilisearch index
- **Created result templates**: Added `hx-search-lists.html` and `hx-search-users.html` templates for rendering list and user search results with infinite scroll support
- **Updated UI filters**: Reorganized search filters to show "Search in" as the primary filter, with media-specific filters (Type, Sort by, Upload date) now conditionally displayed only when searching media
- **Enhanced Meilisearch initialization**: Updated startup checks to verify all three indexes ("media", "lists", "users") are accessible
- **Reused visibility filtering**: List search leverages the existing `build_visibility_filter()` logic to respect access control rules

## Implementation Details

- List search results display owner, item count, and highlighted list names
- User search results show profile pictures (with fallback icon), login handles, and highlighted names
- Both new search modes support pagination via infinite scroll with the same 40-item-per-page pattern as media search
- Media-specific filters are hidden when searching lists or users to avoid confusion
- Error handling and empty state messages are consistent across all search types

https://claude.ai/code/session_01BFWtYwzSsG9tEPoaeL7sx9