### PR TITLE
Add unified "All" search type for simultaneous multi-category searching

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16103,6 +16103,23 @@ body.sidebar-collapsed .sidebarbackground {
     gap: 0.5rem;
 }
 
+.search-section-header {
+    grid-column: 1 / -1;
+    padding: 0.75rem 0 0.25rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    margin-bottom: 0.25rem;
+}
+
+.search-section-header:first-child {
+    padding-top: 0;
+}
+
+.search-section-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
+
 .search-result-card {
     display: flex;
     gap: 1rem;

--- a/src/search.rs
+++ b/src/search.rs
@@ -392,6 +392,22 @@ struct MeiliSearchHit {
     upload: i64,
 }
 
+// --- Combined "all" search ---
+
+#[derive(Template)]
+#[template(path = "pages/hx-search-all.html", escape = "none")]
+struct HXSearchAllTemplate {
+    users: Vec<UserSearchHit>,
+    lists: Vec<ListSearchHit>,
+    media: Vec<MeiliSearchHit>,
+    users_total: usize,
+    lists_total: usize,
+    media_total: usize,
+    query_time_ms: usize,
+    search_term: String,
+    config: Config,
+}
+
 async fn hx_search(
     Extension(config): Extension<Config>,
     Extension(pool): Extension<PgPool>,
@@ -415,7 +431,11 @@ async fn hx_search(
         "users" => {
             return hx_search_users_inner(config, meili, pageid, form.search).await;
         }
-        _ => {} // "media" or empty — fall through to Meilisearch
+        "media" => {} // fall through to media-only Meilisearch
+        _ => {
+            // Default: search all types simultaneously
+            return hx_search_all_inner(config, pool, meili, user, form.search).await;
+        }
     }
 
     let hits_per_page: usize = 41;
@@ -743,6 +763,157 @@ async fn hx_search_users_inner(
             )
         }
     }
