### PR TITLE
Enhance search suggestions with users and lists

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16253,6 +16253,21 @@ body.sidebar-collapsed .sidebarbackground {
     list-style: none;
 }
 
+.suggestion-section-header {
+    padding: 0.4rem 0.75rem 0.2rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--bs-secondary);
+    list-style: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.suggestion-section-header:first-child {
+    border-top: none;
+}
+
 #suggestions {
     position: absolute;
     z-index: 1000;

--- a/src/search.rs
+++ b/src/search.rs
@@ -99,6 +99,42 @@ struct HXSearch {
     search: String,
 }
 
+#[derive(Debug, Clone)]
+struct SuggestionUser {
+    login: String,
+    name: String,
+    highlighted_name: String,
+    profile_picture: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SuggestionList {
+    id: String,
+    name: String,
+    highlighted_name: String,
+    owner: String,
+    item_count: i64,
+}
+
+#[derive(Debug, Clone)]
+struct SuggestionMedia {
+    id: String,
+    name: String,
+    highlighted_name: String,
+    owner: String,
+    views: i64,
+    r#type: String,
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-searchsuggestions.html", escape = "none")]
+struct HXSearchSuggestionsTemplate {
+    users: Vec<SuggestionUser>,
+    lists: Vec<SuggestionList>,
+    media: Vec<SuggestionMedia>,
+    config: Config,
+}
+
 async fn hx_search_suggestions(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
@@ -113,53 +149,129 @@ async fn hx_search_suggestions(
 
     let user = get_user_login(headers, &pool, redis).await;
     let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let vis_filter_for_lists = format!("({})", visibility_filter);
 
-    let index = meili.index("media");
-    let results = index
-        .search()
-        .with_query(&form.search)
-        .with_filter(&visibility_filter)
-        .with_limit(6)
-        .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
-        .with_highlight_pre_tag("<mark>")
-        .with_highlight_post_tag("</mark>")
-        .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
-            "id", "name", "owner", "views", "likes", "type", "upload",
-        ]))
-        .execute::<MeiliMedia>()
-        .await;
+    let (users_res, lists_res, media_res) = tokio::join!(
+        async {
+            meili.index("users")
+                .search()
+                .with_query(&form.search)
+                .with_limit(3)
+                .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name", "login"]))
+                .with_highlight_pre_tag("<mark>")
+                .with_highlight_post_tag("</mark>")
+                .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+                    "login", "name", "profile_picture",
+                ]))
+                .execute::<MeiliUser>()
+                .await
+        },
+        async {
+            meili.index("lists")
+                .search()
+                .with_query(&form.search)
+                .with_filter(&vis_filter_for_lists)
+                .with_limit(3)
+                .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
+                .with_highlight_pre_tag("<mark>")
+                .with_highlight_post_tag("</mark>")
+                .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+                    "id", "name", "owner", "item_count",
+                ]))
+                .execute::<MeiliList>()
+                .await
+        },
+        async {
+            meili.index("media")
+                .search()
+                .with_query(&form.search)
+                .with_filter(&visibility_filter)
+                .with_limit(3)
+                .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
+                .with_highlight_pre_tag("<mark>")
+                .with_highlight_post_tag("</mark>")
+                .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+                    "id", "name", "owner", "views", "type",
+                ]))
+                .execute::<MeiliMedia>()
+                .await
+        },
+    );
 
