### PR TITLE
Remove Docker build cache mounts and GitHub Actions caching

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest
@@ -89,8 +87,6 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
-          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
           outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
       - name: Export digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ ARG TARGETARCH
 # Pre-build dependencies (cached layer - only invalidated when Cargo.toml changes)
 COPY Cargo.toml /src/rustvideoplatform/
 RUN mkdir -p /src/rustvideoplatform/src && echo 'fn main() {}' > /src/rustvideoplatform/src/main.rs
-RUN --mount=type=cache,target=/root/.cargo/registry,id=cargo-reg-${TARGETARCH},sharing=locked \
-    --mount=type=cache,target=/root/.cargo/git,id=cargo-git-${TARGETARCH},sharing=locked \
-    case "$TARGETARCH" in \
+RUN case "$TARGETARCH" in \
         amd64)   export RUSTFLAGS="-C target-cpu=x86-64-v3" ;; \
         ppc64le) export RUSTFLAGS="-C target-cpu=pwr8" ;; \
     esac && \
@@ -18,9 +16,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry,id=cargo-reg-${TARGETARCH},s
 
 # Build actual project
 COPY ./ /src/rustvideoplatform
-RUN --mount=type=cache,target=/root/.cargo/registry,id=cargo-reg-${TARGETARCH},sharing=locked \
-    --mount=type=cache,target=/root/.cargo/git,id=cargo-git-${TARGETARCH},sharing=locked \
-    case "$TARGETARCH" in \
+RUN case "$TARGETARCH" in \
         amd64)   export RUSTFLAGS="-C target-cpu=x86-64-v3" ;; \
         ppc64le) export RUSTFLAGS="-C target-cpu=pwr8" ;; \
     esac && \


### PR DESCRIPTION
## Summary
This PR removes Docker build cache mount directives from the Dockerfile and disables GitHub Actions cache integration in the CI/CD workflow. These changes simplify the build configuration by relying on standard Docker layer caching instead of explicit cache mounts.

## Key Changes
- **Dockerfile**: Removed `--mount=type=cache` directives for both cargo registry and git caches from the dependency pre-build and main build stages
- **GitHub Actions Workflow**: Removed `cache-from` and `cache-to` parameters from both build job steps that were using GitHub Actions cache backend

## Implementation Details
The build process will now depend solely on Docker's standard layer caching mechanism rather than explicit cache mounts. This may impact build performance for incremental builds, particularly for cargo dependency resolution, but simplifies the build configuration and removes the GitHub Actions cache storage overhead.

https://claude.ai/code/session_01BrPrLbspU1PceFcuWRfzxs