+}
+
+// --- Combined "all" search inner ---
+
+async fn hx_search_all_inner(
+    config: Config,
+    pool: PgPool,
+    meili: Arc<MeilisearchClient>,
+    user: Option<User>,
+    search_term: String,
+) -> axum::response::Html<String> {
+    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let vis_filter_parens = format!("({})", visibility_filter);
+
+    let (users_res, lists_res, media_res) = tokio::join!(
+        async {
+            meili.index("users")
+                .search()
+                .with_query(&search_term)
+                .with_limit(10)
+                .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name", "login"]))
+                .with_highlight_pre_tag("<mark>")
+                .with_highlight_post_tag("</mark>")
+                .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+                    "login", "name", "profile_picture",
+                ]))
+                .execute::<MeiliUser>()
+                .await
+        },
+        async {
+            meili.index("lists")
+                .search()
+                .with_query(&search_term)
+                .with_filter(&vis_filter_parens)
+                .with_limit(10)
+                .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
+                .with_highlight_pre_tag("<mark>")
+                .with_highlight_post_tag("</mark>")
+                .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+                    "id", "name", "owner", "item_count",
+                ]))
+                .execute::<MeiliList>()
+                .await
+        },
+        async {
+            meili.index("media")
+                .search()
+                .with_query(&search_term)
+                .with_filter(&visibility_filter)
+                .with_limit(20)
+                .with_attributes_to_highlight(meilisearch_sdk::search::Selectors::Some(&["name"]))
+                .with_highlight_pre_tag("<mark>")
+                .with_highlight_post_tag("</mark>")
+                .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
+                    "id", "name", "owner", "views", "likes", "type", "upload",
+                ]))
+                .execute::<MeiliMedia>()
+                .await
+        },
+    );
+
+    let (users, users_total, mut query_time_ms) = match users_res {
+        Ok(r) => {
+            let total = r.estimated_total_hits.unwrap_or(0);
+            let time = r.processing_time_ms;
+            let hits: Vec<UserSearchHit> = r.hits.into_iter().map(|hit| {
+                let highlighted_name = hit.formatted_result.as_ref()
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&hit.result.name)
+                    .to_owned();
+                UserSearchHit {
+                    login: hit.result.login,
+                    name: hit.result.name,
+                    highlighted_name,
+                    profile_picture: hit.result.profile_picture,
+                }
+            }).collect();
+            (hits, total, time)
+        }
+        Err(e) => { eprintln!("Meilisearch users search error: {:?}", e); (vec![], 0, 0) }
+    };
+
+    let (lists, lists_total) = match lists_res {
+        Ok(r) => {
+            let total = r.estimated_total_hits.unwrap_or(0);
+            query_time_ms = query_time_ms.max(r.processing_time_ms);
+            let hits: Vec<ListSearchHit> = r.hits.into_iter().map(|hit| {
+                let highlighted_name = hit.formatted_result.as_ref()
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&hit.result.name)
+                    .to_owned();
+                ListSearchHit {
+                    id: hit.result.id,
+                    name: hit.result.name,
+                    highlighted_name,
+                    owner: hit.result.owner,
+                    item_count: hit.result.item_count,
+                }
+            }).collect();
+            (hits, total)
+        }
+        Err(e) => { eprintln!("Meilisearch lists search error: {:?}", e); (vec![], 0) }
+    };
+
+    let (media, media_total) = match media_res {
+        Ok(r) => {
+            let total = r.estimated_total_hits.unwrap_or(0);
+            query_time_ms = query_time_ms.max(r.processing_time_ms);
+            let hits: Vec<MeiliSearchHit> = r.hits.into_iter().map(|hit| {
+                let highlighted_name = hit.formatted_result.as_ref()
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&hit.result.name)
+                    .to_owned();
+                MeiliSearchHit {
+                    id: hit.result.id,
+                    name: hit.result.name,
+                    highlighted_name,
+                    owner: hit.result.owner,
+                    views: hit.result.views,
+                    likes: hit.result.likes,
+                    r#type: hit.result.r#type,
+                    upload: hit.result.upload,
+                }
+            }).collect();
+            (hits, total)
+        }
+        Err(e) => { eprintln!("Meilisearch media search error: {:?}", e); (vec![], 0) }
+    };
+
+    if users.is_empty() && lists.is_empty() && media.is_empty() {
+        return Html(
+            "<div class=\"search-empty\"><i class=\"fa-solid fa-magnifying-glass fa-3x mb-3\"></i><h4>No results found</h4><p class=\"text-secondary\">Try different keywords or adjust your filters</p></div>"
+                .to_owned(),
+        );
+    }
+
+    let template = HXSearchAllTemplate {
+        users,
+        lists,
+        media,
+        users_total,
+        lists_total,
+        media_total,
+        query_time_ms,
+        search_term,
+        config,
+    };
+    Html(template.render().unwrap())
 }
 
 // --- Search page ---

