### PR TITLE
Update thumbnail filename and add serde default for likes field

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -4,6 +4,7 @@ struct MeiliMedia {
     name: String,
     owner: String,
     views: i64,
+    #[serde(default)]
     likes: i64,
     #[serde(default)]
     dislikes: i64,

--- a/templates/pages/hx-search-all.html
+++ b/templates/pages/hx-search-all.html
@@ -11,7 +11,7 @@
 <a href="/u/{{ hit.login }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
     <div class="search-card-thumbnail" style="display:flex;align-items:center;justify-content:center;">
         {% if hit.profile_picture.is_some() %}
-        <img src="{{ config.source_server_url }}/source/{{ hit.profile_picture.clone().unwrap() }}/thumbnail-small.avif" loading="lazy" style="width:100%;height:100%;object-fit:cover;" />
+        <img src="{{ config.source_server_url }}/source/{{ hit.profile_picture.clone().unwrap() }}/thumbnail-sm.avif" loading="lazy" style="width:100%;height:100%;object-fit:cover;" />
         {% else %}
         <i class="fa-solid fa-user fa-3x text-secondary"></i>
         {% endif %}

--- a/templates/pages/hx-search-users.html
+++ b/templates/pages/hx-search-users.html
@@ -8,7 +8,7 @@
 <a href="/u/{{ hit.login }}" class="search-result-card inf-scroll-reveal" preload="mouseover">
     <div class="search-card-thumbnail" style="display:flex;align-items:center;justify-content:center;">
         {% if hit.profile_picture.is_some() %}
-        <img src="{{ config.source_server_url }}/source/{{ hit.profile_picture.clone().unwrap() }}/thumbnail-small.avif" loading="lazy" style="width:100%;height:100%;object-fit:cover;" />
+        <img src="{{ config.source_server_url }}/source/{{ hit.profile_picture.clone().unwrap() }}/thumbnail-sm.avif" loading="lazy" style="width:100%;height:100%;object-fit:cover;" />
         {% else %}
         <i class="fa-solid fa-user fa-3x text-secondary"></i>
         {% endif %}


### PR DESCRIPTION
## Summary
This PR makes two small but important updates: standardizing the thumbnail filename convention and improving deserialization robustness for the media search results.

## Key Changes
- **Thumbnail filename update**: Changed `thumbnail-small.avif` to `thumbnail-sm.avif` in user search result templates (`hx-search-all.html` and `hx-search-users.html`) to match the actual filename convention used by the source server
- **Serde deserialization fix**: Added `#[serde(default)]` attribute to the `likes` field in the `MeiliMedia` struct to handle cases where the field may be missing from API responses, making it consistent with the existing `dislikes` field handling

## Implementation Details
The serde default for the `likes` field ensures that if the field is absent from the JSON response, it will default to `0` (the default value for `i64`) rather than causing a deserialization error. This improves API compatibility and resilience.

https://claude.ai/code/session_01HtDwLUXADaeghVXxsZGLfG