### PR TITLE
Update GitHub Actions workflow dependencies to latest versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-primary:
     strategy:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: ["main"]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build-primary:
     strategy:
@@ -28,14 +25,14 @@ jobs:
         run: echo "PLATFORM_PAIR=$(echo ${{ matrix.platform }} | tr '/' '-')" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -51,7 +48,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digest-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -76,17 +73,17 @@ jobs:
         run: echo "PLATFORM_PAIR=$(echo ${{ matrix.platform }} | tr '/' '-')" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -102,7 +99,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digest-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
@@ -123,7 +120,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin
@@ -149,7 +146,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
         run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin


### PR DESCRIPTION
## Summary
This pull request updates the Docker and GitHub Actions dependencies used in the CI/CD workflow to their latest stable versions.

## Key Changes
- **docker/setup-buildx-action**: v3 → v4
- **docker/build-push-action**: v6 → v7
- **docker/setup-qemu-action**: v3 → v4
- **actions/upload-artifact**: v4 → v6

These updates are applied consistently across all workflow jobs that use these actions, including the build jobs for different platforms and the manifest merge jobs.

## Implementation Details
All action version updates follow the same pattern across the workflow file, ensuring consistency and reducing maintenance burden. The changes maintain the existing workflow structure and configuration while leveraging improvements and bug fixes available in the newer action versions.

https://claude.ai/code/session_01FWGLwqBtDmKCNx6a92hjzX