--- a/templates/pages/hx-search-all.html
+++ b/templates/pages/hx-search-all.html
@@ -1,0 +1,98 @@
+<div class="search-meta">
+    <span class="search-meta-count"><i class="fa-solid fa-hashtag me-1"></i>{{ users_total + lists_total + media_total }} results</span>
+    <span class="search-meta-time"><i class="fa-solid fa-bolt me-1"></i>{{ query_time_ms }}ms</span>
+</div>
+
+{% if !users.is_empty() %}
+<div class="search-section-header">
+    <h5 class="search-section-title"><i class="fa-solid fa-users me-2"></i>Users <span class="text-secondary">({{ users_total }})</span></h5>
+</div>
+{% for hit in users %}
+<a href="/u/{{ hit.login }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
+    <div class="search-card-thumbnail" style="display:flex;align-items:center;justify-content:center;">
+        {% if hit.profile_picture.is_some() %}
+        <img src="{{ config.source_server_url }}/source/{{ hit.profile_picture.clone().unwrap() }}/thumbnail-small.avif" loading="lazy" style="width:100%;height:100%;object-fit:cover;" />
+        {% else %}
+        <i class="fa-solid fa-user fa-3x text-secondary"></i>
+        {% endif %}
+    </div>
+    <div class="search-card-info">
+        <h5 class="search-card-title">{{ hit.highlighted_name }}</h5>
+        <div class="search-card-meta">
+            <span class="search-card-owner"><i class="fa-solid fa-at me-1"></i>{{ hit.login }}</span>
+        </div>
+    </div>
+</a>
+{% endfor %}
+{% if users_total > 10 %}
+<div class="search-section-more" style="grid-column: 1 / -1; text-align: center; padding: 0.5rem;">
+    <button type="button" class="btn btn-outline-secondary btn-sm search-see-all-btn" data-search-in="users">
+        <i class="fa-solid fa-arrow-right me-1"></i>See all {{ users_total }} users
+    </button>
+</div>
+{% endif %}
+{% endif %}
+
+{% if !lists.is_empty() %}
+<div class="search-section-header">
+    <h5 class="search-section-title"><i class="fa-solid fa-list me-2"></i>Lists <span class="text-secondary">({{ lists_total }})</span></h5>
+</div>
+{% for hit in lists %}
+<a href="/l/{{ hit.id }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
+    <div class="search-card-thumbnail" style="display:flex;align-items:center;justify-content:center;">
+        <i class="fa-solid fa-list fa-3x text-secondary"></i>
+    </div>
+    <div class="search-card-info">
+        <h5 class="search-card-title">{{ hit.highlighted_name }}</h5>
+        <div class="search-card-meta">
+            <span class="search-card-owner"><i class="fa-solid fa-user me-1"></i>{{ hit.owner }}</span>
+            <span class="search-card-views"><i class="fa-solid fa-film me-1"></i>{{ hit.item_count }} items</span>
+        </div>
+    </div>
+</a>
+{% endfor %}
+{% if lists_total > 10 %}
+<div class="search-section-more" style="grid-column: 1 / -1; text-align: center; padding: 0.5rem;">
+    <button type="button" class="btn btn-outline-secondary btn-sm search-see-all-btn" data-search-in="lists">
+        <i class="fa-solid fa-arrow-right me-1"></i>See all {{ lists_total }} lists
+    </button>
+</div>
+{% endif %}
+{% endif %}
+
+{% if !media.is_empty() %}
+<div class="search-section-header">
+    <h5 class="search-section-title"><i class="fa-solid fa-photo-film me-2"></i>Media <span class="text-secondary">({{ media_total }})</span></h5>
+</div>
+{% for hit in media %}
+<a href="/m/{{ hit.id }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
+    <div class="search-card-thumbnail">
+        <img src="{{ config.source_server_url }}/source/{{ hit.id }}/thumbnail-sm.avif" alt="{{ hit.name }}" loading="lazy" />
+        <div class="search-card-type-badge">
+            {% if hit.type == "video" %}
+            <i class="fa-solid fa-video"></i>
+            {% else if hit.type == "audio" %}
+            <i class="fa-solid fa-music"></i>
+            {% else if hit.type == "picture" %}
+            <i class="fa-solid fa-image"></i>
+            {% endif %}
+        </div>
+    </div>
+    <div class="search-card-info">
+        <h5 class="search-card-title">{{ hit.highlighted_name }}</h5>
+        <div class="search-card-meta">
+            <span class="search-card-owner"><i class="fa-solid fa-user me-1"></i>{{ hit.owner }}</span>
+            <span class="search-card-views"><i class="fa-solid fa-eye me-1"></i>{{ hit.views }} views</span>
+            <span class="search-card-likes"><i class="fa-solid fa-heart me-1"></i>{{ hit.likes }}</span>
+        </div>
+    </div>
+</a>
+{% endfor %}
+{% if media_total > 20 %}
+<div class="search-section-more" style="grid-column: 1 / -1; text-align: center; padding: 0.5rem;">
+    <button type="button" class="btn btn-outline-secondary btn-sm search-see-all-btn" data-search-in="media">
+        <i class="fa-solid fa-arrow-right me-1"></i>See all {{ media_total }} media
+    </button>
+</div>
+{% endif %}
+{% endif %}

--- a/templates/pages/hx-search.html
+++ b/templates/pages/hx-search.html
@@ -33,7 +33,7 @@
     <input type="hidden" name="media_type" value="{{ media_type }}" />
     <input type="hidden" name="sort_by" value="{{ sort_by }}" />
     <input type="hidden" name="date_range" value="{{ date_range }}" />
-    <input type="hidden" name="search_in" value="" />
+    <input type="hidden" name="search_in" value="media" />
 </form>
 {% endif %}
 {% endfor %}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -40,14 +40,15 @@
                                 <div class="filter-group">
                                     <label class="filter-label"><i class="fa-solid fa-compass me-1"></i>Search in</label>
                                     <div class="filter-chips" id="searchInFilter">
