### PR TITLE
Refactor Docker CI workflow to build dev images on all branches

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,12 +2,34 @@ name: Docker Image CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["**"]
   pull_request:
     branches: ["main"]
 
 jobs:
+  build-dev:
+    if: github.ref != 'refs/heads/main' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKERPW }}" | docker login -u "panmourovaty" --password-stdin
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: panmourovaty/rustvideoplatform:dev
+
   build-primary:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -36,10 +58,9 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           touch "/tmp/digests/${DIGEST#sha256:}"
@@ -47,7 +68,6 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v6
         with:
           name: digest-${{ env.PLATFORM_PAIR }}
@@ -56,6 +76,7 @@ jobs:
           retention-days: 1
 
   build-secondary:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -87,10 +108,9 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+          outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           touch "/tmp/digests/${DIGEST#sha256:}"
@@ -98,7 +118,6 @@ jobs:
           DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v6
         with:
           name: digest-${{ env.PLATFORM_PAIR }}
@@ -108,7 +127,6 @@ jobs:
 
   merge-primary:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     needs: build-primary
 
     steps:
@@ -134,7 +152,6 @@ jobs:
 
   merge-full:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     needs: [build-primary, build-secondary]
 
     steps:


### PR DESCRIPTION
## Summary
Refactored the Docker Image CI workflow to support building development images on all branches while maintaining separate build pipelines for the main branch. This enables continuous image builds across the entire development workflow.

## Key Changes
- **Expanded push trigger**: Changed push trigger from `main` branch only to all branches (`**`) to enable CI runs on feature branches
- **New dev build job**: Added `build-dev` job that builds and pushes images tagged as `dev` for non-main branches and pull requests
- **Conditional job execution**: 
  - `build-primary` and `build-secondary` now only run on main branch (non-PR pushes)
  - `build-dev` only runs on non-main branches or pull requests
  - `merge-primary` and `merge-full` removed their explicit `if` conditions since they're already gated by their dependencies
- **Simplified build outputs**: Removed conditional `push` parameter from build-primary and build-secondary jobs since they now only run when pushing is desired
- **Removed redundant conditions**: Eliminated `if: github.event_name != 'pull_request'` from digest export and upload steps in build jobs, as these are now only executed in appropriate contexts

## Implementation Details
- The dev build job uses a single `linux/amd64` platform for faster iteration on feature branches
- Main branch builds continue to use multi-platform builds (primary and secondary jobs)
- All conditional logic is now centralized at the job level rather than scattered across individual steps

https://claude.ai/code/session_01UC91gPSKjhiKA1nHB3pc1f