### PR TITLE
Update list link path from /list to /l in search suggestions

### DIFF
--- a/templates/pages/hx-searchsuggestions.html
+++ b/templates/pages/hx-searchsuggestions.html
@@ -26,7 +26,7 @@
     <i class="fa-solid fa-list me-2"></i>Lists
 </li>
 {% for list in lists %}
-<a href="/list/{{ list.id }}" class="text-decoration-none suggestionitem" preload="mouseover">
+<a href="/l/{{ list.id }}" class="text-decoration-none suggestionitem" preload="mouseover">
     <li class="d-flex align-items-center gap-2 py-1 px-2">
         <div class="d-flex align-items-center justify-content-center bg-secondary rounded" style="width:32px;height:32px;flex-shrink:0;">
             <i class="fa-solid fa-list fa-xs text-white"></i>


### PR DESCRIPTION
## Summary
Updated the URL path for list links in the search suggestions template to use the shorter `/l/` route instead of `/list/`.

## Changes
- Changed list link href from `/list/{{ list.id }}` to `/l/{{ list.id }}` in the search suggestions template

## Details
This change updates the search suggestions component to use a shortened URL path for accessing lists. This appears to be part of a URL routing optimization or refactoring to use more concise paths throughout the application.

https://claude.ai/code/session_01MHXRxitc61jUMZYRxVZQLL