-                                        <button type="button" class="filter-chip active" data-value=""><i class="fa-solid fa-photo-film me-1"></i>Media</button>
+                                        <button type="button" class="filter-chip active" data-value="all"><i class="fa-solid fa-magnifying-glass me-1"></i>All</button>
+                                        <button type="button" class="filter-chip" data-value="media"><i class="fa-solid fa-photo-film me-1"></i>Media</button>
                                         <button type="button" class="filter-chip" data-value="lists"><i class="fa-solid fa-list me-1"></i>Lists</button>
                                         <button type="button" class="filter-chip" data-value="users"><i class="fa-solid fa-users me-1"></i>Users</button>
                                     </div>
-                                    <input type="hidden" name="search_in" id="searchInInput" value="" />
+                                    <input type="hidden" name="search_in" id="searchInInput" value="all" />
                                 </div>
 
-                                <div id="mediaSpecificFilters">
+                                <div id="mediaSpecificFilters" style="display:none;">
                                     <div class="filter-group">
                                         <label class="filter-label"><i class="fa-solid fa-photo-film me-1"></i>Type</label>
                                         <div class="filter-chips" id="typeFilter">
@@ -118,10 +119,10 @@
                     if (group.id === 'searchInFilter') {
                         var mediaFilters = document.getElementById('mediaSpecificFilters');
                         var val = chip.getAttribute('data-value');
-                        if (val === 'lists' || val === 'users') {
-                            mediaFilters.style.display = 'none';
-                        } else {
+                        if (val === 'media') {
                             mediaFilters.style.display = '';
+                        } else {
+                            mediaFilters.style.display = 'none';
                         }
                     }
 
@@ -162,6 +163,31 @@
 
             searchInput.focus();
         }
+
+        // "See all" buttons in combined results switch to specific tab
+        document.addEventListener('click', function(e) {
+            var btn = e.target.closest('.search-see-all-btn');
+            if (!btn) return;
+            var searchIn = btn.getAttribute('data-search-in');
+            var filterGroup = document.getElementById('searchInFilter');
+            if (filterGroup) {
+                filterGroup.querySelectorAll('.filter-chip').forEach(function(c) { c.classList.remove('active'); });
+                var target = filterGroup.querySelector('[data-value="' + searchIn + '"]');
+                if (target) {
+                    target.classList.add('active');
+                }
+            }
+            var hiddenInput = document.getElementById('searchInInput');
+            if (hiddenInput) hiddenInput.value = searchIn;
+            var mediaFilters = document.getElementById('mediaSpecificFilters');
+            if (mediaFilters) {
+                mediaFilters.style.display = (searchIn === 'media') ? '' : 'none';
+            }
+            var si = document.getElementById('searchMainInput');
+            if (si && si.value.trim().length > 0) {
+                htmx.trigger('#searchForm', 'submit');
+            }
+        });
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
This PR adds a new unified search mode that allows users to search across users, lists, and media simultaneously, displaying results grouped by category. This becomes the default search behavior when no specific category is selected.

## Key Changes
- **New search template and handler**: Added `HXSearchAllTemplate` struct and `hx_search_all_inner()` function to handle combined searches across all three content types
- **Parallel search execution**: Uses `tokio::join!()` to execute three Meilisearch queries concurrently for users, lists, and media with appropriate visibility filters
- **New template file**: Created `hx-search-all.html` that displays results grouped by category (Users, Lists, Media) with section headers, result counts, and "See all" buttons for each category
- **Updated search UI**: Modified `search.html` to make "All" the default active filter (changed from empty string to "all"), reordered filter chips to show "All" first, and added logic to hide media-specific filters when not searching media
- **Dynamic filter visibility**: Media-specific filters now only display when the "Media" search type is selected
- **Result navigation**: Added JavaScript handler for "See all" buttons that switches the active filter and re-triggers the search with the selected category
- **Styling**: Added CSS classes for search section headers (`.search-section-header`, `.search-section-title`) to visually separate result categories

## Implementation Details
- Each search type (users, lists, media) respects appropriate visibility filters based on user authentication status
- Result limits are optimized per category: 10 users, 10 lists, 20 media items
- Query time is tracked as the maximum processing time across all three searches
- Empty state handling displays a friendly message when no results are found across all categories
- The "See all" buttons preserve the search term and switch to category-specific search views

https://claude.ai/code/session_01KQQKz5Z1a4CTwaYLRmfk4j