-    match results {
-        Ok(search_results) => {
-            let media: Vec<Medium> = search_results
-                .hits
-                .into_iter()
-                .map(|hit| hit.result.into())
-                .collect();
-
-            if media.is_empty() {
-                return Html(
-                    "<li class=\"suggestion-empty\"><i class=\"fa-solid fa-circle-info me-2\"></i>No results found</li>"
-                        .to_owned(),
-                );
+    let users: Vec<SuggestionUser> = match users_res {
+        Ok(r) => r.hits.into_iter().map(|hit| {
+            let highlighted_name = hit
+                .formatted_result
+                .as_ref()
+                .and_then(|f| f.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(&hit.result.name)
+                .to_owned();
+            SuggestionUser {
+                login: hit.result.login,
+                name: hit.result.name,
+                highlighted_name,
+                profile_picture: hit.result.profile_picture,
             }
+        }).collect(),
+        Err(e) => { eprintln!("Meilisearch users suggestion error: {:?}", e); vec![] }
+    };
 
-            let template = HXMediumListTemplate {
-                current_medium_id: String::new(),
-                list_id: String::new(),
-                media,
-                config,
-            };
-            Html(template.render().unwrap())
-        }
-        Err(e) => {
-            eprintln!("Meilisearch search suggestion error: {:?}", e);
-            Html(
-                "<li class=\"suggestion-empty\"><i class=\"fa-solid fa-triangle-exclamation me-2\"></i>Search unavailable</li>"
-                    .to_owned(),
-            )
-        }
+    let lists: Vec<SuggestionList> = match lists_res {
+        Ok(r) => r.hits.into_iter().map(|hit| {
+            let highlighted_name = hit
+                .formatted_result
+                .as_ref()
+                .and_then(|f| f.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(&hit.result.name)
+                .to_owned();
+            SuggestionList {
+                id: hit.result.id,
+                name: hit.result.name,
+                highlighted_name,
+                owner: hit.result.owner,
+                item_count: hit.result.item_count,
+            }
+        }).collect(),
+        Err(e) => { eprintln!("Meilisearch lists suggestion error: {:?}", e); vec![] }
+    };
+
+    let media: Vec<SuggestionMedia> = match media_res {
+        Ok(r) => r.hits.into_iter().map(|hit| {
+            let highlighted_name = hit
+                .formatted_result
+                .as_ref()
+                .and_then(|f| f.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(&hit.result.name)
+                .to_owned();
+            SuggestionMedia {
+                id: hit.result.id,
+                name: hit.result.name,
+                highlighted_name,
+                owner: hit.result.owner,
+                views: hit.result.views,
+                r#type: hit.result.r#type,
+            }
+        }).collect(),
+        Err(e) => { eprintln!("Meilisearch media suggestion error: {:?}", e); vec![] }
+    };
+
+    if users.is_empty() && lists.is_empty() && media.is_empty() {
+        return Html(
+            "<li class=\"suggestion-empty\"><i class=\"fa-solid fa-circle-info me-2\"></i>No results found</li>"
+                .to_owned(),
+        );
     }
+
+    let template = HXSearchSuggestionsTemplate {
+        users,
+        lists,
+        media,
+        config,
+    };
+    Html(template.render().unwrap())
 }
 
 // --- Full search with filters ---

--- a/templates/pages/hx-searchsuggestions.html
+++ b/templates/pages/hx-searchsuggestions.html
@@ -1,0 +1,68 @@
+{% if !users.is_empty() %}
+<li class="suggestion-section-header">
+    <i class="fa-solid fa-user me-2"></i>Channels &amp; Users
+</li>
+{% for user in users %}
+<a href="/u/{{ user.login }}" class="text-decoration-none suggestionitem" preload="mouseover">
+    <li class="d-flex align-items-center gap-2 py-1 px-2">
+        {% if user.profile_picture.is_some() %}
+        <img src="{{ config.source_server_url }}/source/{{ user.profile_picture.as_ref().unwrap() }}" class="rounded-circle" width="32" height="32" style="object-fit:cover;flex-shrink:0;" alt="">
+        {% else %}
+        <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center" style="width:32px;height:32px;flex-shrink:0;">
+            <i class="fa-solid fa-user fa-xs text-white"></i>
+        </div>
+        {% endif %}
+        <div class="overflow-hidden">
+            <div class="text-white text-truncate fw-semibold">{{ user.highlighted_name }}</div>
+            <div class="text-secondary small">@{{ user.login }}</div>
+        </div>
+    </li>
+</a>
+{% endfor %}
+{% endif %}
+
+{% if !lists.is_empty() %}
+<li class="suggestion-section-header {% if !users.is_empty() %}mt-1{% endif %}">
+    <i class="fa-solid fa-list me-2"></i>Lists
+</li>
+{% for list in lists %}
+<a href="/list/{{ list.id }}" class="text-decoration-none suggestionitem" preload="mouseover">
+    <li class="d-flex align-items-center gap-2 py-1 px-2">
+        <div class="d-flex align-items-center justify-content-center bg-secondary rounded" style="width:32px;height:32px;flex-shrink:0;">
+            <i class="fa-solid fa-list fa-xs text-white"></i>
+        </div>
+        <div class="overflow-hidden">
+            <div class="text-white text-truncate fw-semibold">{{ list.highlighted_name }}</div>
+            <div class="text-secondary small">{{ list.owner }} &middot; {{ list.item_count }} items</div>
+        </div>
+    </li>
+</a>
+{% endfor %}
+{% endif %}
+
+{% if !media.is_empty() %}
+<li class="suggestion-section-header {% if !users.is_empty() || !lists.is_empty() %}mt-1{% endif %}">
+    <i class="fa-solid fa-film me-2"></i>Media
+</li>
+{% for item in media %}
+<a href="/m/{{ item.id }}" class="text-decoration-none suggestionitem" preload="mouseover">
+    <li class="d-flex align-items-center gap-2 py-1 px-2">
+        <div class="d-flex align-items-center justify-content-center bg-secondary rounded" style="width:32px;height:32px;flex-shrink:0;">
+            {% if item.type == "video" %}
+            <i class="fa-solid fa-video fa-xs text-white"></i>
+            {% else if item.type == "audio" %}
+            <i class="fa-solid fa-music fa-xs text-white"></i>
+            {% else if item.type == "picture" %}
+            <i class="fa-solid fa-image fa-xs text-white"></i>
+            {% else %}
+            <i class="fa-solid fa-file fa-xs text-white"></i>
+            {% endif %}
+        </div>
+        <div class="overflow-hidden">
+            <div class="text-white text-truncate fw-semibold">{{ item.highlighted_name }}</div>
+            <div class="text-secondary small">{{ item.owner }} &middot; {{ item.views }} views</div>
+        </div>
+    </li>
+</a>
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## Summary
Refactored the search suggestions feature to display results from multiple content types (users, lists, and media) in organized sections, rather than only showing media results.

## Key Changes
- **New suggestion data structures**: Added `SuggestionUser`, `SuggestionList`, and `SuggestionMedia` structs to represent search results from each content type
- **Parallel search queries**: Refactored `hx_search_suggestions` to execute three concurrent Meilisearch queries (users, lists, media) using `tokio::join!` instead of a single media-only query
- **Enhanced template**: Created new `hx-searchsuggestions.html` template that displays results organized by type with section headers, icons, and metadata (profile pictures for users, item counts for lists, view counts for media)
- **Improved styling**: Added `.suggestion-section-header` CSS class for section headers with proper spacing, typography, and border styling
- **Better error handling**: Each search query is handled independently with error logging, allowing partial results if one query fails
- **Visibility filtering**: Applied appropriate visibility filters for lists and media while keeping user searches unrestricted

## Implementation Details
- Search limits set to 3 results per category for concise suggestions
- Highlighted search terms are extracted from Meilisearch formatted results with fallback to original text
- Section headers only display when results exist in that category
- Conditional spacing between sections using Bootstrap margin utilities
- Media type icons (video, audio, picture, file) displayed based on content type

https://claude.ai/code/session_01VpNgaE5ry9ysYkuUEvBdmQ