### PR TITLE
Migrate database from PostgreSQL to SurrealDB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tower = "*"
 tower-http = { version = "*", features = ["fs"] }
 memory-serve = "1"
 serde = { version = "1.0", features = ["derive"] }
-sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "json"] }
+surrealdb = { version = "2", features = ["protocol-ws", "rustls"] }
 askama = { version = "0.15", features = ["serde_json"] }
 serde_json = "*"
 minify-html-onepass = "0.18"

--- a/example-deployment/config.json
+++ b/example-deployment/config.json
@@ -1,5 +1,9 @@
 {
-    "dbconnection":"postgresql://vids:SECRET_PASSWORD_HERE@postgres:5432/vids",
+    "surrealdb_url": "ws://surrealdb:8000",
+    "surrealdb_ns": "main",
+    "surrealdb_db": "main",
+    "surrealdb_user": "root",
+    "surrealdb_pass": "SECRET_PASSWORD_HERE",
     "redis_url": "redis://dragonfly:6379",
     "instancename":"vids.cz",
     "welcome":"Welcome to our experimental open-source multimedia sharing platform! Dive into a vibrant community where creativity knows no bounds. Whether you're a photographer, musician, filmmaker, or digital artist, our site offers the perfect space to showcase your work, connect with like-minded individuals, and explore an endless stream of inspiration. Join us today and start sharing your creativity with the world!",

--- a/example-deployment/docker-compose.yml
+++ b/example-deployment/docker-compose.yml
@@ -9,9 +9,12 @@ services:
      - ./config.json:/config.json
    restart: always
    depends_on:
-     - postgres
-     - meilisearch
-     - indexer
+     surrealdb:
+       condition: service_healthy
+     meilisearch:
+       condition: service_started
+     indexer:
+       condition: service_started
  source:
    image: nginx:alpine
    ports:
@@ -29,35 +32,66 @@ services:
    devices:
      - /dev/dri/renderD128:/dev/dri/renderD128
    depends_on:
-     - postgres
-     - whisper
-     - translatellama
+     surrealdb:
+       condition: service_healthy
+     whisper:
+       condition: service_started
+     translatellama:
+       condition: service_started
  indexer:
    image: panmourovaty/rustvideoplatform-indexer
    volumes:
      - ./config.json:/config.json
    restart: always
    depends_on:
-     - postgres
-     - meilisearch
-     - dragonfly
+     surrealdb:
+       condition: service_healthy
+     meilisearch:
+       condition: service_started
+     dragonfly:
+       condition: service_started
  dragonfly:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly
-    volumes:
-      - ./dragonfly:/data
- postgres:
-    image: postgres:18-alpine
-    ports:
-      - "5432:5432"
-    volumes:
-      - ./postgres:/var/lib/postgresql
-    restart: always
-    environment:
-      - POSTGRES_PASSWORD=SECRET_PASSWORD
-      - POSTGRES_USER=vids
-      - POSTGRES_DB=vids
+   image: docker.dragonflydb.io/dragonflydb/dragonfly
+   restart: always
+   volumes:
+     - ./dragonfly:/data
+ surrealdb:
+   image: surrealdb/surrealdb:latest
+   restart: always
+   ports:
+     - "8000:8000"
+   volumes:
+     - ./surrealdb:/mydata
+   command:
+     - start
+     - --log=info
+     - --user=root
+     - --pass=SECRET_PASSWORD
+     - rocksdb:/mydata/database.db
+   healthcheck:
+     test: ["CMD", "/surreal", "isready", "--conn", "http://localhost:8000"]
+     interval: 5s
+     timeout: 5s
+     retries: 10
+ db-init:
+   image: surrealdb/surrealdb:latest
+   restart: "no"
+   volumes:
+     - ../schema.surql:/schema.surql:ro
+   command:
+     - import
+     - --conn=http://surrealdb:8000
+     - --user=root
+     - --pass=SECRET_PASSWORD
+     - --ns=main
+     - --db=main
+     - /schema.surql
+   depends_on:
+     surrealdb:
+       condition: service_healthy
  meilisearch:
    image: getmeili/meilisearch:latest
+   restart: always
    environment:
      - http_proxy
      - https_proxy

--- a/schema.surql
+++ b/schema.surql
@@ -1,104 +1,163 @@
 -- SurrealDB 3.0 Schema for rustvideoplatform
--- Apply with: surreal import --conn ws://localhost:8000 --user root --pass root --ns main --db main schema.surql
+-- Run once against your SurrealDB instance to create all tables, fields, and indexes.
+--
+-- Usage:
+--   surreal import \
+--     --conn ws://localhost:8000 \
+--     --user root --pass root \
+--     --ns main --db main \
+--     schema.surql
 
 -- ─── Users ───────────────────────────────────────────────────────────────────
-DEFINE TABLE users SCHEMAFULL;
-DEFINE FIELD name              ON users TYPE string;
-DEFINE FIELD password_hash     ON users TYPE string;
-DEFINE FIELD profile_picture   ON users TYPE option<string>;
-DEFINE FIELD totp_enabled      ON users TYPE bool DEFAULT false;
-DEFINE FIELD totp_secret       ON users TYPE option<string>;
-DEFINE FIELD created           ON users TYPE int DEFAULT time::unix(time::now());
+-- Record ID is the login name: users:alice
+DEFINE TABLE users SCHEMAFULL
+  PERMISSIONS
+    FOR select WHERE true,
+    FOR create, update, delete WHERE $auth.id = id;
+
+DEFINE FIELD name              ON TABLE users TYPE string;
+DEFINE FIELD password_hash     ON TABLE users TYPE string;
+DEFINE FIELD profile_picture   ON TABLE users TYPE option<string>;
+DEFINE FIELD totp_enabled      ON TABLE users TYPE bool    DEFAULT false;
+DEFINE FIELD totp_secret       ON TABLE users TYPE option<string>;
+DEFINE FIELD created           ON TABLE users TYPE int     DEFAULT time::unix(time::now());
 
 -- ─── Media ───────────────────────────────────────────────────────────────────
-DEFINE TABLE media SCHEMAFULL;
-DEFINE FIELD name                 ON media TYPE string;
-DEFINE FIELD description          ON media TYPE string DEFAULT '';
-DEFINE FIELD owner                ON media TYPE string;
-DEFINE FIELD type                 ON media TYPE string;    -- video | audio | picture | document_pdf
-DEFINE FIELD visibility           ON media TYPE string DEFAULT 'hidden';  -- public | hidden | restricted
-DEFINE FIELD restricted_to_group  ON media TYPE option<string>;
-DEFINE FIELD views                ON media TYPE int DEFAULT 0;
-DEFINE FIELD upload               ON media TYPE int DEFAULT time::unix(time::now());
-DEFINE FIELD public               ON media TYPE bool DEFAULT false;
+-- Record ID is the randomly-generated media ID: media:abc123
+DEFINE TABLE media SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE INDEX media_owner_idx   ON media FIELDS owner;
-DEFINE INDEX media_upload_idx  ON media FIELDS upload;
+DEFINE FIELD name                 ON TABLE media TYPE string;
+DEFINE FIELD description          ON TABLE media TYPE string  DEFAULT '';
+DEFINE FIELD owner                ON TABLE media TYPE string;
+DEFINE FIELD type                 ON TABLE media TYPE string;
+  -- Accepted values: video | audio | picture | document_pdf
+DEFINE FIELD visibility           ON TABLE media TYPE string  DEFAULT 'hidden';
+  -- Accepted values: public | hidden | restricted
+DEFINE FIELD restricted_to_group  ON TABLE media TYPE option<string>;
+  -- Accepted values: __all_registered__ | __subscribers__ | <user_group id>
+DEFINE FIELD views                ON TABLE media TYPE int     DEFAULT 0;
+DEFINE FIELD upload               ON TABLE media TYPE int     DEFAULT time::unix(time::now());
+DEFINE FIELD public               ON TABLE media TYPE bool    DEFAULT false;
+
+DEFINE INDEX media_owner_idx   ON TABLE media FIELDS owner;
+DEFINE INDEX media_upload_idx  ON TABLE media FIELDS upload;
 
 -- ─── Media Likes / Dislikes ──────────────────────────────────────────────────
-DEFINE TABLE media_likes SCHEMAFULL;
-DEFINE FIELD media_id    ON media_likes TYPE string;
-DEFINE FIELD user_login  ON media_likes TYPE string;
-DEFINE FIELD reaction    ON media_likes TYPE string;   -- like | dislike
+-- UPSERT media_likes SET media_id=$mid, user_login=$user, reaction='like'
+-- UNIQUE index prevents duplicate reactions per user per media item.
+DEFINE TABLE media_likes SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE INDEX media_likes_media_user ON media_likes FIELDS media_id, user_login UNIQUE;
+DEFINE FIELD media_id    ON TABLE media_likes TYPE string;
+DEFINE FIELD user_login  ON TABLE media_likes TYPE string;
+DEFINE FIELD reaction    ON TABLE media_likes TYPE string;
+  -- Accepted values: like | dislike
+
+DEFINE INDEX media_likes_media_user ON TABLE media_likes FIELDS media_id, user_login UNIQUE;
+DEFINE INDEX media_likes_media_idx  ON TABLE media_likes FIELDS media_id;
 
 -- ─── Comments ────────────────────────────────────────────────────────────────
-DEFINE TABLE comments SCHEMAFULL;
-DEFINE FIELD media   ON comments TYPE string;
-DEFINE FIELD author  ON comments TYPE string;
-DEFINE FIELD text    ON comments TYPE string;
-DEFINE FIELD time    ON comments TYPE int DEFAULT time::unix(time::now());
+DEFINE TABLE comments SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE INDEX comments_media_idx ON comments FIELDS media;
+DEFINE FIELD media   ON TABLE comments TYPE string;
+DEFINE FIELD author  ON TABLE comments TYPE string;
+DEFINE FIELD text    ON TABLE comments TYPE string;
+DEFINE FIELD time    ON TABLE comments TYPE int DEFAULT time::unix(time::now());
+
+DEFINE INDEX comments_media_idx ON TABLE comments FIELDS media;
+DEFINE INDEX comments_time_idx  ON TABLE comments FIELDS time;
 
 -- ─── Subscriptions ───────────────────────────────────────────────────────────
-DEFINE TABLE subscriptions SCHEMAFULL;
-DEFINE FIELD subscriber ON subscriptions TYPE string;
-DEFINE FIELD target     ON subscriptions TYPE string;
+-- Composite record ID: subscriptions:[$subscriber, $target]
+-- UPSERT subscriptions:[$subscriber,$target] SET subscriber=$sub, target=$tgt
+DEFINE TABLE subscriptions SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE INDEX subscriptions_sub_target ON subscriptions FIELDS subscriber, target UNIQUE;
-DEFINE INDEX subscriptions_target_idx ON subscriptions FIELDS target;
+DEFINE FIELD subscriber ON TABLE subscriptions TYPE string;
+DEFINE FIELD target     ON TABLE subscriptions TYPE string;
+
+DEFINE INDEX subscriptions_sub_target ON TABLE subscriptions FIELDS subscriber, target UNIQUE;
+DEFINE INDEX subscriptions_subscriber ON TABLE subscriptions FIELDS subscriber;
+DEFINE INDEX subscriptions_target     ON TABLE subscriptions FIELDS target;
 
 -- ─── User Groups ─────────────────────────────────────────────────────────────
-DEFINE TABLE user_groups SCHEMAFULL;
-DEFINE FIELD name     ON user_groups TYPE string;
-DEFINE FIELD owner    ON user_groups TYPE string;
-DEFINE FIELD created  ON user_groups TYPE int DEFAULT time::unix(time::now());
+-- Record ID is a randomly-generated ID: user_groups:xyz789
+DEFINE TABLE user_groups SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE TABLE user_group_members SCHEMAFULL;
-DEFINE FIELD group_id   ON user_group_members TYPE string;
-DEFINE FIELD user_login ON user_group_members TYPE string;
+DEFINE FIELD name     ON TABLE user_groups TYPE string;
+DEFINE FIELD owner    ON TABLE user_groups TYPE string;
+DEFINE FIELD created  ON TABLE user_groups TYPE int DEFAULT time::unix(time::now());
 
-DEFINE INDEX ugm_group_user ON user_group_members FIELDS group_id, user_login UNIQUE;
-DEFINE INDEX ugm_user_idx   ON user_group_members FIELDS user_login;
+DEFINE INDEX user_groups_owner_idx   ON TABLE user_groups FIELDS owner;
+DEFINE INDEX user_groups_created_idx ON TABLE user_groups FIELDS created;
+
+-- ─── User Group Members ──────────────────────────────────────────────────────
+DEFINE TABLE user_group_members SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
+
+DEFINE FIELD group_id   ON TABLE user_group_members TYPE string;
+DEFINE FIELD user_login ON TABLE user_group_members TYPE string;
+
+DEFINE INDEX ugm_group_user ON TABLE user_group_members FIELDS group_id, user_login UNIQUE;
+DEFINE INDEX ugm_user_idx   ON TABLE user_group_members FIELDS user_login;
+DEFINE INDEX ugm_group_idx  ON TABLE user_group_members FIELDS group_id;
 
 -- ─── Lists ───────────────────────────────────────────────────────────────────
-DEFINE TABLE lists SCHEMAFULL;
-DEFINE FIELD name                ON lists TYPE string;
-DEFINE FIELD owner               ON lists TYPE string;
-DEFINE FIELD public              ON lists TYPE bool DEFAULT false;
-DEFINE FIELD visibility          ON lists TYPE string DEFAULT 'hidden';
-DEFINE FIELD restricted_to_group ON lists TYPE option<string>;
-DEFINE FIELD created             ON lists TYPE int DEFAULT time::unix(time::now());
+-- Record ID is a randomly-generated ID: lists:abc123
+DEFINE TABLE lists SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE INDEX lists_owner_idx   ON lists FIELDS owner;
-DEFINE INDEX lists_created_idx ON lists FIELDS created;
+DEFINE FIELD name                ON TABLE lists TYPE string;
+DEFINE FIELD owner               ON TABLE lists TYPE string;
+DEFINE FIELD public              ON TABLE lists TYPE bool   DEFAULT false;
+DEFINE FIELD visibility          ON TABLE lists TYPE string DEFAULT 'hidden';
+  -- Accepted values: public | hidden | restricted
+DEFINE FIELD restricted_to_group ON TABLE lists TYPE option<string>;
+DEFINE FIELD created             ON TABLE lists TYPE int    DEFAULT time::unix(time::now());
 
-DEFINE TABLE list_items SCHEMAFULL;
-DEFINE FIELD list_id  ON list_items TYPE string;
-DEFINE FIELD media_id ON list_items TYPE string;
-DEFINE FIELD position ON list_items TYPE int DEFAULT 0;
+DEFINE INDEX lists_owner_idx   ON TABLE lists FIELDS owner;
+DEFINE INDEX lists_created_idx ON TABLE lists FIELDS created;
 
-DEFINE INDEX list_items_list_idx ON list_items FIELDS list_id;
+-- ─── List Items ──────────────────────────────────────────────────────────────
+DEFINE TABLE list_items SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
--- ─── Media Concepts (processing queue) ───────────────────────────────────────
-DEFINE TABLE media_concepts SCHEMAFULL;
-DEFINE FIELD name      ON media_concepts TYPE string;
-DEFINE FIELD owner     ON media_concepts TYPE string;
-DEFINE FIELD type      ON media_concepts TYPE string;  -- video | audio | picture | document_pdf | vtt_translate
-DEFINE FIELD processed ON media_concepts TYPE bool DEFAULT false;
+DEFINE FIELD list_id  ON TABLE list_items TYPE string;
+DEFINE FIELD media_id ON TABLE list_items TYPE string;
+DEFINE FIELD position ON TABLE list_items TYPE int DEFAULT 0;
 
-DEFINE INDEX media_concepts_processed ON media_concepts FIELDS processed;
+DEFINE INDEX list_items_list_pos ON TABLE list_items FIELDS list_id, position;
+DEFINE INDEX list_items_list_idx ON TABLE list_items FIELDS list_id;
 
--- ─── WebAuthn Credentials ────────────────────────────────────────────────────
-DEFINE TABLE webauthn_credentials SCHEMAFULL;
-DEFINE FIELD user_login      ON webauthn_credentials TYPE string;
-DEFINE FIELD credential_name ON webauthn_credentials TYPE string;
-DEFINE FIELD passkey         ON webauthn_credentials TYPE string;  -- JSON-serialised Passkey
-DEFINE FIELD created         ON webauthn_credentials TYPE int DEFAULT time::unix(time::now());
+-- ─── Media Concepts (processing job queue) ───────────────────────────────────
+-- Record ID is the upload filename / concept slug.
+-- The processor polls: SELECT id, type FROM media_concepts WHERE processed = false
+DEFINE TABLE media_concepts SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
 
-DEFINE INDEX webauthn_user_idx ON webauthn_credentials FIELDS user_login;
+DEFINE FIELD name      ON TABLE media_concepts TYPE string;
+DEFINE FIELD owner     ON TABLE media_concepts TYPE string;
+DEFINE FIELD type      ON TABLE media_concepts TYPE string;
+  -- Accepted values: video | audio | picture | document_pdf | vtt_translate
+DEFINE FIELD processed ON TABLE media_concepts TYPE bool DEFAULT false;
 
--- ─── Session Tokens ──────────────────────────────────────────────────────────
--- Sessions are stored in Redis; no SurrealDB table needed.
+DEFINE INDEX media_concepts_processed ON TABLE media_concepts FIELDS processed;
+DEFINE INDEX media_concepts_owner_idx ON TABLE media_concepts FIELDS owner;
+
+-- ─── WebAuthn / Passkey Credentials ─────────────────────────────────────────
+-- Record ID is user-provided credential name.
+DEFINE TABLE webauthn_credentials SCHEMAFULL
+  PERMISSIONS FOR select, create, update, delete WHERE true;
+
+DEFINE FIELD user_login      ON TABLE webauthn_credentials TYPE string;
+DEFINE FIELD credential_name ON TABLE webauthn_credentials TYPE string;
+DEFINE FIELD passkey         ON TABLE webauthn_credentials TYPE string;
+  -- JSON-serialised webauthn_rs Passkey struct
+DEFINE FIELD created         ON TABLE webauthn_credentials TYPE int DEFAULT time::unix(time::now());
+
+DEFINE INDEX webauthn_user_idx ON TABLE webauthn_credentials FIELDS user_login;
+
+-- ─── End of schema ───────────────────────────────────────────────────────────

--- a/schema.surql
+++ b/schema.surql
@@ -8,6 +8,26 @@
 --     --ns main --db main \
 --     schema.surql
 
+-- ─── Visibility helper function ──────────────────────────────────────────────
+-- Returns true if a resource is visible to $viewer.
+-- $viewer is the user's login string, or '' for anonymous.
+-- Used in WHERE clauses as: fn::visible_to(visibility, restricted_to_group, owner, $viewer)
+DEFINE FUNCTION fn::visible_to(
+    $visibility: string,
+    $rtg: option<string>,
+    $owner: string,
+    $viewer: string
+) {
+    RETURN $visibility = 'public'
+        OR ($visibility = 'restricted' AND (
+            $rtg IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $viewer)
+            OR ($rtg = '__all_registered__' AND string::len($viewer) > 0)
+            OR ($rtg = '__subscribers__'
+                AND string::len($viewer) > 0
+                AND $owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $viewer))
+        ));
+} PERMISSIONS FULL;
+
 -- ─── Users ───────────────────────────────────────────────────────────────────
 -- Record ID is the login name: users:alice
 DEFINE TABLE users SCHEMAFULL
@@ -39,9 +59,14 @@ DEFINE FIELD restricted_to_group  ON TABLE media TYPE option<string>;
 DEFINE FIELD views                ON TABLE media TYPE int     DEFAULT 0;
 DEFINE FIELD upload               ON TABLE media TYPE int     DEFAULT time::unix(time::now());
 DEFINE FIELD public               ON TABLE media TYPE bool    DEFAULT false;
+-- Denormalized reaction counts kept in sync by the media_likes_changed event below.
+-- Always prefer reading these fields over counting media_likes rows at query time.
+DEFINE FIELD likes_count          ON TABLE media TYPE int     DEFAULT 0;
+DEFINE FIELD dislikes_count       ON TABLE media TYPE int     DEFAULT 0;
 
-DEFINE INDEX media_owner_idx   ON TABLE media FIELDS owner;
-DEFINE INDEX media_upload_idx  ON TABLE media FIELDS upload;
+DEFINE INDEX media_owner_idx      ON TABLE media FIELDS owner;
+DEFINE INDEX media_upload_idx     ON TABLE media FIELDS upload;
+DEFINE INDEX media_likes_idx      ON TABLE media FIELDS likes_count;
 
 -- ─── Media Likes / Dislikes ──────────────────────────────────────────────────
 -- UPSERT media_likes SET media_id=$mid, user_login=$user, reaction='like'
@@ -56,6 +81,17 @@ DEFINE FIELD reaction    ON TABLE media_likes TYPE string;
 
 DEFINE INDEX media_likes_media_user ON TABLE media_likes FIELDS media_id, user_login UNIQUE;
 DEFINE INDEX media_likes_media_idx  ON TABLE media_likes FIELDS media_id;
+
+-- Keep likes_count / dislikes_count on the parent media record up to date
+-- whenever a reaction is inserted, updated, or deleted.
+DEFINE EVENT media_likes_changed ON TABLE media_likes
+  WHEN $event = "CREATE" OR $event = "UPDATE" OR $event = "DELETE"
+  THEN {
+    LET $mid = IF $event = "DELETE" THEN $before.media_id ELSE $after.media_id END;
+    UPDATE type::thing('media', $mid) SET
+      likes_count    = array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'like')),
+      dislikes_count = array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'dislike'));
+  };
 
 -- ─── Comments ────────────────────────────────────────────────────────────────
 DEFINE TABLE comments SCHEMAFULL

--- a/schema.surql
+++ b/schema.surql
@@ -1,0 +1,104 @@
+-- SurrealDB 3.0 Schema for rustvideoplatform
+-- Apply with: surreal import --conn ws://localhost:8000 --user root --pass root --ns main --db main schema.surql
+
+-- ─── Users ───────────────────────────────────────────────────────────────────
+DEFINE TABLE users SCHEMAFULL;
+DEFINE FIELD name              ON users TYPE string;
+DEFINE FIELD password_hash     ON users TYPE string;
+DEFINE FIELD profile_picture   ON users TYPE option<string>;
+DEFINE FIELD totp_enabled      ON users TYPE bool DEFAULT false;
+DEFINE FIELD totp_secret       ON users TYPE option<string>;
+DEFINE FIELD created           ON users TYPE int DEFAULT time::unix(time::now());
+
+-- ─── Media ───────────────────────────────────────────────────────────────────
+DEFINE TABLE media SCHEMAFULL;
+DEFINE FIELD name                 ON media TYPE string;
+DEFINE FIELD description          ON media TYPE string DEFAULT '';
+DEFINE FIELD owner                ON media TYPE string;
+DEFINE FIELD type                 ON media TYPE string;    -- video | audio | picture | document_pdf
+DEFINE FIELD visibility           ON media TYPE string DEFAULT 'hidden';  -- public | hidden | restricted
+DEFINE FIELD restricted_to_group  ON media TYPE option<string>;
+DEFINE FIELD views                ON media TYPE int DEFAULT 0;
+DEFINE FIELD upload               ON media TYPE int DEFAULT time::unix(time::now());
+DEFINE FIELD public               ON media TYPE bool DEFAULT false;
+
+DEFINE INDEX media_owner_idx   ON media FIELDS owner;
+DEFINE INDEX media_upload_idx  ON media FIELDS upload;
+
+-- ─── Media Likes / Dislikes ──────────────────────────────────────────────────
+DEFINE TABLE media_likes SCHEMAFULL;
+DEFINE FIELD media_id    ON media_likes TYPE string;
+DEFINE FIELD user_login  ON media_likes TYPE string;
+DEFINE FIELD reaction    ON media_likes TYPE string;   -- like | dislike
+
+DEFINE INDEX media_likes_media_user ON media_likes FIELDS media_id, user_login UNIQUE;
+
+-- ─── Comments ────────────────────────────────────────────────────────────────
+DEFINE TABLE comments SCHEMAFULL;
+DEFINE FIELD media   ON comments TYPE string;
+DEFINE FIELD author  ON comments TYPE string;
+DEFINE FIELD text    ON comments TYPE string;
+DEFINE FIELD time    ON comments TYPE int DEFAULT time::unix(time::now());
+
+DEFINE INDEX comments_media_idx ON comments FIELDS media;
+
+-- ─── Subscriptions ───────────────────────────────────────────────────────────
+DEFINE TABLE subscriptions SCHEMAFULL;
+DEFINE FIELD subscriber ON subscriptions TYPE string;
+DEFINE FIELD target     ON subscriptions TYPE string;
+
+DEFINE INDEX subscriptions_sub_target ON subscriptions FIELDS subscriber, target UNIQUE;
+DEFINE INDEX subscriptions_target_idx ON subscriptions FIELDS target;
+
+-- ─── User Groups ─────────────────────────────────────────────────────────────
+DEFINE TABLE user_groups SCHEMAFULL;
+DEFINE FIELD name     ON user_groups TYPE string;
+DEFINE FIELD owner    ON user_groups TYPE string;
+DEFINE FIELD created  ON user_groups TYPE int DEFAULT time::unix(time::now());
+
+DEFINE TABLE user_group_members SCHEMAFULL;
+DEFINE FIELD group_id   ON user_group_members TYPE string;
+DEFINE FIELD user_login ON user_group_members TYPE string;
+
+DEFINE INDEX ugm_group_user ON user_group_members FIELDS group_id, user_login UNIQUE;
+DEFINE INDEX ugm_user_idx   ON user_group_members FIELDS user_login;
+
+-- ─── Lists ───────────────────────────────────────────────────────────────────
+DEFINE TABLE lists SCHEMAFULL;
+DEFINE FIELD name                ON lists TYPE string;
+DEFINE FIELD owner               ON lists TYPE string;
+DEFINE FIELD public              ON lists TYPE bool DEFAULT false;
+DEFINE FIELD visibility          ON lists TYPE string DEFAULT 'hidden';
+DEFINE FIELD restricted_to_group ON lists TYPE option<string>;
+DEFINE FIELD created             ON lists TYPE int DEFAULT time::unix(time::now());
+
+DEFINE INDEX lists_owner_idx   ON lists FIELDS owner;
+DEFINE INDEX lists_created_idx ON lists FIELDS created;
+
+DEFINE TABLE list_items SCHEMAFULL;
+DEFINE FIELD list_id  ON list_items TYPE string;
+DEFINE FIELD media_id ON list_items TYPE string;
+DEFINE FIELD position ON list_items TYPE int DEFAULT 0;
+
+DEFINE INDEX list_items_list_idx ON list_items FIELDS list_id;
+
+-- ─── Media Concepts (processing queue) ───────────────────────────────────────
+DEFINE TABLE media_concepts SCHEMAFULL;
+DEFINE FIELD name      ON media_concepts TYPE string;
+DEFINE FIELD owner     ON media_concepts TYPE string;
+DEFINE FIELD type      ON media_concepts TYPE string;  -- video | audio | picture | document_pdf | vtt_translate
+DEFINE FIELD processed ON media_concepts TYPE bool DEFAULT false;
+
+DEFINE INDEX media_concepts_processed ON media_concepts FIELDS processed;
+
+-- ─── WebAuthn Credentials ────────────────────────────────────────────────────
+DEFINE TABLE webauthn_credentials SCHEMAFULL;
+DEFINE FIELD user_login      ON webauthn_credentials TYPE string;
+DEFINE FIELD credential_name ON webauthn_credentials TYPE string;
+DEFINE FIELD passkey         ON webauthn_credentials TYPE string;  -- JSON-serialised Passkey
+DEFINE FIELD created         ON webauthn_credentials TYPE int DEFAULT time::unix(time::now());
+
+DEFINE INDEX webauthn_user_idx ON webauthn_credentials FIELDS user_login;
+
+-- ─── Session Tokens ──────────────────────────────────────────────────────────
+-- Sessions are stored in Redis; no SurrealDB table needed.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -90,7 +90,7 @@ async fn hx_usermedia_page(
 }
 
 #[derive(Deserialize)]
-struct MediumRow {
+struct ChannelMediumRow {
     id: surrealdb::RecordId,
     name: String,
     owner: String,
@@ -126,7 +126,7 @@ async fn hx_usermedia_inner(
         .await
         .expect("Database error");
 
-    let rows: Vec<MediumRow> = response.take(0).expect("Database error");
+    let rows: Vec<ChannelMediumRow> = response.take(0).expect("Database error");
     let mut media: Vec<Medium> = rows
         .into_iter()
         .map(|row| Medium {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -42,8 +42,8 @@ async fn channel(
 FROM users
 WHERE login = $id;",
         )
-        .bind(("id", &userid))
-        .bind(("owner", &userid))
+        .bind(("id", userid.clone()))
+        .bind(("owner", userid.clone()))
         .await
         .expect("Database error");
 
@@ -119,8 +119,8 @@ async fn hx_usermedia_inner(
              AND fn::visible_to(visibility, restricted_to_group, owner, $user) \
              ORDER BY upload DESC LIMIT $lim START $offset",
         )
-        .bind(("owner", &userid))
-        .bind(("user", &user_login))
+        .bind(("owner", userid.clone()))
+        .bind(("user", user_login.clone()))
         .bind(("lim", limit))
         .bind(("offset", offset))
         .await

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -6,6 +6,16 @@ struct UserChannel {
     channel_picture: Option<String>,
     subscribed: Option<i64>,
 }
+
+#[derive(Deserialize)]
+struct UserChannelRow {
+    login: String,
+    name: String,
+    profile_picture: Option<String>,
+    channel_picture: Option<String>,
+    subscribed: Option<i64>,
+}
+
 #[derive(Template)]
 #[template(path = "pages/channel.html", escape = "none")]
 struct ChannelTemplate {
@@ -14,41 +24,40 @@ struct ChannelTemplate {
     common_headers: CommonHeaders,
     user: UserChannel,
 }
+
 async fn channel(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(config): Extension<Config>,
     headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = sqlx::query_as!(
-        UserChannel,
-        "SELECT
-    u.login,
-    u.name,
-    u.profile_picture,
-    u.channel_picture,
-    COALESCE(subs.count, 0) AS subscribed
-FROM
-    users u
-LEFT JOIN
-    (
-        SELECT
-            target,
-            COUNT(*) AS count
-        FROM
-            subscriptions
-        GROUP BY
-            target
-    ) subs
-ON
-    u.login = subs.target
-WHERE
-    u.login = $1;",
-        userid
-    )
-    .fetch_one(&pool)
-    .await
-    .unwrap();
+    let mut response = db
+        .query(
+            "SELECT
+    login,
+    name,
+    profile_picture,
+    channel_picture,
+    (SELECT count() FROM subscriptions WHERE target = $owner)[0].count AS subscribed
+FROM users
+WHERE login = $id;",
+        )
+        .bind(("id", &userid))
+        .bind(("owner", &userid))
+        .await
+        .expect("Database error");
+
+    let row: Option<UserChannelRow> = response.take(0).expect("Database error");
+    let row = row.expect("User not found");
+
+    let user = UserChannel {
+        login: row.login,
+        name: row.name,
+        profile_picture: row.profile_picture,
+        channel_picture: row.channel_picture,
+        subscribed: row.subscribed,
+    };
+
     let sidebar = generate_sidebar(&config, "channel".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
     let template = ChannelTemplate {
@@ -62,58 +71,83 @@ WHERE
 
 async fn hx_usermedia(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_usermedia_inner(config, pool, redis, headers, userid, 0).await
+    hx_usermedia_inner(config, db, redis, headers, userid, 0).await
 }
 
 async fn hx_usermedia_page(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((userid, page)): Path<(String, i64)>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_usermedia_inner(config, pool, redis, headers, userid, page).await
+    hx_usermedia_inner(config, db, redis, headers, userid, page).await
+}
+
+#[derive(Deserialize)]
+struct MediumRow {
+    id: surrealdb::RecordId,
+    name: String,
+    owner: String,
+    views: i64,
+    #[serde(rename = "type")]
+    r#type: String,
 }
 
 async fn hx_usermedia_inner(
     config: Config,
-    pool: PgPool,
+    db: Db,
     redis: RedisConn,
     headers: HeaderMap,
     userid: String,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, redis.clone()).await;
+    let user = get_user_login(headers, &db, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
     let offset = page * 40;
+    let limit: i64 = 41;
 
-    let mut media: Vec<Medium> = sqlx::query(
-        "SELECT id,name,owner,views,type FROM media WHERE owner=$1 AND (visibility = 'public' OR (visibility = 'restricted' AND (restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) OR (restricted_to_group = '__all_registered__' AND $2 != '') OR (restricted_to_group = '__subscribers__' AND $2 != '' AND owner IN (SELECT target FROM subscriptions WHERE subscriber = $2))))) ORDER BY upload DESC LIMIT 41 OFFSET $3;"
-    )
-    .bind(&userid)
-    .bind(&user_login)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        Medium {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            views: row.get("views"),
-            r#type: row.get("type"),
+    let mut response = db
+        .query(
+            "SELECT id, name, owner, views, type FROM media
+WHERE owner = $owner
+AND (
+    visibility = 'public'
+    OR (visibility = 'restricted' AND (
+        restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user)
+        OR (restricted_to_group = '__all_registered__' AND $user != '')
+        OR (restricted_to_group = '__subscribers__' AND $user != '' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user))
+    ))
+)
+ORDER BY upload DESC
+LIMIT $lim START $offset;",
+        )
+        .bind(("owner", &userid))
+        .bind(("user", &user_login))
+        .bind(("lim", limit))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
+
+    let rows: Vec<MediumRow> = response.take(0).expect("Database error");
+    let mut media: Vec<Medium> = rows
+        .into_iter()
+        .map(|row| Medium {
+            id: row.id.key().to_string(),
+            name: row.name,
+            owner: row.owner,
+            views: row.views,
+            r#type: row.r#type,
             sprite_filename: None,
             sprite_x: 0,
             sprite_y: 0,
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+        })
+        .collect();
 
     let has_more = media.len() == 41;
     if has_more {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -114,18 +114,10 @@ async fn hx_usermedia_inner(
 
     let mut response = db
         .query(
-            "SELECT id, name, owner, views, type FROM media
-WHERE owner = $owner
-AND (
-    visibility = 'public'
-    OR (visibility = 'restricted' AND (
-        restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user)
-        OR (restricted_to_group = '__all_registered__' AND $user != '')
-        OR (restricted_to_group = '__subscribers__' AND $user != '' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user))
-    ))
-)
-ORDER BY upload DESC
-LIMIT $lim START $offset;",
+            "SELECT id, name, owner, views, type FROM media \
+             WHERE owner = $owner \
+             AND fn::visible_to(visibility, restricted_to_group, owner, $user) \
+             ORDER BY upload DESC LIMIT $lim START $offset",
         )
         .bind(("owner", &userid))
         .bind(("user", &user_login))

--- a/src/chapters.rs
+++ b/src/chapters.rs
@@ -5,28 +5,33 @@ struct ChapterData {
 }
 
 async fn studio_chapters_get(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::Value::Array(vec![]));
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Json(serde_json::Value::Array(vec![]));
             }
         }
-        Err(_) => {
+        None => {
             return Json(serde_json::Value::Array(vec![]));
         }
     }
@@ -42,13 +47,13 @@ async fn studio_chapters_get(
 }
 
 async fn studio_chapters_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Json(chapters): Json<Vec<ChapterData>>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -58,12 +63,17 @@ async fn studio_chapters_save(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -72,7 +82,7 @@ async fn studio_chapters_save(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")

--- a/src/chapters.rs
+++ b/src/chapters.rs
@@ -20,7 +20,7 @@ async fn studio_chapters_get(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -67,7 +67,7 @@ async fn studio_chapters_save(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -1,6 +1,7 @@
 #[derive(Serialize, Deserialize)]
 struct Comment {
-    id: i64,
+    id: String,
+    #[serde(rename = "author")]
     user: String,
     user_name: String,
     user_picture: Option<String>,
@@ -24,38 +25,49 @@ struct HXCommentsTemplate {
 
 const COMMENTS_PER_PAGE: i64 = 20;
 
+#[derive(Deserialize)]
+struct CommentRow {
+    id: surrealdb::RecordId,
+    author: String,
+    user_name: String,
+    user_picture: Option<String>,
+    text: serde_json::Value,
+    time: i64,
+}
+
 async fn hx_comments(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path(mediumid): Path<String>,
     axum::extract::Query(query): axum::extract::Query<CommentsQuery>,
 ) -> axum::response::Html<Vec<u8>> {
     let page = query.page.unwrap_or(0);
     let offset = page * COMMENTS_PER_PAGE;
+    let limit = COMMENTS_PER_PAGE + 1;
 
-    let rows = sqlx::query(
-        r#"SELECT c.id, c."user", u.name as user_name, u.profile_picture as user_picture, c.text, c.time
-           FROM comments c
-           LEFT JOIN users u ON c."user" = u.login
-           WHERE c.media=$1 ORDER BY c.time DESC LIMIT $2 OFFSET $3;"#,
-    )
-    .bind(&mediumid)
-    .bind(COMMENTS_PER_PAGE + 1)
-    .bind(offset)
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query(
+            "SELECT id, author, author.name AS user_name, author.profile_picture AS user_picture, text, time \
+             FROM comments WHERE media = $media \
+             ORDER BY time DESC LIMIT $limit START $offset"
+        )
+        .bind(("media", surrealdb::RecordId::from_table_key("media", &mediumid)))
+        .bind(("limit", limit))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
 
-    use sqlx::Row;
+    let rows: Vec<CommentRow> = resp.take(0).unwrap_or_default();
+
     let comments: Vec<Comment> = rows
-        .iter()
+        .into_iter()
         .map(|row| Comment {
-            id: row.get("id"),
-            user: row.get("user"),
-            user_name: row.get("user_name"),
-            user_picture: row.get("user_picture"),
-            text: row.get("text"),
-            time: row.get("time"),
+            id: row.id.key().to_string(),
+            user: row.author,
+            user_name: row.user_name,
+            user_picture: row.user_picture,
+            text: row.text,
+            time: row.time,
         })
         .collect();
 
@@ -78,18 +90,19 @@ struct CommentForm {
 }
 
 async fn comment_delta(
-    Extension(pool): Extension<PgPool>,
-    Path(comment_id): Path<i64>,
+    Extension(db): Extension<Db>,
+    Path(comment_id): Path<String>,
 ) -> Json<serde_json::Value> {
-    let row = sqlx::query!(
-        r#"SELECT text FROM comments WHERE id=$1;"#,
-        comment_id
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
+    #[derive(Deserialize)]
+    struct TextRow { text: serde_json::Value }
 
-    Json(row.text)
+    let mut resp = db
+        .query("SELECT text FROM comments WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("comments", &comment_id)))
+        .await
+        .expect("Database error");
+    let row: Option<TextRow> = resp.take(0).expect("Database error");
+    Json(row.map(|r| r.text).unwrap_or(serde_json::Value::Null))
 }
 
 #[derive(Template)]
@@ -101,13 +114,13 @@ struct HXCommentSingleTemplate {
 
 async fn hx_add_comment(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<CommentForm>,
 ) -> impl IntoResponse {
-    let user = get_user_login(headers, &pool, redis.clone()).await;
+    let user = get_user_login(headers, &db, redis.clone()).await;
 
     if user.is_none() {
         return (StatusCode::UNAUTHORIZED, Html(Vec::new()));
@@ -118,29 +131,36 @@ async fn hx_add_comment(
     let delta: serde_json::Value =
         serde_json::from_str(&form.text).unwrap_or_default();
 
-    let row = sqlx::query(
-        r#"WITH inserted AS (
-            INSERT INTO comments (media, "user", text) VALUES ($1, $2, $3) RETURNING id, "user", text, time
-        )
-        SELECT i.id, i."user", u.name as user_name, u.profile_picture as user_picture, i.text, i.time
-        FROM inserted i
-        LEFT JOIN users u ON i."user" = u.login;"#,
-    )
-    .bind(&mediumid)
-    .bind(&user.login)
-    .bind(delta)
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
+    use chrono::Utc;
+    let now_unix = Utc::now().timestamp();
 
-    use sqlx::Row;
+    let mut resp = db
+        .query(
+            "CREATE comments SET \
+             media = $media, author = $author, text = $text, time = $time; \
+             SELECT id, author, author.name AS user_name, author.profile_picture AS user_picture, text, time \
+             FROM comments ORDER BY time DESC LIMIT 1"
+        )
+        .bind(("media", surrealdb::RecordId::from_table_key("media", &mediumid)))
+        .bind(("author", surrealdb::RecordId::from_table_key("users", &user.login)))
+        .bind(("text", delta))
+        .bind(("time", now_unix))
+        .await
+        .expect("Database error");
+
+    let rows: Vec<CommentRow> = resp.take(1).unwrap_or_default();
+    let row = match rows.into_iter().next() {
+        Some(r) => r,
+        None => return (StatusCode::INTERNAL_SERVER_ERROR, Html(Vec::new())),
+    };
+
     let comment = Comment {
-        id: row.get("id"),
-        user: row.get("user"),
-        user_name: row.get("user_name"),
-        user_picture: row.get("user_picture"),
-        text: row.get("text"),
-        time: row.get("time"),
+        id: row.id.key().to_string(),
+        user: row.author,
+        user_name: row.user_name,
+        user_picture: row.user_picture,
+        text: row.text,
+        time: row.time,
     };
 
     let template = HXCommentSingleTemplate { comment, config };

--- a/src/concept.rs
+++ b/src/concept.rs
@@ -6,13 +6,22 @@ struct MediumConcept {
     r#type: String,
 }
 
+#[derive(Deserialize)]
+struct MediumConceptRow {
+    id: surrealdb::RecordId,
+    name: String,
+    processed: bool,
+    #[serde(rename = "type")]
+    r#type: String,
+}
+
 async fn concepts(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(config): Extension<Config>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -34,21 +43,31 @@ async fn concepts(
 struct HXConceptsTemplate {
     concepts: Vec<MediumConcept>,
 }
+
 async fn hx_concepts(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let userinfo = get_user_login(headers, &pool, redis.clone()).await.unwrap();
+    let userinfo = get_user_login(headers, &db, redis.clone()).await.unwrap();
 
-    let concepts = sqlx::query_as!(
-        MediumConcept,
-        "SELECT id,name,processed,type FROM media_concepts WHERE owner = $1;",
-        userinfo.login
-    )
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut response = db
+        .query("SELECT id, name, processed, type FROM media_concepts WHERE owner = $owner;")
+        .bind(("owner", &userinfo.login))
+        .await
+        .expect("Database error");
+
+    let rows: Vec<MediumConceptRow> = response.take(0).expect("Database error");
+    let concepts: Vec<MediumConcept> = rows
+        .into_iter()
+        .map(|row| MediumConcept {
+            id: row.id.key().to_string(),
+            name: row.name,
+            processed: row.processed,
+            r#type: row.r#type,
+        })
+        .collect();
+
     let template = HXConceptsTemplate { concepts };
     Html(minifi_html(template.render().unwrap()))
 }
@@ -62,14 +81,15 @@ struct ConceptTemplate {
     common_headers: CommonHeaders,
     owner_groups: Vec<UserGroup>,
 }
+
 async fn concept(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(config): Extension<Config>,
     Extension(redis): Extension<RedisConn>,
     Path(conceptid): Path<String>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -77,28 +97,49 @@ async fn concept(
     }
     let user_info = user_info.unwrap();
 
-    let concept = sqlx::query_as!(MediumConcept,
-        "SELECT id,name,type,processed FROM media_concepts WHERE owner = $1 AND id = $2 AND processed = true;", user_info.login, conceptid
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
+    let mut response = db
+        .query(
+            "SELECT id, name, type, processed FROM media_concepts WHERE owner = $owner AND id = $id AND processed = true;",
+        )
+        .bind(("owner", &user_info.login))
+        .bind(("id", surrealdb::RecordId::from_table_key("media_concepts", &conceptid)))
+        .await
+        .expect("Database error");
+
+    let row: Option<MediumConceptRow> = response.take(0).expect("Database error");
+    let row = row.expect("Concept not found");
+    let concept = MediumConcept {
+        id: row.id.key().to_string(),
+        name: row.name,
+        processed: row.processed,
+        r#type: row.r#type,
+    };
 
     // Fetch user's groups for the dropdown (system groups + user groups)
     let mut owner_groups = system_groups_for_owner(&user_info.login);
-    let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-        .bind(&user_info.login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        })
-        .fetch_all(&pool)
+
+    #[derive(Deserialize)]
+    struct UserGroupRow {
+        id: surrealdb::RecordId,
+        name: String,
+        owner: String,
+    }
+
+    let mut grp_response = db
+        .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .bind(("owner", &user_info.login))
         .await
-        .unwrap_or_default();
+        .unwrap_or_else(|_| panic!("Database error"));
+
+    let grp_rows: Vec<UserGroupRow> = grp_response.take(0).unwrap_or_default();
+    let user_groups: Vec<UserGroup> = grp_rows
+        .into_iter()
+        .map(|row| UserGroup {
+            id: row.id.key().to_string(),
+            name: row.name,
+            owner: row.owner,
+        })
+        .collect();
     owner_groups.extend(user_groups);
 
     let sidebar = generate_sidebar(&config, "studio".to_owned());
@@ -121,25 +162,37 @@ struct PublishForm {
     medium_visibility: String,
     medium_restricted_group: Option<String>,
 }
+
 async fn publish(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(conceptid): Path<String>,
     Form(form): Form<PublishForm>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
     let user_info = user_info.unwrap();
 
-    let concept = sqlx::query_as!(MediumConcept,
-        "SELECT id,name,type,processed FROM media_concepts WHERE owner = $1 AND id = $2 AND processed = true;", user_info.login, conceptid
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
+    let mut response = db
+        .query(
+            "SELECT id, name, type, processed FROM media_concepts WHERE owner = $owner AND id = $id AND processed = true;",
+        )
+        .bind(("owner", &user_info.login))
+        .bind(("id", surrealdb::RecordId::from_table_key("media_concepts", &conceptid)))
+        .await
+        .expect("Database error");
+
+    let row: Option<MediumConceptRow> = response.take(0).expect("Database error");
+    let row = row.expect("Concept not found");
+    let concept = MediumConcept {
+        id: row.id.key().to_string(),
+        name: row.name,
+        processed: row.processed,
+        r#type: row.r#type,
+    };
 
     let concept_move = move_dir(
         format!("upload/{}_processing", conceptid).as_str(),
@@ -159,22 +212,38 @@ async fn publish(
         };
         let description: serde_json::Value =
             serde_json::from_str(&form.medium_description).unwrap();
-        let _ = sqlx::query(
-            "INSERT INTO media (id,name,description,owner,public,visibility,restricted_to_group,type) VALUES ($1,$2,$3,$4,$5,$6,$7,$8);"
-        )
-        .bind(form.medium_id.to_ascii_lowercase())
-        .bind(&form.medium_name)
-        .bind(&description)
-        .bind(&user_info.login)
-        .bind(ispublic)
-        .bind(&visibility)
-        .bind(&restricted_to_group)
-        .bind(&concept.r#type)
-        .execute(&pool)
-        .await;
-        let _ = sqlx::query!("DELETE FROM media_concepts WHERE id=$1;", concept.id)
-            .execute(&pool)
+
+        let medium_id = form.medium_id.to_ascii_lowercase();
+        let media_record_id = surrealdb::RecordId::from_table_key("media", &medium_id);
+        let _ = db
+            .query(
+                "CREATE $id SET
+    name = $name,
+    description = $description,
+    owner = $owner,
+    public = $public,
+    visibility = $visibility,
+    restricted_to_group = $restricted_to_group,
+    type = $type,
+    upload = time::unix(time::now());",
+            )
+            .bind(("id", media_record_id))
+            .bind(("name", &form.medium_name))
+            .bind(("description", &description))
+            .bind(("owner", &user_info.login))
+            .bind(("public", ispublic))
+            .bind(("visibility", &visibility))
+            .bind(("restricted_to_group", &restricted_to_group))
+            .bind(("type", &concept.r#type))
             .await;
+
+        let concept_record_id =
+            surrealdb::RecordId::from_table_key("media_concepts", &concept.id);
+        let _ = db
+            .query("DELETE $id;")
+            .bind(("id", concept_record_id))
+            .await;
+
         return Html(format!(
             "<script>window.location.replace(\"/m/{}\");</script>",
             form.medium_id

--- a/src/concept.rs
+++ b/src/concept.rs
@@ -53,7 +53,7 @@ async fn hx_concepts(
 
     let mut response = db
         .query("SELECT id, name, processed, type FROM media_concepts WHERE owner = $owner;")
-        .bind(("owner", &userinfo.login))
+        .bind(("owner", userinfo.login.clone()))
         .await
         .expect("Database error");
 
@@ -101,7 +101,7 @@ async fn concept(
         .query(
             "SELECT id, name, type, processed FROM media_concepts WHERE owner = $owner AND id = $id AND processed = true;",
         )
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("media_concepts", &conceptid)))
         .await
         .expect("Database error");
@@ -127,7 +127,7 @@ async fn concept(
 
     let mut grp_response = db
         .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .unwrap_or_else(|_| panic!("Database error"));
 
@@ -180,7 +180,7 @@ async fn publish(
         .query(
             "SELECT id, name, type, processed FROM media_concepts WHERE owner = $owner AND id = $id AND processed = true;",
         )
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("media_concepts", &conceptid)))
         .await
         .expect("Database error");
@@ -228,13 +228,13 @@ async fn publish(
     upload = time::unix(time::now());",
             )
             .bind(("id", media_record_id))
-            .bind(("name", &form.medium_name))
-            .bind(("description", &description))
-            .bind(("owner", &user_info.login))
+            .bind(("name", form.medium_name.clone()))
+            .bind(("description", description.clone()))
+            .bind(("owner", user_info.login.clone()))
             .bind(("public", ispublic))
-            .bind(("visibility", &visibility))
-            .bind(("restricted_to_group", &restricted_to_group))
-            .bind(("type", &concept.r#type))
+            .bind(("visibility", visibility.clone()))
+            .bind(("restricted_to_group", restricted_to_group.clone()))
+            .bind(("type", concept.r#type.clone()))
             .await;
 
         let concept_record_id =

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -93,7 +93,7 @@ async fn hx_studio_groups(
 
     let mut resp = db
         .query("SELECT id, name, owner, (SELECT count() FROM user_group_members WHERE group_id = $parent.id GROUP ALL)[0].count AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
 
@@ -120,9 +120,9 @@ async fn hx_create_group(
     let group_id = generate_medium_id();
 
     db.query("CREATE user_groups:[$id] SET name = $name, owner = $owner, created = time::unix(time::now());")
-        .bind(("id", &group_id))
-        .bind(("name", &form.name))
-        .bind(("owner", &user_info.login))
+        .bind(("id", group_id.clone()))
+        .bind(("name", form.name.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
 
@@ -144,7 +144,7 @@ async fn hx_create_group(
 
     let mut resp = db
         .query("SELECT id, name, owner, (SELECT count() FROM user_group_members WHERE group_id = $parent.id GROUP ALL)[0].count AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
 
@@ -181,7 +181,7 @@ async fn hx_delete_group(
 
     let mut resp = db
         .query("SELECT owner FROM user_groups WHERE id = $id;")
-        .bind(("id", &groupid))
+        .bind(("id", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -197,23 +197,23 @@ async fn hx_delete_group(
 
     // Clear group references from media and lists
     db.query("UPDATE media SET visibility = 'hidden', restricted_to_group = NONE WHERE restricted_to_group = $gid;")
-        .bind(("gid", &groupid))
+        .bind(("gid", groupid.clone()))
         .await
         .expect("Database error");
 
     db.query("UPDATE lists SET visibility = 'hidden', restricted_to_group = NONE WHERE restricted_to_group = $gid;")
-        .bind(("gid", &groupid))
+        .bind(("gid", groupid.clone()))
         .await
         .expect("Database error");
 
     // Delete members and group
     db.query("DELETE FROM user_group_members WHERE group_id = $gid;")
-        .bind(("gid", &groupid))
+        .bind(("gid", groupid.clone()))
         .await
         .expect("Database error");
 
     db.query("DELETE FROM user_groups WHERE id = $id;")
-        .bind(("id", &groupid))
+        .bind(("id", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -238,7 +238,7 @@ async fn hx_delete_group(
 
     let mut resp = db
         .query("SELECT id, name, owner, (SELECT count() FROM user_group_members WHERE group_id = $parent.id GROUP ALL)[0].count AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
 
@@ -287,7 +287,7 @@ async fn hx_group_members(
 
     let mut resp = db
         .query("SELECT id, name, owner FROM user_groups WHERE id = $id;")
-        .bind(("id", &groupid))
+        .bind(("id", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -302,7 +302,7 @@ async fn hx_group_members(
 
     let mut members_resp = db
         .query("SELECT user_login FROM user_group_members WHERE group_id = $gid ORDER BY user_login;")
-        .bind(("gid", &groupid))
+        .bind(("gid", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -337,7 +337,7 @@ async fn hx_add_group_member(
     // Verify group ownership
     let mut resp = db
         .query("SELECT id, name, owner FROM user_groups WHERE id = $id;")
-        .bind(("id", &groupid))
+        .bind(("id", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -360,7 +360,7 @@ async fn hx_add_group_member(
 
     let mut user_resp = db
         .query("SELECT login FROM users WHERE login = $login;")
-        .bind(("login", &form.user_login))
+        .bind(("login", form.user_login.clone()))
         .await
         .expect("Database error");
 
@@ -370,8 +370,8 @@ async fn hx_add_group_member(
         // Upsert member (ignore if already exists)
         let _ = db
             .query("UPSERT user_group_members:[$gid, $user] SET group_id = $gid, user_login = $user;")
-            .bind(("gid", &groupid))
-            .bind(("user", &form.user_login))
+            .bind(("gid", groupid.clone()))
+            .bind(("user", form.user_login.clone()))
             .await;
 
         // Invalidate Redis group membership cache
@@ -381,7 +381,7 @@ async fn hx_add_group_member(
     // Return updated members list
     let mut members_resp = db
         .query("SELECT user_login FROM user_group_members WHERE group_id = $gid ORDER BY user_login;")
-        .bind(("gid", &groupid))
+        .bind(("gid", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -415,7 +415,7 @@ async fn hx_remove_group_member(
     // Verify group ownership
     let mut resp = db
         .query("SELECT id, name, owner FROM user_groups WHERE id = $id;")
-        .bind(("id", &groupid))
+        .bind(("id", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -431,8 +431,8 @@ async fn hx_remove_group_member(
     }
 
     db.query("DELETE FROM user_group_members WHERE group_id = $gid AND user_login = $user;")
-        .bind(("gid", &groupid))
-        .bind(("user", &login))
+        .bind(("gid", groupid.clone()))
+        .bind(("user", login.clone()))
         .await
         .expect("Database error");
 
@@ -442,7 +442,7 @@ async fn hx_remove_group_member(
     // Return updated members list
     let mut members_resp = db
         .query("SELECT user_login FROM user_group_members WHERE group_id = $gid ORDER BY user_login;")
-        .bind(("gid", &groupid))
+        .bind(("gid", groupid.clone()))
         .await
         .expect("Database error");
 
@@ -471,7 +471,7 @@ async fn hx_user_groups_json(
 
     let mut resp = db
         .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
 

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -92,7 +92,7 @@ async fn hx_studio_groups(
     ];
 
     let mut resp = db
-        .query("SELECT id, name, owner, array::len((SELECT id FROM user_group_members WHERE group_id = $parent.id)) AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .query("SELECT id, name, owner, (SELECT count() FROM user_group_members WHERE group_id = $parent.id GROUP ALL)[0].count AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
         .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
@@ -143,7 +143,7 @@ async fn hx_create_group(
     ];
 
     let mut resp = db
-        .query("SELECT id, name, owner, array::len((SELECT id FROM user_group_members WHERE group_id = $parent.id)) AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .query("SELECT id, name, owner, (SELECT count() FROM user_group_members WHERE group_id = $parent.id GROUP ALL)[0].count AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
         .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
@@ -237,7 +237,7 @@ async fn hx_delete_group(
     ];
 
     let mut resp = db
-        .query("SELECT id, name, owner, array::len((SELECT id FROM user_group_members WHERE group_id = $parent.id)) AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .query("SELECT id, name, owner, (SELECT count() FROM user_group_members WHERE group_id = $parent.id GROUP ALL)[0].count AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
         .bind(("owner", &user_info.login))
         .await
         .expect("Database error");

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -30,11 +30,11 @@ struct AddMemberForm {
 
 async fn studio_groups(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -64,11 +64,11 @@ struct HXGroupsListTemplate {
 }
 
 async fn hx_studio_groups(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -91,22 +91,13 @@ async fn hx_studio_groups(
         },
     ];
 
-    let user_groups: Vec<UserGroupWithCount> = sqlx::query(
-        "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
-    )
-    .bind(&user_info.login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        UserGroupWithCount {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            member_count: row.get("member_count"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query("SELECT id, name, owner, array::len((SELECT id FROM user_group_members WHERE group_id = $parent.id)) AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .bind(("owner", &user_info.login))
+        .await
+        .expect("Database error");
+
+    let user_groups: Vec<UserGroupWithCount> = resp.take(0).unwrap_or_default();
 
     groups.extend(user_groups);
 
@@ -115,12 +106,12 @@ async fn hx_studio_groups(
 }
 
 async fn hx_create_group(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<CreateGroupForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -128,11 +119,10 @@ async fn hx_create_group(
 
     let group_id = generate_medium_id();
 
-    sqlx::query("INSERT INTO user_groups (id, name, owner) VALUES ($1, $2, $3);")
-        .bind(&group_id)
-        .bind(&form.name)
-        .bind(&user_info.login)
-        .execute(&pool)
+    db.query("CREATE user_groups:[$id] SET name = $name, owner = $owner, created = time::unix(time::now());")
+        .bind(("id", &group_id))
+        .bind(("name", &form.name))
+        .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
 
@@ -152,22 +142,13 @@ async fn hx_create_group(
         },
     ];
 
-    let user_groups: Vec<UserGroupWithCount> = sqlx::query(
-        "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
-    )
-    .bind(&user_info.login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        UserGroupWithCount {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            member_count: row.get("member_count"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query("SELECT id, name, owner, array::len((SELECT id FROM user_group_members WHERE group_id = $parent.id)) AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .bind(("owner", &user_info.login))
+        .await
+        .expect("Database error");
+
+    let user_groups: Vec<UserGroupWithCount> = resp.take(0).unwrap_or_default();
 
     groups.extend(user_groups);
 
@@ -176,12 +157,12 @@ async fn hx_create_group(
 }
 
 async fn hx_delete_group(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(groupid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -193,16 +174,21 @@ async fn hx_delete_group(
     }
 
     // Verify ownership
-    let owner_check: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT owner FROM user_groups WHERE id = $1;")
-        .bind(&groupid)
-        .fetch_optional(&pool)
+    #[derive(Deserialize)]
+    struct OwnerRecord {
+        owner: String,
+    }
+
+    let mut resp = db
+        .query("SELECT owner FROM user_groups WHERE id = $id;")
+        .bind(("id", &groupid))
         .await
         .expect("Database error");
 
+    let owner_check: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
+
     if let Some(row) = owner_check {
-        use sqlx::Row;
-        let owner: String = row.get("owner");
-        if owner != user_info.login {
+        if row.owner != user_info.login {
             return Html("".as_bytes().to_vec());
         }
     } else {
@@ -210,28 +196,24 @@ async fn hx_delete_group(
     }
 
     // Clear group references from media and lists
-    sqlx::query("UPDATE media SET visibility = 'hidden', restricted_to_group = NULL WHERE restricted_to_group = $1;")
-        .bind(&groupid)
-        .execute(&pool)
+    db.query("UPDATE media SET visibility = 'hidden', restricted_to_group = NONE WHERE restricted_to_group = $gid;")
+        .bind(("gid", &groupid))
         .await
         .expect("Database error");
 
-    sqlx::query("UPDATE lists SET visibility = 'hidden', restricted_to_group = NULL WHERE restricted_to_group = $1;")
-        .bind(&groupid)
-        .execute(&pool)
+    db.query("UPDATE lists SET visibility = 'hidden', restricted_to_group = NONE WHERE restricted_to_group = $gid;")
+        .bind(("gid", &groupid))
         .await
         .expect("Database error");
 
     // Delete members and group
-    sqlx::query("DELETE FROM user_group_members WHERE group_id = $1;")
-        .bind(&groupid)
-        .execute(&pool)
+    db.query("DELETE FROM user_group_members WHERE group_id = $gid;")
+        .bind(("gid", &groupid))
         .await
         .expect("Database error");
 
-    sqlx::query("DELETE FROM user_groups WHERE id = $1;")
-        .bind(&groupid)
-        .execute(&pool)
+    db.query("DELETE FROM user_groups WHERE id = $id;")
+        .bind(("id", &groupid))
         .await
         .expect("Database error");
 
@@ -254,22 +236,13 @@ async fn hx_delete_group(
         },
     ];
 
-    let user_groups: Vec<UserGroupWithCount> = sqlx::query(
-        "SELECT g.id, g.name, g.owner, (SELECT COUNT(*) FROM user_group_members gm WHERE gm.group_id = g.id) AS member_count FROM user_groups g WHERE g.owner = $1 ORDER BY g.created DESC;"
-    )
-    .bind(&user_info.login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        UserGroupWithCount {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            member_count: row.get("member_count"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query("SELECT id, name, owner, array::len((SELECT id FROM user_group_members WHERE group_id = $parent.id)) AS member_count FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .bind(("owner", &user_info.login))
+        .await
+        .expect("Database error");
+
+    let user_groups: Vec<UserGroupWithCount> = resp.take(0).unwrap_or_default();
 
     groups.extend(user_groups);
 
@@ -286,12 +259,12 @@ struct HXGroupMembersTemplate {
 }
 
 async fn hx_group_members(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(groupid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -312,37 +285,28 @@ async fn hx_group_members(
         return Html(minifi_html(template.render().unwrap()));
     }
 
-    let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
-        .bind(&groupid)
-        .fetch_optional(&pool)
+    let mut resp = db
+        .query("SELECT id, name, owner FROM user_groups WHERE id = $id;")
+        .bind(("id", &groupid))
         .await
         .expect("Database error");
 
+    let group_row: Option<UserGroup> = resp.take(0).unwrap_or_default();
+
     let group = match group_row {
-        Some(row) => {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        }
+        Some(g) => g,
         None => return Html("".as_bytes().to_vec()),
     };
 
     let is_owner = group.owner == user_info.login;
 
-    let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
-        .bind(&groupid)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            GroupMember {
-                user_login: row.get("user_login"),
-            }
-        })
-        .fetch_all(&pool)
+    let mut members_resp = db
+        .query("SELECT user_login FROM user_group_members WHERE group_id = $gid ORDER BY user_login;")
+        .bind(("gid", &groupid))
         .await
         .expect("Database error");
+
+    let members: Vec<GroupMember> = members_resp.take(0).unwrap_or_default();
 
     let template = HXGroupMembersTemplate {
         group,
@@ -353,13 +317,13 @@ async fn hx_group_members(
 }
 
 async fn hx_add_group_member(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(groupid): Path<String>,
     Form(form): Form<AddMemberForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -371,21 +335,16 @@ async fn hx_add_group_member(
     }
 
     // Verify group ownership
-    let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
-        .bind(&groupid)
-        .fetch_optional(&pool)
+    let mut resp = db
+        .query("SELECT id, name, owner FROM user_groups WHERE id = $id;")
+        .bind(("id", &groupid))
         .await
         .expect("Database error");
 
+    let group_row: Option<UserGroup> = resp.take(0).unwrap_or_default();
+
     let group = match group_row {
-        Some(row) => {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        }
+        Some(g) => g,
         None => return Html("".as_bytes().to_vec()),
     };
 
@@ -394,18 +353,25 @@ async fn hx_add_group_member(
     }
 
     // Check that the user exists
-    let user_exists: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT login FROM users WHERE login = $1;")
-        .bind(&form.user_login)
-        .fetch_optional(&pool)
+    #[derive(Deserialize)]
+    struct LoginRecord {
+        login: String,
+    }
+
+    let mut user_resp = db
+        .query("SELECT login FROM users WHERE login = $login;")
+        .bind(("login", &form.user_login))
         .await
         .expect("Database error");
 
+    let user_exists: Option<LoginRecord> = user_resp.take(0).unwrap_or_default();
+
     if user_exists.is_some() {
-        // Insert member (ignore if already exists)
-        let _ = sqlx::query("INSERT INTO user_group_members (group_id, user_login) VALUES ($1, $2) ON CONFLICT DO NOTHING;")
-            .bind(&groupid)
-            .bind(&form.user_login)
-            .execute(&pool)
+        // Upsert member (ignore if already exists)
+        let _ = db
+            .query("UPSERT user_group_members:[$gid, $user] SET group_id = $gid, user_login = $user;")
+            .bind(("gid", &groupid))
+            .bind(("user", &form.user_login))
             .await;
 
         // Invalidate Redis group membership cache
@@ -413,17 +379,13 @@ async fn hx_add_group_member(
     }
 
     // Return updated members list
-    let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
-        .bind(&groupid)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            GroupMember {
-                user_login: row.get("user_login"),
-            }
-        })
-        .fetch_all(&pool)
+    let mut members_resp = db
+        .query("SELECT user_login FROM user_group_members WHERE group_id = $gid ORDER BY user_login;")
+        .bind(("gid", &groupid))
         .await
         .expect("Database error");
+
+    let members: Vec<GroupMember> = members_resp.take(0).unwrap_or_default();
 
     let template = HXGroupMembersTemplate {
         group,
@@ -434,12 +396,12 @@ async fn hx_add_group_member(
 }
 
 async fn hx_remove_group_member(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((groupid, login)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -451,21 +413,16 @@ async fn hx_remove_group_member(
     }
 
     // Verify group ownership
-    let group_row: Option<sqlx::postgres::PgRow> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE id = $1;")
-        .bind(&groupid)
-        .fetch_optional(&pool)
+    let mut resp = db
+        .query("SELECT id, name, owner FROM user_groups WHERE id = $id;")
+        .bind(("id", &groupid))
         .await
         .expect("Database error");
 
+    let group_row: Option<UserGroup> = resp.take(0).unwrap_or_default();
+
     let group = match group_row {
-        Some(row) => {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        }
+        Some(g) => g,
         None => return Html("".as_bytes().to_vec()),
     };
 
@@ -473,10 +430,9 @@ async fn hx_remove_group_member(
         return Html("".as_bytes().to_vec());
     }
 
-    sqlx::query("DELETE FROM user_group_members WHERE group_id = $1 AND user_login = $2;")
-        .bind(&groupid)
-        .bind(&login)
-        .execute(&pool)
+    db.query("DELETE FROM user_group_members WHERE group_id = $gid AND user_login = $user;")
+        .bind(("gid", &groupid))
+        .bind(("user", &login))
         .await
         .expect("Database error");
 
@@ -484,17 +440,13 @@ async fn hx_remove_group_member(
     let _: Result<(), _> = redis.clone().del(format!("group:{}:members", groupid)).await;
 
     // Return updated members list
-    let members: Vec<GroupMember> = sqlx::query("SELECT user_login FROM user_group_members WHERE group_id = $1 ORDER BY user_login;")
-        .bind(&groupid)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            GroupMember {
-                user_login: row.get("user_login"),
-            }
-        })
-        .fetch_all(&pool)
+    let mut members_resp = db
+        .query("SELECT user_login FROM user_group_members WHERE group_id = $gid ORDER BY user_login;")
+        .bind(("gid", &groupid))
         .await
         .expect("Database error");
+
+    let members: Vec<GroupMember> = members_resp.take(0).unwrap_or_default();
 
     let template = HXGroupMembersTemplate {
         group,
@@ -505,11 +457,11 @@ async fn hx_remove_group_member(
 }
 
 async fn hx_user_groups_json(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> Json<Vec<UserGroup>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(vec![]);
     }
@@ -517,19 +469,13 @@ async fn hx_user_groups_json(
 
     let mut groups = system_groups_for_owner(&user_info.login);
 
-    let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-        .bind(&user_info.login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        })
-        .fetch_all(&pool)
+    let mut resp = db
+        .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+        .bind(("owner", &user_info.login))
         .await
-        .unwrap_or_default();
+        .expect("Database error");
+
+    let user_groups: Vec<UserGroup> = resp.take(0).unwrap_or_default();
 
     groups.extend(user_groups);
 

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -90,9 +90,15 @@ fn extract_common_headers(headers: &HeaderMap) -> Result<CommonHeaders, &'static
     })
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct UserRow {
+    name: String,
+    profile_picture: Option<String>,
+}
+
 async fn get_user_login(
     headers: HeaderMap,
-    pool: &PgPool,
+    db: &Db,
     mut redis: RedisConn,
 ) -> Option<User> {
     let session_cookie = parse_cookie_header(headers.get("Cookie")?.to_str().ok()?)
@@ -104,19 +110,19 @@ async fn get_user_login(
         .await
         .ok()?;
 
-    let row = sqlx::query(
-        "SELECT name, profile_picture FROM users WHERE login=$1;"
-    )
-    .bind(&login)
-    .fetch_one(pool)
-    .await
-    .ok()?;
+    let mut resp = db
+        .query("SELECT name, profile_picture FROM users WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &login)))
+        .await
+        .ok()?;
 
-    use sqlx::Row;
+    let row: Option<UserRow> = resp.take(0).ok()?;
+    let row = row?;
+
     Some(User {
         login,
-        name: row.get("name"),
-        profile_picture: row.get("profile_picture"),
+        name: row.name,
+        profile_picture: row.profile_picture,
     })
 }
 
@@ -149,7 +155,6 @@ fn generate_medium_id() -> String {
 
     (0..10)
         .map(|_| {
-            // No 'rng' variable needed, no trait import needed
             let idx = rand::random_range(0..charset.len());
             charset[idx] as char
         })
@@ -159,96 +164,72 @@ fn generate_medium_id() -> String {
 fn detect_medium_type_mime(mime: String) -> String {
     let mime_type = mime.to_ascii_lowercase();
 
-    // --- Video ---
     if mime_type.contains("video")
         || matches!(
             mime_type.as_str(),
-            "application/x-matroska"
-                | "application/ogg"  // .ogv
+            "application/x-matroska" | "application/ogg"
         )
     {
         return "video".to_owned();
     }
 
-    // --- Audio ---
     if mime_type.contains("audio")
         || matches!(
             mime_type.as_str(),
-            "application/ogg"        // .ogg / .oga
+            "application/ogg"
                 | "application/x-ogg"
                 | "application/flac"
                 | "application/x-flac"
-                | "application/mp4"  // audio-only mp4
+                | "application/mp4"
         )
     {
         return "audio".to_owned();
     }
 
-    // --- Picture ---
     if mime_type.contains("image")
-        || matches!(
-            mime_type.as_str(),
-            "application/dicom"      // medical imaging
-        )
+        || matches!(mime_type.as_str(), "application/dicom")
     {
         return "picture".to_owned();
     }
 
-    // --- Document: PDF ---
     if mime_type == "application/pdf" {
         return "document_pdf".to_owned();
     }
 
-    // --- Document: Writer (word processors) ---
     if matches!(
         mime_type.as_str(),
-        // OpenDocument
         "application/vnd.oasis.opendocument.text"
             | "application/vnd.oasis.opendocument.text-template"
-            // Legacy MS Word
             | "application/msword"
-            // Modern MS Word
             | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             | "application/vnd.openxmlformats-officedocument.wordprocessingml.template"
-            // Apple Pages
             | "application/vnd.apple.pages"
-            // Rich Text / plain text variants
             | "application/rtf"
             | "text/rtf"
     ) {
         return "document_writer".to_owned();
     }
 
-    // --- Document: Spreadsheet ---
     if matches!(
         mime_type.as_str(),
-        // OpenDocument
         "application/vnd.oasis.opendocument.spreadsheet"
             | "application/vnd.oasis.opendocument.spreadsheet-template"
-            // Legacy MS Excel
             | "application/vnd.ms-excel"
-            // Modern MS Excel
             | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             | "application/vnd.openxmlformats-officedocument.spreadsheetml.template"
-            // Apple Numbers
             | "application/vnd.apple.numbers"
     ) {
         return "document_spreadsheet".to_owned();
     }
 
-    // --- Document: Presentation ---
     if matches!(
         mime_type.as_str(),
-        // OpenDocument
         "application/vnd.oasis.opendocument.presentation"
             | "application/vnd.oasis.opendocument.presentation-template"
-            // Legacy MS PowerPoint
             | "application/vnd.ms-powerpoint"
-            // Modern MS PowerPoint
             | "application/vnd.openxmlformats-officedocument.presentationml.presentation"
             | "application/vnd.openxmlformats-officedocument.presentationml.template"
             | "application/vnd.openxmlformats-officedocument.presentationml.slideshow"
-            // Apple Keynote
             | "application/vnd.apple.keynote"
     ) {
         return "document_presentation".to_owned();
@@ -312,45 +293,48 @@ fn system_groups_for_owner(owner: &str) -> Vec<UserGroup> {
     ]
 }
 
-async fn is_subscribed(pool: &PgPool, subscriber: &str, target: &str) -> bool {
-    sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS(SELECT 1 FROM subscriptions WHERE subscriber = $1 AND target = $2)"
-    )
-    .bind(subscriber)
-    .bind(target)
-    .fetch_one(pool)
-    .await
-    .unwrap_or(false)
+async fn is_subscribed(db: &Db, subscriber: &str, target: &str) -> bool {
+    let mut resp = db
+        .query("SELECT id FROM subscriptions WHERE subscriber = $subscriber AND target = $target LIMIT 1")
+        .bind(("subscriber", subscriber))
+        .bind(("target", target))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let rows: Vec<serde_json::Value> = resp.take(0).unwrap_or_default();
+    !rows.is_empty()
 }
 
-async fn is_group_member(pool: &PgPool, group_id: &str, user_login: &str, mut redis: RedisConn) -> bool {
+async fn is_group_member(db: &Db, group_id: &str, user_login: &str, mut redis: RedisConn) -> bool {
     let redis_key = format!("group:{}:members", group_id);
 
-    // Check if membership set is cached in Redis
     let key_exists: bool = redis.exists(&redis_key).await.unwrap_or(false);
 
     if key_exists {
         return redis.sismember(&redis_key, user_login).await.unwrap_or(false);
     }
 
-    // Cache miss - load all members from DB and cache in Redis
-    let members: Vec<String> = sqlx::query_scalar("SELECT user_login FROM user_group_members WHERE group_id = $1")
-        .bind(group_id)
-        .fetch_all(pool)
+    #[derive(Deserialize)]
+    struct MemberRow { user_login: String }
+
+    let mut resp = db
+        .query("SELECT user_login FROM user_group_members WHERE group_id = $group_id")
+        .bind(("group_id", group_id))
         .await
-        .unwrap_or_default();
+        .unwrap_or_else(|_| unreachable!());
+    let members: Vec<MemberRow> = resp.take(0).unwrap_or_default();
+    let member_logins: Vec<String> = members.into_iter().map(|m| m.user_login).collect();
 
-    let is_member = members.contains(&user_login.to_owned());
+    let is_member = member_logins.contains(&user_login.to_owned());
 
-    if !members.is_empty() {
-        let _: Result<(), _> = redis.sadd(&redis_key, &members).await;
+    if !member_logins.is_empty() {
+        let _: Result<(), _> = redis.sadd(&redis_key, &member_logins).await;
         let _: Result<(), _> = redis.expire(&redis_key, 3600).await;
     }
 
     is_member
 }
 
-async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_group: Option<&str>, owner: &str, user: &Option<User>, redis: RedisConn) -> bool {
+async fn can_access_restricted(db: &Db, visibility: &str, restricted_to_group: Option<&str>, owner: &str, user: &Option<User>, redis: RedisConn) -> bool {
     match visibility {
         "public" => true,
         "restricted" => {
@@ -360,16 +344,16 @@ async fn can_access_restricted(pool: &PgPool, visibility: &str, restricted_to_gr
                 }
                 if let Some(group_id) = restricted_to_group {
                     if group_id == SYSTEM_GROUP_ALL_REGISTERED {
-                        return true; // user is logged in
+                        return true;
                     }
                     if group_id == SYSTEM_GROUP_SUBSCRIBERS {
-                        return is_subscribed(pool, &u.login, owner).await;
+                        return is_subscribed(db, &u.login, owner).await;
                     }
-                    return is_group_member(pool, group_id, &u.login, redis).await;
+                    return is_group_member(db, group_id, &u.login, redis).await;
                 }
             }
             false
         }
-        _ => true // "hidden" - accessible via direct link (existing behavior)
+        _ => true
     }
 }

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -296,8 +296,8 @@ fn system_groups_for_owner(owner: &str) -> Vec<UserGroup> {
 async fn is_subscribed(db: &Db, subscriber: &str, target: &str) -> bool {
     let mut resp = db
         .query("SELECT id FROM subscriptions WHERE subscriber = $subscriber AND target = $target LIMIT 1")
-        .bind(("subscriber", subscriber))
-        .bind(("target", target))
+        .bind(("subscriber", subscriber.to_string()))
+        .bind(("target", target.to_string()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let rows: Vec<serde_json::Value> = resp.take(0).unwrap_or_default();
@@ -318,7 +318,7 @@ async fn is_group_member(db: &Db, group_id: &str, user_login: &str, mut redis: R
 
     let mut resp = db
         .query("SELECT user_login FROM user_group_members WHERE group_id = $group_id")
-        .bind(("group_id", group_id))
+        .bind(("group_id", group_id.to_string()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let members: Vec<MemberRow> = resp.take(0).unwrap_or_default();

--- a/src/likes_dislikes.rs
+++ b/src/likes_dislikes.rs
@@ -12,34 +12,42 @@ fn like_dislike_html_unauth(mediumid: &str, likes: i64, dislikes: i64) -> String
     )
 }
 
-/// Get reaction counts from DB (authoritative source). Used after write operations.
-async fn get_reaction_state_db(pool: &PgPool, mediumid: &str, user_login: Option<&str>) -> (i64, i64, Option<String>) {
-    use sqlx::Row;
+#[derive(Deserialize)]
+struct ReactionCountRow {
+    likes: i64,
+    dislikes: i64,
+}
 
-    let counts_row = sqlx::query(
-        "SELECT COUNT(*) FILTER (WHERE reaction = 'like') AS likes, COUNT(*) FILTER (WHERE reaction = 'dislike') AS dislikes FROM media_likes WHERE media_id=$1;"
-    )
-    .bind(mediumid)
-    .fetch_one(pool)
-    .await
-    .expect("Database error");
+#[derive(Deserialize)]
+struct ReactionRow {
+    reaction: String,
+}
 
-    let likes: i64 = counts_row.get("likes");
-    let dislikes: i64 = counts_row.get("dislikes");
+/// Get reaction counts from DB. Used after write operations.
+async fn get_reaction_state_db(db: &Db, mediumid: &str, user_login: Option<&str>) -> (i64, i64, Option<String>) {
+    let mut resp = db
+        .query(
+            "SELECT \
+             array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'like')) AS likes, \
+             array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'dislike')) AS dislikes \
+             FROM media WHERE id = $mid"
+        )
+        .bind(("mid", surrealdb::RecordId::from_table_key("media", mediumid)))
+        .await
+        .expect("Database error");
+
+    let rows: Vec<ReactionCountRow> = resp.take(0).unwrap_or_default();
+    let (likes, dislikes) = rows.first().map(|r| (r.likes, r.dislikes)).unwrap_or((0, 0));
 
     let user_reaction = if let Some(login) = user_login {
-        sqlx::query(
-            "SELECT reaction FROM media_likes WHERE media_id=$1 AND user_login=$2;"
-        )
-        .bind(mediumid)
-        .bind(login)
-        .fetch_optional(pool)
-        .await
-        .unwrap_or(None)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            row.get::<String, _>("reaction")
-        })
+        let mut resp2 = db
+            .query("SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1")
+            .bind(("mid", mediumid))
+            .bind(("user", login))
+            .await
+            .unwrap_or_else(|_| unreachable!());
+        let rows2: Vec<ReactionRow> = resp2.take(0).unwrap_or_default();
+        rows2.into_iter().next().map(|r| r.reaction)
     } else {
         None
     };
@@ -48,41 +56,36 @@ async fn get_reaction_state_db(pool: &PgPool, mediumid: &str, user_login: Option
 }
 
 /// Get reaction state using Redis cache for counts (falls back to DB on cache miss).
-/// User's personal reaction is always fetched from DB.
-async fn get_reaction_state_cached(pool: &PgPool, mediumid: &str, user_login: Option<&str>, mut redis: RedisConn) -> (i64, i64, Option<String>) {
-    // Try getting counts from Redis cache
+async fn get_reaction_state_cached(db: &Db, mediumid: &str, user_login: Option<&str>, mut redis: RedisConn) -> (i64, i64, Option<String>) {
     let cached_likes: Result<i64, _> = redis.get(format!("cache:media:{}:likes", mediumid)).await;
     let cached_dislikes: Result<i64, _> = redis.get(format!("cache:media:{}:dislikes", mediumid)).await;
 
     let (likes, dislikes) = if let (Ok(l), Ok(d)) = (cached_likes, cached_dislikes) {
         (l, d)
     } else {
-        // Cache miss — fall back to DB
-        use sqlx::Row;
-        let counts_row = sqlx::query(
-            "SELECT COUNT(*) FILTER (WHERE reaction = 'like') AS likes, COUNT(*) FILTER (WHERE reaction = 'dislike') AS dislikes FROM media_likes WHERE media_id=$1;"
-        )
-        .bind(mediumid)
-        .fetch_one(pool)
-        .await
-        .expect("Database error");
-        (counts_row.get("likes"), counts_row.get("dislikes"))
+        let mut resp = db
+            .query(
+                "SELECT \
+                 array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'like')) AS likes, \
+                 array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'dislike')) AS dislikes \
+                 FROM media WHERE id = $mid"
+            )
+            .bind(("mid", surrealdb::RecordId::from_table_key("media", mediumid)))
+            .await
+            .expect("Database error");
+        let rows: Vec<ReactionCountRow> = resp.take(0).unwrap_or_default();
+        rows.first().map(|r| (r.likes, r.dislikes)).unwrap_or((0, 0))
     };
 
-    // User's personal reaction must come from DB (per-user, not worth caching individually)
     let user_reaction = if let Some(login) = user_login {
-        sqlx::query(
-            "SELECT reaction FROM media_likes WHERE media_id=$1 AND user_login=$2;"
-        )
-        .bind(mediumid)
-        .bind(login)
-        .fetch_optional(pool)
-        .await
-        .unwrap_or(None)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            row.get::<String, _>("reaction")
-        })
+        let mut resp2 = db
+            .query("SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1")
+            .bind(("mid", mediumid))
+            .bind(("user", login))
+            .await
+            .unwrap_or_else(|_| unreachable!());
+        let rows2: Vec<ReactionRow> = resp2.take(0).unwrap_or_default();
+        rows2.into_iter().next().map(|r| r.reaction)
     } else {
         None
     };
@@ -90,7 +93,6 @@ async fn get_reaction_state_cached(pool: &PgPool, mediumid: &str, user_login: Op
     (likes, dislikes, user_reaction)
 }
 
-/// Update the cached reaction counts in Redis after a write operation.
 async fn update_reaction_cache(redis: &mut RedisConn, mediumid: &str, likes: i64, dislikes: i64) {
     let _: Result<(), _> = redis.set(format!("cache:media:{}:likes", mediumid), likes).await;
     let _: Result<(), _> = redis.set(format!("cache:media:{}:dislikes", mediumid), dislikes).await;
@@ -98,97 +100,88 @@ async fn update_reaction_cache(redis: &mut RedisConn, mediumid: &str, likes: i64
 
 async fn hx_likedislikebutton(
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
-    if let Some(user) = get_user_login(headers, &pool, redis.clone()).await {
-        let (likes, dislikes, user_reaction) = get_reaction_state_cached(&pool, &mediumid, Some(&user.login), redis.clone()).await;
+    if let Some(user) = get_user_login(headers, &db, redis.clone()).await {
+        let (likes, dislikes, user_reaction) = get_reaction_state_cached(&db, &mediumid, Some(&user.login), redis.clone()).await;
         Html(like_dislike_html(&mediumid, likes, dislikes, user_reaction.as_deref()))
     } else {
-        let (likes, dislikes, _) = get_reaction_state_cached(&pool, &mediumid, None, redis.clone()).await;
+        let (likes, dislikes, _) = get_reaction_state_cached(&db, &mediumid, None, redis.clone()).await;
         Html(like_dislike_html_unauth(&mediumid, likes, dislikes))
     }
 }
 
 async fn hx_like(
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
-    if let Some(user) = get_user_login(headers, &pool, redis.clone()).await {
-        let (_, _, current_reaction) = get_reaction_state_db(&pool, &mediumid, Some(&user.login)).await;
+    if let Some(user) = get_user_login(headers, &db, redis.clone()).await {
+        let (_, _, current_reaction) = get_reaction_state_db(&db, &mediumid, Some(&user.login)).await;
 
         if current_reaction.as_deref() == Some("like") {
-            sqlx::query(
-                "DELETE FROM media_likes WHERE media_id=$1 AND user_login=$2;"
-            )
-            .bind(&mediumid)
-            .bind(&user.login)
-            .execute(&pool)
-            .await
-            .expect("Database error");
+            // Toggle off — delete the like
+            db.query("DELETE media_likes WHERE media_id = $mid AND user_login = $user")
+                .bind(("mid", &mediumid))
+                .bind(("user", &user.login))
+                .await
+                .expect("Database error");
         } else {
-            sqlx::query(
-                "INSERT INTO media_likes (media_id, user_login, reaction) VALUES ($1,$2,'like') ON CONFLICT (media_id, user_login) DO UPDATE SET reaction='like';"
+            // Upsert like using composite record ID
+            let rec_id = format!("{}:{}", mediumid, user.login);
+            db.query(
+                "UPSERT media_likes SET media_id = $mid, user_login = $user, reaction = 'like'"
             )
-            .bind(&mediumid)
-            .bind(&user.login)
-            .execute(&pool)
+            .bind(("mid", &mediumid))
+            .bind(("user", &user.login))
             .await
             .expect("Database error");
         }
 
-        // Get fresh counts from DB after the write
-        let (likes, dislikes, user_reaction) = get_reaction_state_db(&pool, &mediumid, Some(&user.login)).await;
-        // Update Redis cache with the new counts
+        let (likes, dislikes, user_reaction) = get_reaction_state_db(&db, &mediumid, Some(&user.login)).await;
         let mut cache_redis = redis.clone();
         update_reaction_cache(&mut cache_redis, &mediumid, likes, dislikes).await;
         Html(like_dislike_html(&mediumid, likes, dislikes, user_reaction.as_deref()))
     } else {
-        let (likes, dislikes, _) = get_reaction_state_cached(&pool, &mediumid, None, redis.clone()).await;
+        let (likes, dislikes, _) = get_reaction_state_cached(&db, &mediumid, None, redis.clone()).await;
         Html(like_dislike_html_unauth(&mediumid, likes, dislikes))
     }
 }
 
 async fn hx_dislike(
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
-    if let Some(user) = get_user_login(headers, &pool, redis.clone()).await {
-        let (_, _, current_reaction) = get_reaction_state_db(&pool, &mediumid, Some(&user.login)).await;
+    if let Some(user) = get_user_login(headers, &db, redis.clone()).await {
+        let (_, _, current_reaction) = get_reaction_state_db(&db, &mediumid, Some(&user.login)).await;
 
         if current_reaction.as_deref() == Some("dislike") {
-            sqlx::query(
-                "DELETE FROM media_likes WHERE media_id=$1 AND user_login=$2;"
-            )
-            .bind(&mediumid)
-            .bind(&user.login)
-            .execute(&pool)
-            .await
-            .expect("Database error");
+            db.query("DELETE media_likes WHERE media_id = $mid AND user_login = $user")
+                .bind(("mid", &mediumid))
+                .bind(("user", &user.login))
+                .await
+                .expect("Database error");
         } else {
-            sqlx::query(
-                "INSERT INTO media_likes (media_id, user_login, reaction) VALUES ($1,$2,'dislike') ON CONFLICT (media_id, user_login) DO UPDATE SET reaction='dislike';"
+            db.query(
+                "UPSERT media_likes SET media_id = $mid, user_login = $user, reaction = 'dislike'"
             )
-            .bind(&mediumid)
-            .bind(&user.login)
-            .execute(&pool)
+            .bind(("mid", &mediumid))
+            .bind(("user", &user.login))
             .await
             .expect("Database error");
         }
 
-        // Get fresh counts from DB after the write
-        let (likes, dislikes, user_reaction) = get_reaction_state_db(&pool, &mediumid, Some(&user.login)).await;
-        // Update Redis cache with the new counts
+        let (likes, dislikes, user_reaction) = get_reaction_state_db(&db, &mediumid, Some(&user.login)).await;
         let mut cache_redis = redis.clone();
         update_reaction_cache(&mut cache_redis, &mediumid, likes, dislikes).await;
         Html(like_dislike_html(&mediumid, likes, dislikes, user_reaction.as_deref()))
     } else {
-        let (likes, dislikes, _) = get_reaction_state_cached(&pool, &mediumid, None, redis.clone()).await;
+        let (likes, dislikes, _) = get_reaction_state_cached(&db, &mediumid, None, redis.clone()).await;
         Html(like_dislike_html_unauth(&mediumid, likes, dislikes))
     }
 }

--- a/src/likes_dislikes.rs
+++ b/src/likes_dislikes.rs
@@ -31,7 +31,7 @@ async fn get_reaction_state_db(db: &Db, mediumid: &str, user_login: Option<&str>
              FROM media WHERE id = $mid"
         )
         .bind(("mid", surrealdb::RecordId::from_table_key("media", mediumid)))
-        .bind(("user", user))
+        .bind(("user", user.to_string()))
         .await
         .expect("Database error");
 
@@ -56,8 +56,8 @@ async fn get_reaction_state_cached(db: &Db, mediumid: &str, user_login: Option<&
             #[derive(Deserialize)] struct ReactionRow { reaction: String }
             let mut resp = db
                 .query("SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1")
-                .bind(("mid", mediumid))
-                .bind(("user", user))
+                .bind(("mid", mediumid.to_string()))
+                .bind(("user", user.to_string()))
                 .await
                 .unwrap_or_else(|_| unreachable!());
             let rows: Vec<ReactionRow> = resp.take(0).unwrap_or_default();
@@ -73,7 +73,7 @@ async fn get_reaction_state_cached(db: &Db, mediumid: &str, user_login: Option<&
                  FROM media WHERE id = $mid"
             )
             .bind(("mid", surrealdb::RecordId::from_table_key("media", mediumid)))
-            .bind(("user", user))
+            .bind(("user", user.to_string()))
             .await
             .expect("Database error");
         let rows: Vec<ReactionStateRow> = resp.take(0).unwrap_or_default();
@@ -114,8 +114,8 @@ async fn hx_like(
         if current_reaction.as_deref() == Some("like") {
             // Toggle off — delete the like
             db.query("DELETE media_likes WHERE media_id = $mid AND user_login = $user")
-                .bind(("mid", &mediumid))
-                .bind(("user", &user.login))
+                .bind(("mid", mediumid.clone()))
+                .bind(("user", user.login.clone()))
                 .await
                 .expect("Database error");
         } else {
@@ -124,8 +124,8 @@ async fn hx_like(
             db.query(
                 "UPSERT media_likes SET media_id = $mid, user_login = $user, reaction = 'like'"
             )
-            .bind(("mid", &mediumid))
-            .bind(("user", &user.login))
+            .bind(("mid", mediumid.clone()))
+            .bind(("user", user.login.clone()))
             .await
             .expect("Database error");
         }
@@ -151,16 +151,16 @@ async fn hx_dislike(
 
         if current_reaction.as_deref() == Some("dislike") {
             db.query("DELETE media_likes WHERE media_id = $mid AND user_login = $user")
-                .bind(("mid", &mediumid))
-                .bind(("user", &user.login))
+                .bind(("mid", mediumid.clone()))
+                .bind(("user", user.login.clone()))
                 .await
                 .expect("Database error");
         } else {
             db.query(
                 "UPSERT media_likes SET media_id = $mid, user_login = $user, reaction = 'dislike'"
             )
-            .bind(("mid", &mediumid))
-            .bind(("user", &user.login))
+            .bind(("mid", mediumid.clone()))
+            .bind(("user", user.login.clone()))
             .await
             .expect("Database error");
         }

--- a/src/likes_dislikes.rs
+++ b/src/likes_dislikes.rs
@@ -13,84 +13,73 @@ fn like_dislike_html_unauth(mediumid: &str, likes: i64, dislikes: i64) -> String
 }
 
 #[derive(Deserialize)]
-struct ReactionCountRow {
+struct ReactionStateRow {
     likes: i64,
     dislikes: i64,
+    user_reaction: Option<String>,
 }
 
-#[derive(Deserialize)]
-struct ReactionRow {
-    reaction: String,
-}
-
-/// Get reaction counts from DB. Used after write operations.
+/// Get reaction state from DB in a single query.
+/// Reads denormalized likes_count/dislikes_count fields (kept current by DEFINE EVENT)
+/// and fetches the current user's reaction in the same round-trip.
 async fn get_reaction_state_db(db: &Db, mediumid: &str, user_login: Option<&str>) -> (i64, i64, Option<String>) {
+    let user = user_login.unwrap_or("");
     let mut resp = db
         .query(
-            "SELECT \
-             array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'like')) AS likes, \
-             array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'dislike')) AS dislikes \
+            "SELECT likes_count AS likes, dislikes_count AS dislikes, \
+             (SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1)[0].reaction AS user_reaction \
              FROM media WHERE id = $mid"
         )
         .bind(("mid", surrealdb::RecordId::from_table_key("media", mediumid)))
+        .bind(("user", user))
         .await
         .expect("Database error");
 
-    let rows: Vec<ReactionCountRow> = resp.take(0).unwrap_or_default();
-    let (likes, dislikes) = rows.first().map(|r| (r.likes, r.dislikes)).unwrap_or((0, 0));
-
-    let user_reaction = if let Some(login) = user_login {
-        let mut resp2 = db
-            .query("SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1")
-            .bind(("mid", mediumid))
-            .bind(("user", login))
-            .await
-            .unwrap_or_else(|_| unreachable!());
-        let rows2: Vec<ReactionRow> = resp2.take(0).unwrap_or_default();
-        rows2.into_iter().next().map(|r| r.reaction)
-    } else {
-        None
-    };
-
-    (likes, dislikes, user_reaction)
+    let rows: Vec<ReactionStateRow> = resp.take(0).unwrap_or_default();
+    let row = rows.into_iter().next().unwrap_or(ReactionStateRow { likes: 0, dislikes: 0, user_reaction: None });
+    (row.likes, row.dislikes, row.user_reaction)
 }
 
-/// Get reaction state using Redis cache for counts (falls back to DB on cache miss).
+/// Get reaction state using Redis cache for counts.
+/// On cache hit: reads counts from Redis and user reaction from DB (one query).
+/// On cache miss: single DB query for counts + user reaction using denormalized fields.
 async fn get_reaction_state_cached(db: &Db, mediumid: &str, user_login: Option<&str>, mut redis: RedisConn) -> (i64, i64, Option<String>) {
     let cached_likes: Result<i64, _> = redis.get(format!("cache:media:{}:likes", mediumid)).await;
     let cached_dislikes: Result<i64, _> = redis.get(format!("cache:media:{}:dislikes", mediumid)).await;
+    let user = user_login.unwrap_or("");
 
-    let (likes, dislikes) = if let (Ok(l), Ok(d)) = (cached_likes, cached_dislikes) {
-        (l, d)
+    if let (Ok(likes), Ok(dislikes)) = (cached_likes, cached_dislikes) {
+        // Counts come from cache; fetch only the user's reaction
+        let user_reaction = if user.is_empty() {
+            None
+        } else {
+            #[derive(Deserialize)] struct ReactionRow { reaction: String }
+            let mut resp = db
+                .query("SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1")
+                .bind(("mid", mediumid))
+                .bind(("user", user))
+                .await
+                .unwrap_or_else(|_| unreachable!());
+            let rows: Vec<ReactionRow> = resp.take(0).unwrap_or_default();
+            rows.into_iter().next().map(|r| r.reaction)
+        };
+        (likes, dislikes, user_reaction)
     } else {
+        // Cache miss: single query — denormalized counts + user reaction
         let mut resp = db
             .query(
-                "SELECT \
-                 array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'like')) AS likes, \
-                 array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'dislike')) AS dislikes \
+                "SELECT likes_count AS likes, dislikes_count AS dislikes, \
+                 (SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1)[0].reaction AS user_reaction \
                  FROM media WHERE id = $mid"
             )
             .bind(("mid", surrealdb::RecordId::from_table_key("media", mediumid)))
+            .bind(("user", user))
             .await
             .expect("Database error");
-        let rows: Vec<ReactionCountRow> = resp.take(0).unwrap_or_default();
-        rows.first().map(|r| (r.likes, r.dislikes)).unwrap_or((0, 0))
-    };
-
-    let user_reaction = if let Some(login) = user_login {
-        let mut resp2 = db
-            .query("SELECT reaction FROM media_likes WHERE media_id = $mid AND user_login = $user LIMIT 1")
-            .bind(("mid", mediumid))
-            .bind(("user", login))
-            .await
-            .unwrap_or_else(|_| unreachable!());
-        let rows2: Vec<ReactionRow> = resp2.take(0).unwrap_or_default();
-        rows2.into_iter().next().map(|r| r.reaction)
-    } else {
-        None
-    };
-
-    (likes, dislikes, user_reaction)
+        let rows: Vec<ReactionStateRow> = resp.take(0).unwrap_or_default();
+        let row = rows.into_iter().next().unwrap_or(ReactionStateRow { likes: 0, dislikes: 0, user_reaction: None });
+        (row.likes, row.dislikes, row.user_reaction)
+    }
 }
 
 async fn update_reaction_cache(redis: &mut RedisConn, mediumid: &str, likes: i64, dislikes: i64) {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -71,44 +71,35 @@ struct HXUserListsTemplate {
 
 async fn list_page(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(listid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let list_row = sqlx::query(
-        "SELECT id, name, owner, visibility, restricted_to_group FROM lists WHERE id=$1;"
-    )
-    .bind(&listid)
-    .fetch_one(&pool)
-    .await;
+    let mut resp = db
+        .query("SELECT id, name, owner, visibility, restricted_to_group FROM lists WHERE id = $id")
+        .bind(("id", &listid))
+        .await
+        .expect("Database error");
 
-    let list = match list_row {
-        Ok(row) => {
-            use sqlx::Row;
-            List {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-                visibility: row.get("visibility"),
-                restricted_to_group: row.get("restricted_to_group"),
-            }
-        }
-        Err(_) => {
+    let list: Option<List> = resp.take(0).expect("Deserialize error");
+    let list = match list {
+        Some(l) => l,
+        None => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),
             ));
         }
     };
 
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     let is_owner = user_info
         .as_ref()
         .map(|u| u.login == list.owner)
         .unwrap_or(false);
 
     // Access control for restricted lists
-    if !is_owner && !can_access_restricted(&pool, &list.visibility, list.restricted_to_group.as_deref(), &list.owner, &user_info, redis.clone()).await {
+    if !is_owner && !can_access_restricted(&db, &list.visibility, list.restricted_to_group.as_deref(), &list.owner, &user_info, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
@@ -126,44 +117,60 @@ async fn list_page(
     Html(minifi_html(template.render().unwrap()))
 }
 
+#[derive(Deserialize)]
+struct MediaWithOwner {
+    id: String,
+    name: String,
+    description: String,
+    upload: i64,
+    owner: String,
+    owner_name: String,
+    owner_picture: Option<String>,
+    views: i64,
+    #[serde(rename = "type")]
+    media_type: String,
+    visibility: String,
+    restricted_to_group: Option<String>,
+}
+
 async fn medium_in_list(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let list_row = sqlx::query(
-        "SELECT id, visibility, restricted_to_group, owner, name FROM lists WHERE id=$1;"
-    )
-    .bind(&listid)
-    .fetch_one(&pool)
-    .await;
+    let mut resp = db
+        .query("SELECT id, visibility, restricted_to_group, owner, name FROM lists WHERE id = $id")
+        .bind(("id", &listid))
+        .await
+        .expect("Database error");
 
-    let list = match list_row {
-        Ok(row) => {
-            use sqlx::Row;
-            (
-                row.get::<String, _>("id"),
-                row.get::<String, _>("visibility"),
-                row.get::<Option<String>, _>("restricted_to_group"),
-                row.get::<String, _>("owner"),
-                row.get::<String, _>("name"),
-            )
-        }
-        Err(_) => {
+    #[derive(Deserialize)]
+    struct ListBasic {
+        id: String,
+        visibility: String,
+        restricted_to_group: Option<String>,
+        owner: String,
+        name: String,
+    }
+
+    let list: Option<ListBasic> = resp.take(0).expect("Deserialize error");
+    let list = match list {
+        Some(l) => l,
+        None => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),
             ));
         }
     };
 
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     let is_logged_in = user_info.is_some();
 
     // Access control for restricted lists
-    let is_owner = user_info.as_ref().map(|u| u.login == list.3).unwrap_or(false);
-    if !is_owner && !can_access_restricted(&pool, &list.1, list.2.as_deref(), &list.3, &user_info, redis.clone()).await {
+    let is_owner = user_info.as_ref().map(|u| u.login == list.owner).unwrap_or(false);
+    if !is_owner && !can_access_restricted(&db, &list.visibility, list.restricted_to_group.as_deref(), &list.owner, &user_info, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
@@ -171,35 +178,62 @@ async fn medium_in_list(
 
     let common_headers = extract_common_headers(&headers).unwrap();
 
-    // Also check media access
-    let medium_row = sqlx::query(
-        "SELECT m.id, m.name, m.description, m.upload, m.owner, m.views, m.type, m.visibility, m.restricted_to_group, u.name as owner_name, u.profile_picture as owner_picture FROM media m LEFT JOIN users u ON m.owner = u.login WHERE m.id=$1;"
-    )
-    .bind(mediumid.to_ascii_lowercase())
-    .fetch_one(&pool)
-    .await;
+    // Fetch media record
+    let mut media_resp = db
+        .query("SELECT id, name, description, upload, owner, views, type, visibility, restricted_to_group FROM media WHERE id = $id")
+        .bind(("id", mediumid.to_ascii_lowercase()))
+        .await
+        .expect("Database error");
 
-    let medium = match medium_row {
-        Ok(row) => row,
-        Err(_) => {
+    #[derive(Deserialize)]
+    struct MediaBasic {
+        id: String,
+        name: String,
+        description: String,
+        upload: i64,
+        owner: String,
+        views: i64,
+        #[serde(rename = "type")]
+        media_type: String,
+        visibility: String,
+        restricted_to_group: Option<String>,
+    }
+
+    let medium: Option<MediaBasic> = media_resp.take(0).expect("Deserialize error");
+    let medium = match medium {
+        Some(m) => m,
+        None => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),
             ));
         }
     };
 
-    use sqlx::Row;
-    let m_visibility: String = medium.get("visibility");
-    let m_restricted: Option<String> = medium.get("restricted_to_group");
-    let m_owner: String = medium.get("owner");
-
-    if !can_access_restricted(&pool, &m_visibility, m_restricted.as_deref(), &m_owner, &user_info, redis.clone()).await {
+    if !can_access_restricted(&db, &medium.visibility, medium.restricted_to_group.as_deref(), &medium.owner, &user_info, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
     }
 
-    let medium_id: String = medium.get("id");
+    // Fetch owner info
+    let mut owner_resp = db
+        .query("SELECT name, profile_picture FROM users WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &medium.owner)))
+        .await
+        .expect("Database error");
+
+    #[derive(Deserialize)]
+    struct OwnerInfo {
+        name: String,
+        profile_picture: Option<String>,
+    }
+
+    let owner_info: Option<OwnerInfo> = owner_resp.take(0).unwrap_or(None);
+    let (owner_name, owner_picture) = owner_info
+        .map(|o| (o.name, o.profile_picture))
+        .unwrap_or_else(|| (medium.owner.clone(), None));
+
+    let medium_id = medium.id.clone();
     let medium_captions_exist: bool;
     let mut medium_captions_list: Vec<CaptionEntry> = Vec::new();
     if std::path::Path::new(&format!("source/{}/captions/list.txt", medium_id)).exists() {
@@ -242,13 +276,13 @@ async fn medium_in_list(
     let template = MediumTemplate {
         sidebar,
         medium_id,
-        medium_name: medium.get("name"),
-        medium_owner: medium.get("owner"),
-        medium_owner_name: medium.get("owner_name"),
-        medium_owner_picture: medium.get("owner_picture"),
-        medium_upload: prettyunixtime(medium.get("upload")).await,
-        medium_views: medium.get("views"),
-        medium_type: medium.get("type"),
+        medium_name: medium.name,
+        medium_owner: medium.owner,
+        medium_owner_name: owner_name,
+        medium_owner_picture: owner_picture,
+        medium_upload: prettyunixtime(medium.upload).await,
+        medium_views: medium.views,
+        medium_type: medium.media_type,
         medium_captions_exist,
         medium_captions_list,
         medium_has_ass_captions,
@@ -260,56 +294,63 @@ async fn medium_in_list(
         common_headers,
         is_logged_in,
         list_id: listid,
-        list_name: list.4,
+        list_name: list.name,
     };
     Html(minifi_html(template.render().unwrap()))
 }
 
 async fn hx_list_items(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path(listid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_list_items_inner(config, pool, listid, 0).await
+    hx_list_items_inner(config, db, listid, 0).await
 }
 
 async fn hx_list_items_page(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path((listid, page)): Path<(String, i64)>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_list_items_inner(config, pool, listid, page).await
+    hx_list_items_inner(config, db, listid, page).await
 }
 
 async fn hx_list_items_inner(
     config: Config,
-    pool: PgPool,
+    db: Db,
     listid: String,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
     let offset = page * 40;
 
-    let mut items: Vec<Medium> = sqlx::query(
-        "SELECT m.id, m.name, m.owner, m.views, m.type FROM list_items li INNER JOIN media m ON li.media_id = m.id WHERE li.list_id = $1 ORDER BY li.position ASC LIMIT 41 OFFSET $2;"
-    )
-    .bind(&listid)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        Medium {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            views: row.get("views"),
-            r#type: row.get("type"),
-            sprite_filename: None,
-            sprite_x: 0,
-            sprite_y: 0,
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    #[derive(Deserialize)]
+    struct ListItemMedia {
+        id: String,
+        name: String,
+        owner: String,
+        views: i64,
+        #[serde(rename = "type")]
+        media_type: String,
+    }
+
+    let mut resp = db
+        .query("SELECT media_id.id AS id, media_id.name AS name, media_id.owner AS owner, media_id.views AS views, media_id.type AS type FROM list_items WHERE list_id = $lid ORDER BY position ASC LIMIT 41 START $offset")
+        .bind(("lid", &listid))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
+
+    let raw: Vec<ListItemMedia> = resp.take(0).expect("Deserialize error");
+    let mut items: Vec<Medium> = raw.into_iter().map(|r| Medium {
+        id: r.id,
+        name: r.name,
+        owner: r.owner,
+        views: r.views,
+        r#type: r.media_type,
+        sprite_filename: None,
+        sprite_x: 0,
+        sprite_y: 0,
+    }).collect();
 
     let has_more = items.len() == 41;
     if has_more {
@@ -331,17 +372,36 @@ async fn hx_list_items_inner(
 
 async fn hx_list_sidebar(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let media: Vec<Medium> = sqlx::query_as!(
-        Medium,
-        "SELECT m.id, m.name, m.owner, m.views, m.type, NULL as sprite_filename, 0::int4 as \"sprite_x!\", 0::int4 as \"sprite_y!\" FROM list_items li INNER JOIN media m ON li.media_id = m.id WHERE li.list_id = $1 ORDER BY li.position ASC;",
-        listid
-    )
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    #[derive(Deserialize)]
+    struct ListItemMedia {
+        id: String,
+        name: String,
+        owner: String,
+        views: i64,
+        #[serde(rename = "type")]
+        media_type: String,
+    }
+
+    let mut resp = db
+        .query("SELECT media_id.id AS id, media_id.name AS name, media_id.owner AS owner, media_id.views AS views, media_id.type AS type FROM list_items WHERE list_id = $lid ORDER BY position ASC")
+        .bind(("lid", &listid))
+        .await
+        .expect("Database error");
+
+    let raw: Vec<ListItemMedia> = resp.take(0).expect("Deserialize error");
+    let media: Vec<Medium> = raw.into_iter().map(|r| Medium {
+        id: r.id,
+        name: r.name,
+        owner: r.owner,
+        views: r.views,
+        r#type: r.media_type,
+        sprite_filename: None,
+        sprite_x: 0,
+        sprite_y: 0,
+    }).collect();
 
     let template = HXMediumListTemplate {
         media,
@@ -353,43 +413,19 @@ async fn hx_list_sidebar(
 }
 
 async fn hx_list_modal(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
     let user_info = user_info.unwrap();
 
-    let lists = sqlx::query_as!(
-        ListModalEntry,
-        "SELECT l.id, l.name, EXISTS(SELECT 1 FROM list_items li WHERE li.list_id = l.id AND li.media_id = $2) AS \"already_added!\" FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
-        user_info.login,
-        mediumid
-    )
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
-
-    // Fetch user's groups for visibility selection in create form (system groups + user groups)
-    let mut owner_groups = system_groups_for_owner(&user_info.login);
-    let user_groups_list: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-        .bind(&user_info.login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        })
-        .fetch_all(&pool)
-        .await
-        .unwrap_or_default();
-    owner_groups.extend(user_groups_list);
+    let lists = fetch_list_modal_entries(&db, &user_info.login, &mediumid).await;
+    let owner_groups = fetch_owner_groups(&db, &user_info.login).await;
 
     let template = HXListModalTemplate {
         lists,
@@ -399,14 +435,51 @@ async fn hx_list_modal(
     Html(minifi_html(template.render().unwrap()))
 }
 
+async fn fetch_list_modal_entries(db: &Db, owner: &str, mediumid: &str) -> Vec<ListModalEntry> {
+    #[derive(Deserialize)]
+    struct ListRow {
+        id: String,
+        name: String,
+        already_added: bool,
+    }
+
+    let mut resp = db
+        .query("SELECT id, name, array::len((SELECT id FROM list_items WHERE list_id = $parent.id AND media_id = $mid)) > 0 AS already_added FROM lists WHERE owner = $owner ORDER BY created DESC")
+        .bind(("owner", owner))
+        .bind(("mid", mediumid))
+        .await
+        .expect("Database error");
+
+    let rows: Vec<ListRow> = resp.take(0).unwrap_or_default();
+    rows.into_iter().map(|r| ListModalEntry {
+        id: r.id,
+        name: r.name,
+        already_added: r.already_added,
+    }).collect()
+}
+
+async fn fetch_owner_groups(db: &Db, owner: &str) -> Vec<UserGroup> {
+    let mut groups = system_groups_for_owner(owner);
+
+    let mut resp = db
+        .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC")
+        .bind(("owner", owner))
+        .await
+        .expect("Database error");
+
+    let user_groups: Vec<UserGroup> = resp.take(0).unwrap_or_default();
+    groups.extend(user_groups);
+    groups
+}
+
 async fn hx_create_list(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<CreateListForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
@@ -425,54 +498,26 @@ async fn hx_create_list(
         None
     };
 
-    sqlx::query(
-        "INSERT INTO lists (id, name, owner, public, visibility, restricted_to_group) VALUES ($1, $2, $3, $4, $5, $6);"
-    )
-    .bind(&list_id)
-    .bind(&form.name)
-    .bind(&user_info.login)
-    .bind(is_public)
-    .bind(visibility)
-    .bind(&restricted_to_group)
-    .execute(&pool)
-    .await
-    .expect("Database error");
-
-    sqlx::query!(
-        "INSERT INTO list_items (list_id, media_id, position) VALUES ($1, $2, 0);",
-        list_id,
-        mediumid
-    )
-    .execute(&pool)
-    .await
-    .expect("Database error");
-
-    let lists = sqlx::query_as!(
-        ListModalEntry,
-        "SELECT l.id, l.name, EXISTS(SELECT 1 FROM list_items li WHERE li.list_id = l.id AND li.media_id = $2) AS \"already_added!\" FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
-        user_info.login,
-        mediumid
-    )
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
-
-    // Fetch user's groups for visibility selection in create form (system groups + user groups)
-    let mut owner_groups = system_groups_for_owner(&user_info.login);
-    let user_groups_list: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-        .bind(&user_info.login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        })
-        .fetch_all(&pool)
+    let _ = db
+        .query("CREATE type::thing('lists', $lid) SET name = $name, owner = $owner, public = $public, visibility = $visibility, restricted_to_group = $rtg, created = time::unix(time::now())")
+        .bind(("lid", &list_id))
+        .bind(("name", &form.name))
+        .bind(("owner", &user_info.login))
+        .bind(("public", is_public))
+        .bind(("visibility", visibility))
+        .bind(("rtg", &restricted_to_group))
         .await
-        .unwrap_or_default();
-    owner_groups.extend(user_groups_list);
+        .expect("Database error");
+
+    let _ = db
+        .query("CREATE list_items SET list_id = $lid, media_id = $mid, position = 0")
+        .bind(("lid", &list_id))
+        .bind(("mid", &mediumid))
+        .await
+        .expect("Database error");
+
+    let lists = fetch_list_modal_entries(&db, &user_info.login, &mediumid).await;
+    let owner_groups = fetch_owner_groups(&db, &user_info.login).await;
 
     let template = HXListModalTemplate {
         lists,
@@ -483,68 +528,51 @@ async fn hx_create_list(
 }
 
 async fn hx_add_to_list(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
     let user_info = user_info.unwrap();
 
-    let list = sqlx::query!("SELECT owner FROM lists WHERE id=$1;", listid)
-        .fetch_one(&pool)
+    let mut owner_resp = db
+        .query("SELECT owner FROM lists WHERE id = $id")
+        .bind(("id", &listid))
         .await
         .expect("Database error");
-    if list.owner != user_info.login {
-        return Html("".as_bytes().to_vec());
+
+    #[derive(Deserialize)]
+    struct OwnerRow { owner: String }
+    let owner_row: Option<OwnerRow> = owner_resp.take(0).expect("Deserialize error");
+    match owner_row {
+        Some(r) if r.owner == user_info.login => {}
+        _ => return Html("".as_bytes().to_vec()),
     }
 
-    let max_pos = sqlx::query!(
-        "SELECT COALESCE(MAX(position), -1) AS max_pos FROM list_items WHERE list_id=$1;",
-        listid
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
-
-    let next_pos = max_pos.max_pos.unwrap_or(-1) + 1;
-
-    sqlx::query!(
-        "INSERT INTO list_items (list_id, media_id, position) VALUES ($1, $2, $3);",
-        listid,
-        mediumid,
-        next_pos
-    )
-    .execute(&pool)
-    .await
-    .expect("Database error");
-
-    let lists = sqlx::query_as!(
-        ListModalEntry,
-        "SELECT l.id, l.name, EXISTS(SELECT 1 FROM list_items li WHERE li.list_id = l.id AND li.media_id = $2) AS \"already_added!\" FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
-        user_info.login,
-        mediumid
-    )
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
-
-    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-        .bind(&user_info.login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        })
-        .fetch_all(&pool)
+    // Get max position
+    let mut pos_resp = db
+        .query("SELECT VALUE math::max(position) FROM list_items WHERE list_id = $lid")
+        .bind(("lid", &listid))
         .await
-        .unwrap_or_default();
+        .expect("Database error");
+
+    let max_pos: Option<i64> = pos_resp.take(0).unwrap_or(None);
+    let next_pos = max_pos.unwrap_or(-1) + 1;
+
+    let _ = db
+        .query("CREATE list_items SET list_id = $lid, media_id = $mid, position = $pos")
+        .bind(("lid", &listid))
+        .bind(("mid", &mediumid))
+        .bind(("pos", next_pos))
+        .await
+        .expect("Database error");
+
+    let lists = fetch_list_modal_entries(&db, &user_info.login, &mediumid).await;
+    let owner_groups = fetch_owner_groups(&db, &user_info.login).await;
 
     let template = HXListModalTemplate {
         lists,
@@ -555,57 +583,40 @@ async fn hx_add_to_list(
 }
 
 async fn hx_remove_from_list(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((listid, mediumid)): Path<(String, String)>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("".as_bytes().to_vec());
     }
     let user_info = user_info.unwrap();
 
-    let list = sqlx::query!("SELECT owner FROM lists WHERE id=$1;", listid)
-        .fetch_one(&pool)
+    let mut owner_resp = db
+        .query("SELECT owner FROM lists WHERE id = $id")
+        .bind(("id", &listid))
         .await
         .expect("Database error");
-    if list.owner != user_info.login {
-        return Html("".as_bytes().to_vec());
+
+    #[derive(Deserialize)]
+    struct OwnerRow { owner: String }
+    let owner_row: Option<OwnerRow> = owner_resp.take(0).expect("Deserialize error");
+    match owner_row {
+        Some(r) if r.owner == user_info.login => {}
+        _ => return Html("".as_bytes().to_vec()),
     }
 
-    sqlx::query!(
-        "DELETE FROM list_items WHERE list_id=$1 AND media_id=$2;",
-        listid,
-        mediumid
-    )
-    .execute(&pool)
-    .await
-    .expect("Database error");
-
-    let lists = sqlx::query_as!(
-        ListModalEntry,
-        "SELECT l.id, l.name, EXISTS(SELECT 1 FROM list_items li WHERE li.list_id = l.id AND li.media_id = $2) AS \"already_added!\" FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC;",
-        user_info.login,
-        mediumid
-    )
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
-
-    let owner_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-        .bind(&user_info.login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            UserGroup {
-                id: row.get("id"),
-                name: row.get("name"),
-                owner: row.get("owner"),
-            }
-        })
-        .fetch_all(&pool)
+    let _ = db
+        .query("DELETE FROM list_items WHERE list_id = $lid AND media_id = $mid")
+        .bind(("lid", &listid))
+        .bind(("mid", &mediumid))
         .await
-        .unwrap_or_default();
+        .expect("Database error");
+
+    let lists = fetch_list_modal_entries(&db, &user_info.login, &mediumid).await;
+    let owner_groups = fetch_owner_groups(&db, &user_info.login).await;
 
     let template = HXListModalTemplate {
         lists,
@@ -616,96 +627,82 @@ async fn hx_remove_from_list(
 }
 
 async fn hx_delete_list(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(listid): Path<String>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
     let user_info = user_info.unwrap();
 
-    let list = sqlx::query!("SELECT owner FROM lists WHERE id=$1;", listid)
-        .fetch_one(&pool)
-        .await;
+    let mut owner_resp = db
+        .query("SELECT owner FROM lists WHERE id = $id")
+        .bind(("id", &listid))
+        .await
+        .expect("Database error");
 
-    match list {
-        Ok(record) => {
-            if record.owner != user_info.login {
-                return Html(
-                    "<script>window.location.replace(\"/\");</script>".to_owned(),
-                );
-            }
-        }
-        Err(_) => {
-            return Html(
-                "<script>window.location.replace(\"/\");</script>".to_owned(),
-            );
-        }
+    #[derive(Deserialize)]
+    struct OwnerRow { owner: String }
+    let owner_row: Option<OwnerRow> = owner_resp.take(0).expect("Deserialize error");
+    match owner_row {
+        Some(r) if r.owner == user_info.login => {}
+        _ => return Html("<script>window.location.replace(\"/\");</script>".to_owned()),
     }
 
-    let _ = sqlx::query!("DELETE FROM list_items WHERE list_id=$1;", listid)
-        .execute(&pool)
+    let _ = db
+        .query("DELETE FROM list_items WHERE list_id = $lid")
+        .bind(("lid", &listid))
         .await;
 
-    let _ = sqlx::query!("DELETE FROM lists WHERE id=$1;", listid)
-        .execute(&pool)
+    let _ = db
+        .query("DELETE FROM lists WHERE id = $id")
+        .bind(("id", &listid))
         .await;
 
     Html("<b class=\"text-success\">LIST DELETED</b><script>window.location.replace(\"/\");</script>".to_owned())
 }
 
 async fn hx_user_lists(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_user_lists_inner(pool, redis, headers, userid, 0).await
+    hx_user_lists_inner(db, redis, headers, userid, 0).await
 }
 
 async fn hx_user_lists_page(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path((userid, page)): Path<(String, i64)>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_user_lists_inner(pool, redis, headers, userid, page).await
+    hx_user_lists_inner(db, redis, headers, userid, page).await
 }
 
 async fn hx_user_lists_inner(
-    pool: PgPool,
+    db: Db,
     redis: RedisConn,
     headers: HeaderMap,
     userid: String,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, redis.clone()).await;
+    let user = get_user_login(headers, &db, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
     let offset = page * 40;
 
-    let mut lists: Vec<ListWithCount> = sqlx::query(
-        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 AND (l.visibility = 'public' OR (l.visibility = 'restricted' AND (l.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $2) OR (l.restricted_to_group = '__all_registered__' AND $2 != '') OR (l.restricted_to_group = '__subscribers__' AND $2 != '' AND l.owner IN (SELECT target FROM subscriptions WHERE subscriber = $2))))) ORDER BY l.created DESC LIMIT 41 OFFSET $3;"
-    )
-    .bind(&userid)
-    .bind(&user_login)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        ListWithCount {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            visibility: row.get("visibility"),
-            restricted_to_group: row.get("restricted_to_group"),
-            item_count: row.get("item_count"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query("SELECT id, name, owner, visibility, restricted_to_group, array::len((SELECT id FROM list_items WHERE list_id = $parent.id)) AS item_count FROM lists WHERE owner = $owner AND (visibility = 'public' OR (visibility = 'restricted' AND (restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $viewer) OR (restricted_to_group = '__all_registered__' AND string::len($viewer) > 0) OR (restricted_to_group = '__subscribers__' AND string::len($viewer) > 0 AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $viewer))))) ORDER BY created DESC LIMIT 41 START $offset")
+        .bind(("owner", &userid))
+        .bind(("viewer", &user_login))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
+
+    let mut lists: Vec<ListWithCount> = resp.take(0).unwrap_or_default();
 
     let has_more = lists.len() == 41;
     if has_more {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -444,7 +444,7 @@ async fn fetch_list_modal_entries(db: &Db, owner: &str, mediumid: &str) -> Vec<L
     }
 
     let mut resp = db
-        .query("SELECT id, name, array::len((SELECT id FROM list_items WHERE list_id = $parent.id AND media_id = $mid)) > 0 AS already_added FROM lists WHERE owner = $owner ORDER BY created DESC")
+        .query("SELECT id, name, (SELECT count() FROM list_items WHERE list_id = $parent.id AND media_id = $mid GROUP ALL)[0].count > 0 AS already_added FROM lists WHERE owner = $owner ORDER BY created DESC")
         .bind(("owner", owner))
         .bind(("mid", mediumid))
         .await
@@ -695,7 +695,7 @@ async fn hx_user_lists_inner(
     let offset = page * 40;
 
     let mut resp = db
-        .query("SELECT id, name, owner, visibility, restricted_to_group, array::len((SELECT id FROM list_items WHERE list_id = $parent.id)) AS item_count FROM lists WHERE owner = $owner AND (visibility = 'public' OR (visibility = 'restricted' AND (restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $viewer) OR (restricted_to_group = '__all_registered__' AND string::len($viewer) > 0) OR (restricted_to_group = '__subscribers__' AND string::len($viewer) > 0 AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $viewer))))) ORDER BY created DESC LIMIT 41 START $offset")
+        .query("SELECT id, name, owner, visibility, restricted_to_group, (SELECT count() FROM list_items WHERE list_id = $parent.id GROUP ALL)[0].count AS item_count FROM lists WHERE owner = $owner AND fn::visible_to(visibility, restricted_to_group, owner, $viewer) ORDER BY created DESC LIMIT 41 START $offset")
         .bind(("owner", &userid))
         .bind(("viewer", &user_login))
         .bind(("offset", offset))

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -78,7 +78,7 @@ async fn list_page(
 ) -> axum::response::Html<Vec<u8>> {
     let mut resp = db
         .query("SELECT id, name, owner, visibility, restricted_to_group FROM lists WHERE id = $id")
-        .bind(("id", &listid))
+        .bind(("id", listid.clone()))
         .await
         .expect("Database error");
 
@@ -142,7 +142,7 @@ async fn medium_in_list(
 ) -> axum::response::Html<Vec<u8>> {
     let mut resp = db
         .query("SELECT id, visibility, restricted_to_group, owner, name FROM lists WHERE id = $id")
-        .bind(("id", &listid))
+        .bind(("id", listid.clone()))
         .await
         .expect("Database error");
 
@@ -335,7 +335,7 @@ async fn hx_list_items_inner(
 
     let mut resp = db
         .query("SELECT media_id.id AS id, media_id.name AS name, media_id.owner AS owner, media_id.views AS views, media_id.type AS type FROM list_items WHERE list_id = $lid ORDER BY position ASC LIMIT 41 START $offset")
-        .bind(("lid", &listid))
+        .bind(("lid", listid.clone()))
         .bind(("offset", offset))
         .await
         .expect("Database error");
@@ -387,7 +387,7 @@ async fn hx_list_sidebar(
 
     let mut resp = db
         .query("SELECT media_id.id AS id, media_id.name AS name, media_id.owner AS owner, media_id.views AS views, media_id.type AS type FROM list_items WHERE list_id = $lid ORDER BY position ASC")
-        .bind(("lid", &listid))
+        .bind(("lid", listid.clone()))
         .await
         .expect("Database error");
 
@@ -445,8 +445,8 @@ async fn fetch_list_modal_entries(db: &Db, owner: &str, mediumid: &str) -> Vec<L
 
     let mut resp = db
         .query("SELECT id, name, (SELECT count() FROM list_items WHERE list_id = $parent.id AND media_id = $mid GROUP ALL)[0].count > 0 AS already_added FROM lists WHERE owner = $owner ORDER BY created DESC")
-        .bind(("owner", owner))
-        .bind(("mid", mediumid))
+        .bind(("owner", owner.to_string()))
+        .bind(("mid", mediumid.to_string()))
         .await
         .expect("Database error");
 
@@ -463,7 +463,7 @@ async fn fetch_owner_groups(db: &Db, owner: &str) -> Vec<UserGroup> {
 
     let mut resp = db
         .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC")
-        .bind(("owner", owner))
+        .bind(("owner", owner.to_string()))
         .await
         .expect("Database error");
 
@@ -500,19 +500,19 @@ async fn hx_create_list(
 
     let _ = db
         .query("CREATE type::thing('lists', $lid) SET name = $name, owner = $owner, public = $public, visibility = $visibility, restricted_to_group = $rtg, created = time::unix(time::now())")
-        .bind(("lid", &list_id))
-        .bind(("name", &form.name))
-        .bind(("owner", &user_info.login))
+        .bind(("lid", list_id.clone()))
+        .bind(("name", form.name.clone()))
+        .bind(("owner", user_info.login.clone()))
         .bind(("public", is_public))
-        .bind(("visibility", visibility))
-        .bind(("rtg", &restricted_to_group))
+        .bind(("visibility", visibility.to_string()))
+        .bind(("rtg", restricted_to_group.clone()))
         .await
         .expect("Database error");
 
     let _ = db
         .query("CREATE list_items SET list_id = $lid, media_id = $mid, position = 0")
-        .bind(("lid", &list_id))
-        .bind(("mid", &mediumid))
+        .bind(("lid", list_id.clone()))
+        .bind(("mid", mediumid.clone()))
         .await
         .expect("Database error");
 
@@ -541,7 +541,7 @@ async fn hx_add_to_list(
 
     let mut owner_resp = db
         .query("SELECT owner FROM lists WHERE id = $id")
-        .bind(("id", &listid))
+        .bind(("id", listid.clone()))
         .await
         .expect("Database error");
 
@@ -556,7 +556,7 @@ async fn hx_add_to_list(
     // Get max position
     let mut pos_resp = db
         .query("SELECT VALUE math::max(position) FROM list_items WHERE list_id = $lid")
-        .bind(("lid", &listid))
+        .bind(("lid", listid.clone()))
         .await
         .expect("Database error");
 
@@ -565,8 +565,8 @@ async fn hx_add_to_list(
 
     let _ = db
         .query("CREATE list_items SET list_id = $lid, media_id = $mid, position = $pos")
-        .bind(("lid", &listid))
-        .bind(("mid", &mediumid))
+        .bind(("lid", listid.clone()))
+        .bind(("mid", mediumid.clone()))
         .bind(("pos", next_pos))
         .await
         .expect("Database error");
@@ -596,7 +596,7 @@ async fn hx_remove_from_list(
 
     let mut owner_resp = db
         .query("SELECT owner FROM lists WHERE id = $id")
-        .bind(("id", &listid))
+        .bind(("id", listid.clone()))
         .await
         .expect("Database error");
 
@@ -610,8 +610,8 @@ async fn hx_remove_from_list(
 
     let _ = db
         .query("DELETE FROM list_items WHERE list_id = $lid AND media_id = $mid")
-        .bind(("lid", &listid))
-        .bind(("mid", &mediumid))
+        .bind(("lid", listid.clone()))
+        .bind(("mid", mediumid.clone()))
         .await
         .expect("Database error");
 
@@ -640,7 +640,7 @@ async fn hx_delete_list(
 
     let mut owner_resp = db
         .query("SELECT owner FROM lists WHERE id = $id")
-        .bind(("id", &listid))
+        .bind(("id", listid.clone()))
         .await
         .expect("Database error");
 
@@ -654,12 +654,12 @@ async fn hx_delete_list(
 
     let _ = db
         .query("DELETE FROM list_items WHERE list_id = $lid")
-        .bind(("lid", &listid))
+        .bind(("lid", listid.clone()))
         .await;
 
     let _ = db
         .query("DELETE FROM lists WHERE id = $id")
-        .bind(("id", &listid))
+        .bind(("id", listid.clone()))
         .await;
 
     Html("<b class=\"text-success\">LIST DELETED</b><script>window.location.replace(\"/\");</script>".to_owned())
@@ -696,8 +696,8 @@ async fn hx_user_lists_inner(
 
     let mut resp = db
         .query("SELECT id, name, owner, visibility, restricted_to_group, (SELECT count() FROM list_items WHERE list_id = $parent.id GROUP ALL)[0].count AS item_count FROM lists WHERE owner = $owner AND fn::visible_to(visibility, restricted_to_group, owner, $viewer) ORDER BY created DESC LIMIT 41 START $offset")
-        .bind(("owner", &userid))
-        .bind(("viewer", &user_login))
+        .bind(("owner", userid.clone()))
+        .bind(("viewer", user_login.clone()))
         .bind(("offset", offset))
         .await
         .expect("Database error");

--- a/src/login_handler.rs
+++ b/src/login_handler.rs
@@ -24,34 +24,51 @@ struct LoginForm {
     password: String,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 struct User {
     login: String,
     name: String,
     profile_picture: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct UserAuthRow {
+    password_hash: String,
+}
+
+#[derive(Deserialize)]
+struct TotpEnabledRow {
+    totp_enabled: bool,
+}
+
 async fn hx_login(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     Form(form): Form<LoginForm>,
 ) -> impl IntoResponse {
-    let password_hash_get = sqlx::query!(
-        "SELECT password_hash FROM users WHERE login=$1;",
-        form.login
-    )
-    .fetch_one(&pool)
-    .await;
+    let mut resp = match db
+        .query("SELECT password_hash FROM users WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &form.login)))
+        .await
+    {
+        Ok(r) => r,
+        Err(_) => {
+            return (StatusCode::OK, HeaderMap::new(), "<b class=\"text-danger\">Wrong user name or password</b>".to_owned());
+        }
+    };
 
-    if password_hash_get.is_err() {
-        let response_headers = HeaderMap::new();
-        let response_body = "<b class=\"text-danger\">Wrong user name or password</b>".to_owned();
+    let row: Option<UserAuthRow> = match resp.take(0) {
+        Ok(r) => r,
+        Err(_) => None,
+    };
 
-        return (StatusCode::OK, response_headers, response_body);
-    }
-
-    let password_hash = password_hash_get.unwrap().password_hash;
+    let password_hash = match row {
+        Some(r) => r.password_hash,
+        None => {
+            return (StatusCode::OK, HeaderMap::new(), "<b class=\"text-danger\">Wrong user name or password</b>".to_owned());
+        }
+    };
 
     if Argon2::default()
         .verify_password(
@@ -61,16 +78,15 @@ async fn hx_login(
         .is_ok()
     {
         // Check if TOTP is enabled for this user
-        let totp_enabled: bool = sqlx::query_scalar(
-            "SELECT totp_enabled FROM users WHERE login=$1",
-        )
-        .bind(&form.login)
-        .fetch_one(&pool)
-        .await
-        .unwrap_or(false);
+        let mut resp2 = db
+            .query("SELECT totp_enabled FROM users WHERE id = $id")
+            .bind(("id", surrealdb::RecordId::from_table_key("users", &form.login)))
+            .await
+            .unwrap_or_else(|_| unreachable!());
+        let totp_row: Option<TotpEnabledRow> = resp2.take(0).unwrap_or(None);
+        let totp_enabled = totp_row.map(|r| r.totp_enabled).unwrap_or(false);
 
         if totp_enabled {
-            // Create a short-lived pending session and ask for TOTP code
             let pending_token = generate_secure_string();
             let _: () = redis
                 .set_ex(
@@ -113,10 +129,7 @@ async fn hx_login(
         let response_body = "<b class=\"text-sucess\">LOGIN SUCESS</b><script>window.location.replace(\"/\");</script>".to_owned();
         return (StatusCode::OK, response_headers, response_body);
     } else {
-        let response_headers = HeaderMap::new();
-        let response_body = "<b class=\"text-danger\">Wrong user name or password</b>".to_owned();
-
-        return (StatusCode::OK, response_headers, response_body);
+        return (StatusCode::OK, HeaderMap::new(), "<b class=\"text-danger\">Wrong user name or password</b>".to_owned());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,18 +28,28 @@ use meilisearch_sdk::client::Client as MeilisearchClient;
 use redis::AsyncCommands;
 use serde::Deserialize;
 use serde::Serialize;
-use sqlx::postgres::PgPoolOptions;
-use sqlx::PgPool;
+use surrealdb::engine::remote::ws::{Client as WsClient, Ws};
+use surrealdb::opt::auth::Root;
+use surrealdb::Surreal;
 use std::io::BufRead;
 use std::sync::Arc;
 use tokio::{fs, io, io::AsyncWriteExt};
 use tower_http::services::ServeDir;
 
 type RedisConn = redis::aio::ConnectionManager;
+type Db = Surreal<WsClient>;
 
 #[derive(Deserialize, Clone)]
 struct Config {
-    dbconnection: String,
+    surrealdb_url: String,
+    #[serde(default = "default_surreal_ns")]
+    surrealdb_ns: String,
+    #[serde(default = "default_surreal_db")]
+    surrealdb_db: String,
+    #[serde(default = "default_surreal_user")]
+    surrealdb_user: String,
+    #[serde(default = "default_surreal_pass")]
+    surrealdb_pass: String,
     redis_url: String,
     instancename: String,
     welcome: String,
@@ -54,16 +64,37 @@ struct Config {
     /// WebAuthn Relying Party origin (e.g. "https://example.com"). Required to enable WebAuthn/passkey login.
     webauthn_rp_origin: Option<String>,
 }
+
+fn default_surreal_ns() -> String { "platform".to_string() }
+fn default_surreal_db() -> String { "platform".to_string() }
+fn default_surreal_user() -> String { "root".to_string() }
+fn default_surreal_pass() -> String { "root".to_string() }
+
 #[tokio::main]
 async fn main() {
     let config: Config =
         serde_json::from_str(&fs::read_to_string("config.json").await.unwrap()).unwrap();
 
-    let pool = PgPoolOptions::new()
-        .max_connections(100)
-        .connect(&config.dbconnection)
+    let db: Db = Surreal::new::<Ws>(&config.surrealdb_url)
         .await
-        .unwrap();
+        .expect("Failed to connect to SurrealDB");
+
+    db.signin(Root {
+        username: &config.surrealdb_user,
+        password: &config.surrealdb_pass,
+    })
+    .await
+    .expect("Failed to authenticate with SurrealDB");
+
+    db.use_ns(&config.surrealdb_ns)
+        .use_db(&config.surrealdb_db)
+        .await
+        .expect("Failed to select SurrealDB namespace/database");
+
+    println!(
+        "SurrealDB connected: url={}, ns={}, db={}",
+        &config.surrealdb_url, &config.surrealdb_ns, &config.surrealdb_db
+    );
 
     let meilisearch_client = MeilisearchClient::new(
         &config.meilisearch_url,
@@ -255,7 +286,7 @@ async fn main() {
         .route("/hx/group/{groupid}/removemember/{login}", get(hx_remove_group_member))
         .route("/hx/usergroups.json", get(hx_user_groups_json))
         .nest("/source", static_router("source"))
-        .layer(Extension(pool))
+        .layer(Extension(db))
         .layer(Extension(config))
         .layer(Extension(redis_conn))
         .layer(Extension(Arc::new(meilisearch_client)))

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -60,40 +60,59 @@ struct Medium {
     sprite_y: i32,
 }
 
+#[derive(Deserialize)]
+struct MediumRow {
+    id: String,
+    name: String,
+    owner: String,
+    views: i64,
+    r#type: String,
+    visibility: String,
+    restricted_to_group: Option<String>,
+    upload: i64,
+    owner_name: Option<String>,
+    owner_picture: Option<String>,
+}
+
 async fn medium(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user = get_user_login(headers.clone(), &db, redis.clone()).await;
     let is_logged_in = user.is_some();
 
     // Fetch media with visibility info and owner profile
-    let medium_row = sqlx::query(
-        "SELECT m.id, m.name, m.description, m.upload, m.owner, m.views, m.type, m.visibility, m.restricted_to_group, u.name as owner_name, u.profile_picture as owner_picture FROM media m LEFT JOIN users u ON m.owner = u.login WHERE m.id=$1;"
-    )
-    .bind(mediumid.to_ascii_lowercase())
-    .fetch_one(&pool)
-    .await;
+    let medium_row: Option<MediumRow> = db
+        .query(
+            "SELECT m.id, m.name, m.description, m.upload, m.owner, m.views, m.type, m.visibility, m.restricted_to_group, \
+             (SELECT name FROM users WHERE id = $parent.owner)[0] AS owner_name, \
+             (SELECT profile_picture FROM users WHERE id = $parent.owner)[0] AS owner_picture \
+             FROM media AS m WHERE m.id = $id LIMIT 1;"
+        )
+        .bind(("id", surrealdb::RecordId::from_table_key("media", &mediumid.to_ascii_lowercase())))
+        .await
+        .and_then(|mut r| r.take(0))
+        .ok()
+        .and_then(|mut v: Vec<MediumRow>| if v.is_empty() { None } else { Some(v.remove(0)) });
 
     let medium = match medium_row {
-        Ok(row) => row,
-        Err(_) => {
+        Some(row) => row,
+        None => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),
             ));
         }
     };
 
-    use sqlx::Row;
-    let visibility: String = medium.get("visibility");
-    let restricted_to_group: Option<String> = medium.get("restricted_to_group");
-    let owner: String = medium.get("owner");
+    let visibility = medium.visibility.clone();
+    let restricted_to_group = medium.restricted_to_group.clone();
+    let owner = medium.owner.clone();
 
     // Access control for restricted content
-    if !can_access_restricted(&pool, &visibility, restricted_to_group.as_deref(), &owner, &user, redis.clone()).await {
+    if !can_access_restricted(&db, &visibility, restricted_to_group.as_deref(), &owner, &user, redis.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/\");</script>".to_owned(),
         ));
@@ -101,7 +120,7 @@ async fn medium(
 
     let common_headers = extract_common_headers(&headers).unwrap();
 
-    let medium_id: String = medium.get("id");
+    let medium_id = medium.id.clone();
     let medium_captions_exist: bool;
     let mut medium_captions_list: Vec<CaptionEntry> = Vec::new();
     if std::path::Path::new(&format!("source/{}/captions/list.txt", medium_id)).exists() {
@@ -144,13 +163,13 @@ async fn medium(
     let template = MediumTemplate {
         sidebar,
         medium_id,
-        medium_name: medium.get("name"),
-        medium_owner: medium.get("owner"),
-        medium_owner_name: medium.get("owner_name"),
-        medium_owner_picture: medium.get("owner_picture"),
-        medium_upload: prettyunixtime(medium.get("upload")).await,
-        medium_views: medium.get("views"),
-        medium_type: medium.get("type"),
+        medium_name: medium.name,
+        medium_owner: medium.owner,
+        medium_owner_name: medium.owner_name.unwrap_or_default(),
+        medium_owner_picture: medium.owner_picture,
+        medium_upload: prettyunixtime(medium.upload).await,
+        medium_views: medium.views,
+        medium_type: medium.r#type,
         medium_captions_exist,
         medium_captions_list,
         medium_has_ass_captions,
@@ -222,21 +241,26 @@ fn fix_vtt_urls(vtt_content: &str, mediumid: &str) -> String {
         .join("\n")
 }
 
+#[derive(Deserialize)]
+struct DescriptionRow {
+    description: Option<String>,
+}
+
 async fn medium_description_prepare(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    Json(
-        sqlx::query!(
-            "SELECT description FROM media WHERE id=$1;",
-            mediumid.to_ascii_lowercase()
-        )
-        .fetch_one(&pool)
+    let description: Option<String> = db
+        .query("SELECT description FROM media WHERE id = $id LIMIT 1;")
+        .bind(("id", surrealdb::RecordId::from_table_key("media", &mediumid.to_ascii_lowercase())))
         .await
-        .expect("Database error")
-        .description
-        .unwrap_or_default(),
-    )
+        .and_then(|mut r| r.take(0))
+        .ok()
+        .and_then(|mut v: Vec<DescriptionRow>| v.pop())
+        .and_then(|row| row.description)
+        .unwrap_or_default()
+        .into();
+    Json(serde_json::Value::String(description.unwrap_or_default()))
 }
 
 #[derive(Template)]

--- a/src/mp4_compose.rs
+++ b/src/mp4_compose.rs
@@ -1,6 +1,5 @@
 /// Parses an HLS master playlist and returns the URI of the variant with either the lowest
-/// or highest BANDWIDTH. Returns the master path unchanged if it is not a master playlist
-/// or cannot be read.
+/// or highest BANDWIDTH.
 fn hls_variant_for_quality(master_path: &str, lowest: bool) -> String {
     let Ok(content) = std::fs::read_to_string(master_path) else {
         return master_path.to_string();
@@ -42,8 +41,6 @@ fn hls_variant_for_quality(master_path: &str, lowest: bool) -> String {
     best.map(|(_, p)| p).unwrap_or_else(|| master_path.to_string())
 }
 
-/// Parses a DASH MPD and returns the 0-based index (as FFmpeg numbers it) of the video stream
-/// with the lowest bandwidth. Returns 0 on parse failure or when only one stream exists.
 fn mpd_lowest_video_stream_idx(mpd_path: &str) -> usize {
     let Ok(content) = std::fs::read_to_string(mpd_path) else {
         return 0;
@@ -79,23 +76,35 @@ fn xml_attr<'a>(element: &'a str, attr: &str) -> Option<&'a str> {
     Some(&element[start..end])
 }
 
+#[derive(Deserialize)]
+struct MediaStreamRow {
+    id: String,
+    name: String,
+    #[serde(rename = "type")]
+    r#type: String,
+    visibility: String,
+    restricted_to_group: Option<String>,
+    owner: String,
+}
+
 async fn stream_video_as_mp4(
-    pool: &PgPool,
+    db: &Db,
     redis: RedisConn,
     headers: HeaderMap,
     medium_id: &str,
     lowest_quality: bool,
 ) -> Response<Body> {
-    let medium_row = sqlx::query(
-        "SELECT m.id, m.name, m.type, m.visibility, m.restricted_to_group, m.owner FROM media m WHERE m.id=$1;"
-    )
-    .bind(medium_id)
-    .fetch_optional(pool)
-    .await;
+    let mut resp = db
+        .query("SELECT id, name, type, visibility, restricted_to_group, owner FROM media WHERE id = $id")
+        .bind(("id", medium_id))
+        .await
+        .unwrap_or_else(|_| unreachable!());
 
-    let medium = match medium_row {
-        Ok(Some(row)) => row,
-        _ => {
+    let medium: Option<MediaStreamRow> = resp.take(0).unwrap_or(None);
+
+    let medium = match medium {
+        Some(m) => m,
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .body(Body::empty())
@@ -103,25 +112,20 @@ async fn stream_video_as_mp4(
         }
     };
 
-    use sqlx::Row;
-    let medium_type: String = medium.get("type");
-    if medium_type != "video" {
+    if medium.r#type != "video" {
         return Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body(Body::empty())
             .unwrap();
     }
 
-    let visibility: String = medium.get("visibility");
-    let restricted_to_group: Option<String> = medium.get("restricted_to_group");
-    let owner: String = medium.get("owner");
-    let user = get_user_login(headers, pool, redis.clone()).await;
+    let user = get_user_login(headers, db, redis.clone()).await;
 
     if !can_access_restricted(
-        pool,
-        &visibility,
-        restricted_to_group.as_deref(),
-        &owner,
+        db,
+        &medium.visibility,
+        medium.restricted_to_group.as_deref(),
+        &medium.owner,
         &user,
         redis.clone(),
     )
@@ -164,8 +168,6 @@ async fn stream_video_as_mp4(
 
     cmd.arg("-i").arg(&input_path);
 
-    // For DASH with lowest quality, explicitly map the lowest-bandwidth video stream.
-    // For HLS, quality selection is done by passing the variant playlist directly as input.
     if !is_hls && lowest_quality {
         let idx = mpd_lowest_video_stream_idx(&mpd_path);
         cmd.arg("-map").arg(format!("0:v:{}", idx))
@@ -199,8 +201,7 @@ async fn stream_video_as_mp4(
         let _ = child.wait().await;
     });
 
-    let medium_name: String = medium.get("name");
-    let safe_filename: String = medium_name
+    let safe_filename: String = medium.name
         .chars()
         .map(|c| {
             if c.is_alphanumeric() || c == '-' || c == '_' || c == ' ' || c == '.' {
@@ -228,19 +229,19 @@ async fn stream_video_as_mp4(
 }
 
 async fn compose_mp4_sm(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Response<Body> {
-    stream_video_as_mp4(&pool, redis, headers, &mediumid.to_ascii_lowercase(), true).await
+    stream_video_as_mp4(&db, redis, headers, &mediumid.to_ascii_lowercase(), true).await
 }
 
 async fn compose_mp4(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Response<Body> {
-    stream_video_as_mp4(&pool, redis, headers, &mediumid.to_ascii_lowercase(), false).await
+    stream_video_as_mp4(&db, redis, headers, &mediumid.to_ascii_lowercase(), false).await
 }

--- a/src/mp4_compose.rs
+++ b/src/mp4_compose.rs
@@ -96,7 +96,7 @@ async fn stream_video_as_mp4(
 ) -> Response<Body> {
     let mut resp = db
         .query("SELECT id, name, type, visibility, restricted_to_group, owner FROM media WHERE id = $id")
-        .bind(("id", medium_id))
+        .bind(("id", medium_id.to_string()))
         .await
         .unwrap_or_else(|_| unreachable!());
 

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -1,38 +1,65 @@
 async fn hx_recommended(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Result<Html<Vec<u8>>, axum::response::Response> {
-    let user = get_user_login(headers, &pool, redis.clone()).await;
+    let user = get_user_login(headers, &db, redis.clone()).await;
     let user_login = user.map(|u| u.login).unwrap_or_default();
 
-    let media: Vec<Medium> = sqlx::query(
-        "SELECT id, name, owner, views, type FROM media WHERE visibility = 'public' OR (visibility = 'restricted' AND restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1)) LIMIT 20;"
-    )
-    .bind(&user_login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        Medium {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            views: row.get("views"),
-            r#type: row.get("type"),
-            sprite_filename: None,
-            sprite_x: 0,
-            sprite_y: 0,
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .map_err(|_| {
+    #[derive(Deserialize)]
+    struct MediumRow {
+        id: surrealdb::RecordId,
+        name: String,
+        owner: String,
+        views: i64,
+        #[serde(rename = "type")]
+        r#type: String,
+    }
+
+    let mut response = db
+        .query(
+            "SELECT id, name, owner, views, type FROM media
+WHERE (
+    visibility = 'public'
+    OR (visibility = 'restricted' AND (
+        restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user)
+        OR (restricted_to_group = '__all_registered__' AND $user != '')
+        OR (restricted_to_group = '__subscribers__' AND $user != '' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user))
+    ))
+)
+LIMIT 20;",
+        )
+        .bind(("user", &user_login))
+        .await
+        .map_err(|_| {
+            axum::response::Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body("Failed to fetch recommendations".into())
+                .unwrap()
+        })?;
+
+    let rows: Vec<MediumRow> = response.take(0).map_err(|_| {
         axum::response::Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body("Failed to fetch recommendations".into())
             .unwrap()
     })?;
+
+    let media: Vec<Medium> = rows
+        .into_iter()
+        .map(|row| Medium {
+            id: row.id.key().to_string(),
+            name: row.name,
+            owner: row.owner,
+            views: row.views,
+            r#type: row.r#type,
+            sprite_filename: None,
+            sprite_x: 0,
+            sprite_y: 0,
+        })
+        .collect();
 
     let template = HXMediumListTemplate {
         current_medium_id: mediumid,

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -24,7 +24,7 @@ async fn hx_recommended(
              WHERE fn::visible_to(visibility, restricted_to_group, owner, $user) \
              LIMIT 20",
         )
-        .bind(("user", &user_login))
+        .bind(("user", user_login.clone()))
         .await
         .map_err(|_| {
             axum::response::Response::builder()

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -20,16 +20,9 @@ async fn hx_recommended(
 
     let mut response = db
         .query(
-            "SELECT id, name, owner, views, type FROM media
-WHERE (
-    visibility = 'public'
-    OR (visibility = 'restricted' AND (
-        restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user)
-        OR (restricted_to_group = '__all_registered__' AND $user != '')
-        OR (restricted_to_group = '__subscribers__' AND $user != '' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user))
-    ))
-)
-LIMIT 20;",
+            "SELECT id, name, owner, views, type FROM media \
+             WHERE fn::visible_to(visibility, restricted_to_group, owner, $user) \
+             LIMIT 20",
         )
         .bind(("user", &user_login))
         .await

--- a/src/search.rs
+++ b/src/search.rs
@@ -47,7 +47,7 @@ async fn build_visibility_filter(db: &Db, user: &Option<User>) -> String {
 
         let mut resp = db
             .query("SELECT group_id FROM user_group_members WHERE user_login = $user")
-            .bind(("user", &u.login))
+            .bind(("user", u.login.clone()))
             .await
             .unwrap_or_else(|_| unreachable!());
         let group_rows: Vec<GroupRow> = resp.take(0).unwrap_or_default();
@@ -55,7 +55,7 @@ async fn build_visibility_filter(db: &Db, user: &Option<User>) -> String {
 
         let mut resp2 = db
             .query("SELECT target FROM subscriptions WHERE subscriber = $user")
-            .bind(("user", &u.login))
+            .bind(("user", u.login.clone()))
             .await
             .unwrap_or_else(|_| unreachable!());
         let target_rows: Vec<TargetRow> = resp2.take(0).unwrap_or_default();

--- a/src/search.rs
+++ b/src/search.rs
@@ -38,24 +38,28 @@ impl From<MeiliMedia> for Medium {
 /// Build a Meilisearch filter string that respects group-based visibility.
 /// For logged-in users, shows public media + restricted media in their groups.
 /// For anonymous users, shows only public media.
-async fn build_visibility_filter(pool: &PgPool, user: &Option<User>) -> String {
+async fn build_visibility_filter(db: &Db, user: &Option<User>) -> String {
     if let Some(u) = user {
-        let group_ids: Vec<String> = sqlx::query_scalar(
-            "SELECT group_id FROM user_group_members WHERE user_login = $1"
-        )
-        .bind(&u.login)
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default();
+        #[derive(serde::Deserialize)]
+        struct GroupRow { group_id: String }
+        #[derive(serde::Deserialize)]
+        struct TargetRow { target: String }
 
-        // Fetch channels the user is subscribed to
-        let subscribed_channels: Vec<String> = sqlx::query_scalar(
-            "SELECT target FROM subscriptions WHERE subscriber = $1"
-        )
-        .bind(&u.login)
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default();
+        let mut resp = db
+            .query("SELECT group_id FROM user_group_members WHERE user_login = $user")
+            .bind(("user", &u.login))
+            .await
+            .unwrap_or_else(|_| unreachable!());
+        let group_rows: Vec<GroupRow> = resp.take(0).unwrap_or_default();
+        let group_ids: Vec<String> = group_rows.into_iter().map(|r| r.group_id).collect();
+
+        let mut resp2 = db
+            .query("SELECT target FROM subscriptions WHERE subscriber = $user")
+            .bind(("user", &u.login))
+            .await
+            .unwrap_or_else(|_| unreachable!());
+        let target_rows: Vec<TargetRow> = resp2.take(0).unwrap_or_default();
+        let subscribed_channels: Vec<String> = target_rows.into_iter().map(|r| r.target).collect();
 
         // Build the list of group IDs + system group for all registered users
         let mut all_group_ids = group_ids;
@@ -138,7 +142,7 @@ struct HXSearchSuggestionsTemplate {
 
 async fn hx_search_suggestions(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Extension(meili): Extension<Arc<MeilisearchClient>>,
     headers: HeaderMap,
@@ -148,8 +152,8 @@ async fn hx_search_suggestions(
         return Html("".to_owned());
     }
 
-    let user = get_user_login(headers, &pool, redis).await;
-    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let user = get_user_login(headers, &db, redis).await;
+    let visibility_filter = build_visibility_filter(&db, &user).await;
     let vis_filter_for_lists = format!("({})", visibility_filter);
 
     let (users_res, lists_res, media_res) = tokio::join!(
@@ -411,7 +415,7 @@ struct HXSearchAllTemplate {
 
 async fn hx_search(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Extension(meili): Extension<Arc<MeilisearchClient>>,
     headers: HeaderMap,
@@ -423,11 +427,11 @@ async fn hx_search(
     }
 
     let search_in = form.search_in.clone().unwrap_or_default();
-    let user = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user = get_user_login(headers.clone(), &db, redis.clone()).await;
 
     match search_in.as_str() {
         "lists" => {
-            return hx_search_lists_inner(config, pool, meili, user, pageid, form.search).await;
+            return hx_search_lists_inner(config, db.clone(), meili, user, pageid, form.search).await;
         }
         "users" => {
             return hx_search_users_inner(config, meili, pageid, form.search).await;
@@ -435,7 +439,7 @@ async fn hx_search(
         "media" => {} // fall through to media-only Meilisearch
         _ => {
             // Default: search all types simultaneously
-            return hx_search_all_inner(config, pool, meili, user, form.search).await;
+            return hx_search_all_inner(config, db.clone(), meili, user, form.search).await;
         }
     }
 
@@ -448,7 +452,7 @@ async fn hx_search(
     let date_range = form.date_range.clone().unwrap_or_default();
 
     // Build filter string with visibility-aware access control
-    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let visibility_filter = build_visibility_filter(&db, &user).await;
     let mut filters: Vec<String> = vec![format!("({})", visibility_filter)];
 
     // Media type filter
@@ -578,7 +582,7 @@ async fn hx_search(
 
 async fn hx_search_lists_inner(
     config: Config,
-    pool: PgPool,
+    db: Db,
     meili: Arc<MeilisearchClient>,
     user: Option<User>,
     pageid: usize,
@@ -588,7 +592,7 @@ async fn hx_search_lists_inner(
     let offset = pageid * 40;
 
     // Reuse the same visibility filter logic as media search
-    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let visibility_filter = build_visibility_filter(&db, &user).await;
     let filter_str = format!("({})", visibility_filter);
 
     let index = meili.index("lists");
@@ -770,12 +774,12 @@ async fn hx_search_users_inner(
 
 async fn hx_search_all_inner(
     config: Config,
-    pool: PgPool,
+    db: Db,
     meili: Arc<MeilisearchClient>,
     user: Option<User>,
     search_term: String,
 ) -> axum::response::Html<String> {
-    let visibility_filter = build_visibility_filter(&pool, &user).await;
+    let visibility_filter = build_visibility_filter(&db, &user).await;
     let vis_filter_parens = format!("({})", visibility_filter);
 
     let (users_res, lists_res, media_res) = tokio::join!(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,11 +9,11 @@ struct SettingsTemplate {
 
 async fn settings(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -31,11 +31,11 @@ async fn settings(
 
 async fn settings_password(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -53,11 +53,11 @@ async fn settings_password(
 
 async fn settings_profile_picture(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -75,11 +75,11 @@ async fn settings_profile_picture(
 
 async fn settings_channel_picture(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -97,11 +97,11 @@ async fn settings_channel_picture(
 
 async fn settings_diagnostics(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -118,11 +118,11 @@ async fn settings_diagnostics(
 }
 
 async fn settings_2fa(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Response {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return axum::response::Redirect::to("/login").into_response();
     }
     axum::response::Redirect::to("/settings/password").into_response()
@@ -136,11 +136,11 @@ struct HXSettingsChannelNameTemplate {
     current_name: String,
 }
 async fn hx_settings_channel_name(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
@@ -156,12 +156,12 @@ struct ChannelNameForm {
     channel_name: String,
 }
 async fn hx_settings_channel_name_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<ChannelNameForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
@@ -170,10 +170,10 @@ async fn hx_settings_channel_name_save(
     if new_name.is_empty() || new_name.len() > 100 {
         return Html(minifi_html("<b class=\"text-danger\">Channel name must be between 1 and 100 characters.</b>".to_owned()));
     }
-    let result = sqlx::query("UPDATE users SET name=$1 WHERE login=$2;")
-        .bind(new_name)
-        .bind(&user_info.login)
-        .execute(&pool)
+    let result = db
+        .query("UPDATE users SET name = $name WHERE id = $id")
+        .bind(("name", new_name))
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
         return Html(minifi_html("<b class=\"text-danger\">Failed to update channel name.</b>".to_owned()));
@@ -185,11 +185,11 @@ async fn hx_settings_channel_name_save(
 #[template(path = "pages/hx-settings-password.html", escape = "none")]
 struct HXSettingsPasswordTemplate {}
 async fn hx_settings_password(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
@@ -204,12 +204,12 @@ struct PasswordForm {
     confirm_password: String,
 }
 async fn hx_settings_password_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<PasswordForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
@@ -223,10 +223,14 @@ async fn hx_settings_password_save(
     }
 
     // Verify current password
-    let stored = sqlx::query_scalar::<_, String>("SELECT password_hash FROM users WHERE login=$1")
-        .bind(&user_info.login)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)] struct HashRow { password_hash: String }
+    let mut _hash_resp = db
+        .query("SELECT password_hash FROM users WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let _hash_row: Option<HashRow> = _hash_resp.take(0).unwrap_or(None);
+    let stored: Result<String, ()> = _hash_row.map(|r| r.password_hash).ok_or(());
     if stored.is_err() {
         return Html(minifi_html("<b class=\"text-danger\">Failed to verify current password.</b>".to_owned()));
     }
@@ -247,10 +251,10 @@ async fn hx_settings_password_save(
     }
     let new_hash_string = new_hash.unwrap().to_string();
 
-    let result = sqlx::query("UPDATE users SET password_hash=$1 WHERE login=$2;")
-        .bind(&new_hash_string)
-        .bind(&user_info.login)
-        .execute(&pool)
+    let result = db
+        .query("UPDATE users SET password_hash = $hash WHERE id = $id")
+        .bind(("hash", &new_hash_string))
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
         return Html(minifi_html("<b class=\"text-danger\">Failed to update password.</b>".to_owned()));
@@ -275,37 +279,31 @@ struct HXSettingsProfilePictureTemplate {
 }
 async fn hx_settings_profile_picture(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let current_picture: Option<String> = sqlx::query_scalar("SELECT profile_picture FROM users WHERE login=$1")
-        .bind(&user_info.login)
-        .fetch_one(&pool)
+    #[derive(serde::Deserialize)] struct PicRow { profile_picture: Option<String> }
+    let mut _pic_resp = db
+        .query("SELECT profile_picture FROM users WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await
-        .unwrap_or(None);
+        .unwrap_or_else(|_| unreachable!());
+    let _pic_row: Option<PicRow> = _pic_resp.take(0).unwrap_or(None);
+    let current_picture: Option<String> = _pic_row.and_then(|r| r.profile_picture);
 
-    let media: Vec<PictureMedium> = sqlx::query(
-        "SELECT id, name, visibility FROM media WHERE owner=$1 AND type='picture' AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
-    )
-    .bind(&user_info.login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        PictureMedium {
-            id: row.get("id"),
-            name: row.get("name"),
-            visibility: row.get("visibility"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
+    let mut _media_resp = db
+        .query("SELECT id, name, visibility FROM media WHERE owner = $owner AND type = 'picture' AND (visibility = 'public' OR visibility = 'hidden') ORDER BY upload DESC")
+        .bind(("owner", &user_info.login))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media: Vec<PictureMedium> = _media_resp.take(0).unwrap_or_default();
 
     let template = HXSettingsProfilePictureTemplate { media, current_picture, config };
     Html(minifi_html(template.render().unwrap()))
@@ -316,28 +314,31 @@ struct PictureForm {
     medium_id: String,
 }
 async fn hx_settings_profile_picture_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<PictureForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
     let user_info = user_info.unwrap();
 
     // Verify the medium belongs to this user, is an image, and is public or hidden
-    let medium = sqlx::query("SELECT owner, visibility, type FROM media WHERE id=$1")
-        .bind(&form.medium_id)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)] struct MediaVerRow { owner: String, visibility: String, #[serde(rename = "type")] r#type: String }
+    let mut _mver_resp = db
+        .query("SELECT owner, visibility, type FROM media WHERE id = $id")
+        .bind(("id", &form.medium_id))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let _medium_ver: Option<MediaVerRow> = _mver_resp.take(0).unwrap_or(None);
+    let medium = _medium_ver;
     match medium {
-        Ok(record) => {
-            use sqlx::Row;
-            let owner: String = record.get("owner");
-            let visibility: String = record.get("visibility");
-            let medium_type: String = record.get("type");
+        Some(record) => {
+            let owner = record.owner;
+            let visibility = record.visibility;
+            let medium_type = record.r#type;
             if owner != user_info.login {
                 return Html(minifi_html("<b class=\"text-danger\">You can only use your own media.</b>".to_owned()));
             }
@@ -353,10 +354,10 @@ async fn hx_settings_profile_picture_save(
         }
     }
 
-    let result = sqlx::query("UPDATE users SET profile_picture=$1 WHERE login=$2;")
-        .bind(&form.medium_id)
-        .bind(&user_info.login)
-        .execute(&pool)
+    let result = db
+        .query("UPDATE users SET profile_picture = $pic WHERE id = $id")
+        .bind(("pic", &form.medium_id))
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
         return Html(minifi_html("<b class=\"text-danger\">Failed to update profile picture.</b>".to_owned()));
@@ -375,65 +376,62 @@ struct HXSettingsChannelPictureTemplate {
 }
 async fn hx_settings_channel_picture(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let current_picture: Option<String> = sqlx::query_scalar("SELECT channel_picture FROM users WHERE login=$1")
-        .bind(&user_info.login)
-        .fetch_one(&pool)
+    #[derive(serde::Deserialize)] struct ChanPicRow { channel_picture: Option<String> }
+    let mut _cpic_resp = db
+        .query("SELECT channel_picture FROM users WHERE id = $id")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await
-        .unwrap_or(None);
+        .unwrap_or_else(|_| unreachable!());
+    let _cpic_row: Option<ChanPicRow> = _cpic_resp.take(0).unwrap_or(None);
+    let current_picture: Option<String> = _cpic_row.and_then(|r| r.channel_picture);
 
-    let media: Vec<PictureMedium> = sqlx::query(
-        "SELECT id, name, visibility FROM media WHERE owner=$1 AND type='picture' AND (visibility='public' OR visibility='hidden') ORDER BY upload DESC;"
-    )
-    .bind(&user_info.login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        PictureMedium {
-            id: row.get("id"),
-            name: row.get("name"),
-            visibility: row.get("visibility"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
+    let mut _media_resp = db
+        .query("SELECT id, name, visibility FROM media WHERE owner = $owner AND type = 'picture' AND (visibility = 'public' OR visibility = 'hidden') ORDER BY upload DESC")
+        .bind(("owner", &user_info.login))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media: Vec<PictureMedium> = _media_resp.take(0).unwrap_or_default();
 
     let template = HXSettingsChannelPictureTemplate { media, current_picture, config };
     Html(minifi_html(template.render().unwrap()))
 }
 
 async fn hx_settings_channel_picture_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<PictureForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
     let user_info = user_info.unwrap();
 
     // Verify the medium belongs to this user, is an image, and is public or hidden
-    let medium = sqlx::query("SELECT owner, visibility, type FROM media WHERE id=$1")
-        .bind(&form.medium_id)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)] struct MediaVerRow { owner: String, visibility: String, #[serde(rename = "type")] r#type: String }
+    let mut _mver_resp = db
+        .query("SELECT owner, visibility, type FROM media WHERE id = $id")
+        .bind(("id", &form.medium_id))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let _medium_ver: Option<MediaVerRow> = _mver_resp.take(0).unwrap_or(None);
+    let medium = _medium_ver;
     match medium {
-        Ok(record) => {
-            use sqlx::Row;
-            let owner: String = record.get("owner");
-            let visibility: String = record.get("visibility");
-            let medium_type: String = record.get("type");
+        Some(record) => {
+            let owner = record.owner;
+            let visibility = record.visibility;
+            let medium_type = record.r#type;
             if owner != user_info.login {
                 return Html(minifi_html("<b class=\"text-danger\">You can only use your own media.</b>".to_owned()));
             }
@@ -449,10 +447,10 @@ async fn hx_settings_channel_picture_save(
         }
     }
 
-    let result = sqlx::query("UPDATE users SET channel_picture=$1 WHERE login=$2;")
-        .bind(&form.medium_id)
-        .bind(&user_info.login)
-        .execute(&pool)
+    let result = db
+        .query("UPDATE users SET channel_picture = $pic WHERE id = $id")
+        .bind(("pic", &form.medium_id))
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
         return Html(minifi_html("<b class=\"text-danger\">Failed to update channel picture.</b>".to_owned()));
@@ -496,11 +494,11 @@ struct HXSettingsDiagnosticsTemplate {
     os_arch: String,
 }
 async fn hx_settings_diagnostics(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -166,13 +166,13 @@ async fn hx_settings_channel_name_save(
         return Html(minifi_html("<script>window.location.replace(\"/login\");</script>".to_owned()));
     }
     let user_info = user_info.unwrap();
-    let new_name = form.channel_name.trim();
+    let new_name = form.channel_name.trim().to_owned();
     if new_name.is_empty() || new_name.len() > 100 {
         return Html(minifi_html("<b class=\"text-danger\">Channel name must be between 1 and 100 characters.</b>".to_owned()));
     }
     let result = db
         .query("UPDATE users SET name = $name WHERE id = $id")
-        .bind(("name", new_name))
+        .bind(("name", new_name.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
@@ -253,7 +253,7 @@ async fn hx_settings_password_save(
 
     let result = db
         .query("UPDATE users SET password_hash = $hash WHERE id = $id")
-        .bind(("hash", &new_hash_string))
+        .bind(("hash", new_hash_string.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
@@ -300,7 +300,7 @@ async fn hx_settings_profile_picture(
 
     let mut _media_resp = db
         .query("SELECT id, name, visibility FROM media WHERE owner = $owner AND type = 'picture' AND (visibility = 'public' OR visibility = 'hidden') ORDER BY upload DESC")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media: Vec<PictureMedium> = _media_resp.take(0).unwrap_or_default();
@@ -329,7 +329,7 @@ async fn hx_settings_profile_picture_save(
     #[derive(serde::Deserialize)] struct MediaVerRow { owner: String, visibility: String, #[serde(rename = "type")] r#type: String }
     let mut _mver_resp = db
         .query("SELECT owner, visibility, type FROM media WHERE id = $id")
-        .bind(("id", &form.medium_id))
+        .bind(("id", form.medium_id.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let _medium_ver: Option<MediaVerRow> = _mver_resp.take(0).unwrap_or(None);
@@ -349,14 +349,14 @@ async fn hx_settings_profile_picture_save(
                 return Html(minifi_html("<b class=\"text-danger\">Media must be public or hidden.</b>".to_owned()));
             }
         }
-        Err(_) => {
+        None => {
             return Html(minifi_html("<b class=\"text-danger\">Medium not found.</b>".to_owned()));
         }
     }
 
     let result = db
         .query("UPDATE users SET profile_picture = $pic WHERE id = $id")
-        .bind(("pic", &form.medium_id))
+        .bind(("pic", form.medium_id.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {
@@ -397,7 +397,7 @@ async fn hx_settings_channel_picture(
 
     let mut _media_resp = db
         .query("SELECT id, name, visibility FROM media WHERE owner = $owner AND type = 'picture' AND (visibility = 'public' OR visibility = 'hidden') ORDER BY upload DESC")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media: Vec<PictureMedium> = _media_resp.take(0).unwrap_or_default();
@@ -422,7 +422,7 @@ async fn hx_settings_channel_picture_save(
     #[derive(serde::Deserialize)] struct MediaVerRow { owner: String, visibility: String, #[serde(rename = "type")] r#type: String }
     let mut _mver_resp = db
         .query("SELECT owner, visibility, type FROM media WHERE id = $id")
-        .bind(("id", &form.medium_id))
+        .bind(("id", form.medium_id.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let _medium_ver: Option<MediaVerRow> = _mver_resp.take(0).unwrap_or(None);
@@ -442,14 +442,14 @@ async fn hx_settings_channel_picture_save(
                 return Html(minifi_html("<b class=\"text-danger\">Media must be public or hidden.</b>".to_owned()));
             }
         }
-        Err(_) => {
+        None => {
             return Html(minifi_html("<b class=\"text-danger\">Medium not found.</b>".to_owned()));
         }
     }
 
     let result = db
         .query("UPDATE users SET channel_picture = $pic WHERE id = $id")
-        .bind(("pic", &form.medium_id))
+        .bind(("pic", form.medium_id.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
     if result.is_err() {

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -19,11 +19,11 @@ struct HXSidebarTemplate {
 }
 async fn hx_sidebar(
     Extension(redis): Extension<RedisConn>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path(active_item): Path<String>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = get_user_login(headers, &pool, redis.clone()).await;
+    let user = get_user_login(headers, &db, redis.clone()).await;
     if user.is_some() {
         let template = HXSidebarTemplate {
             active_item,

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -83,7 +83,7 @@ async fn hx_studio_inner(
 
     let mut resp = db
         .query("SELECT id, name, description, views, type FROM media WHERE owner = $owner ORDER BY upload DESC LIMIT 41 START $offset;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .bind(("offset", offset))
         .await
         .expect("Database error");
@@ -166,7 +166,7 @@ async fn hx_studio_lists_inner(
 
     let mut resp = db
         .query("SELECT id, name, owner, visibility, restricted_to_group, array::len((SELECT id FROM list_items WHERE list_id = $parent.id)) AS item_count FROM lists WHERE owner = $owner ORDER BY created DESC LIMIT 41 START $offset;")
-        .bind(("owner", &user_info.login))
+        .bind(("owner", user_info.login.clone()))
         .bind(("offset", offset))
         .await
         .expect("Database error");
@@ -268,7 +268,7 @@ async fn studio_edit(
 
     let mut resp = db
         .query("SELECT id, name, owner, visibility, restricted_to_group, type FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .expect("Database error");
 
@@ -341,10 +341,10 @@ async fn studio_edit_save(
     // Ownership check + update in one query: returns nothing if id/owner don't match
     let mut update_resp = db
         .query("UPDATE media SET name = $name, description = $description WHERE id = $id AND owner = $owner RETURN id")
-        .bind(("name", &form.medium_name))
-        .bind(("description", &description))
-        .bind(("id", &mediumid))
-        .bind(("owner", &user_info.login))
+        .bind(("name", form.medium_name.clone()))
+        .bind(("description", description.clone()))
+        .bind(("id", mediumid.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await;
 
     let updated: Vec<serde_json::Value> = update_resp.as_mut().ok()
@@ -374,8 +374,8 @@ async fn hx_delete_video(
     // Ownership check + delete in one query; returns nothing if not owner
     let mut del_resp = db
         .query("DELETE FROM media WHERE id = $id AND owner = $owner RETURN id")
-        .bind(("id", &mediumid))
-        .bind(("owner", &user_info.login))
+        .bind(("id", mediumid.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
 
@@ -387,7 +387,7 @@ async fn hx_delete_video(
     // Media deleted — clean up related records in a single round-trip
     let _ = db
         .query("DELETE FROM comments WHERE media = $id; DELETE FROM list_items WHERE media_id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await;
 
     // Delete the source directory
@@ -411,7 +411,7 @@ async fn hx_studio_edit_description(
 
     let mut resp = db
         .query("SELECT id, name, owner, visibility, restricted_to_group, type FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .expect("Database error");
 
@@ -453,8 +453,8 @@ async fn hx_studio_edit_chapters_tab(
     // Single WHERE clause confirms ownership without a separate read
     let mut owns_resp = db
         .query("SELECT id FROM media WHERE id = $id AND owner = $owner")
-        .bind(("id", &mediumid))
-        .bind(("owner", &user_info.login))
+        .bind(("id", mediumid.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
     if owns_resp.take::<Vec<serde_json::Value>>(0).unwrap_or_default().is_empty() {
@@ -480,8 +480,8 @@ async fn hx_studio_edit_subtitles_tab(
     // Single WHERE clause confirms ownership without a separate read
     let mut owns_resp = db
         .query("SELECT id FROM media WHERE id = $id AND owner = $owner")
-        .bind(("id", &mediumid))
-        .bind(("owner", &user_info.login))
+        .bind(("id", mediumid.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
     if owns_resp.take::<Vec<serde_json::Value>>(0).unwrap_or_default().is_empty() {
@@ -507,8 +507,8 @@ async fn hx_studio_edit_thumbnail_tab(
     // Single WHERE clause confirms ownership without a separate read
     let mut owns_resp = db
         .query("SELECT id FROM media WHERE id = $id AND owner = $owner")
-        .bind(("id", &mediumid))
-        .bind(("owner", &user_info.login))
+        .bind(("id", mediumid.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await
         .expect("Database error");
     if owns_resp.take::<Vec<serde_json::Value>>(0).unwrap_or_default().is_empty() {
@@ -539,7 +539,7 @@ async fn hx_studio_edit_danger_tab(
 
     let mut resp = db
         .query("SELECT owner, name FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .expect("Database error");
 
@@ -572,7 +572,7 @@ async fn hx_studio_edit_permissions_tab(
 
     let mut resp = db
         .query("SELECT id, name, owner, visibility, restricted_to_group, type FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .expect("Database error");
 
@@ -588,7 +588,7 @@ async fn hx_studio_edit_permissions_tab(
 
             let mut groups_resp = db
                 .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
-                .bind(("owner", &user_info.login))
+                .bind(("owner", user_info.login.clone()))
                 .await
                 .expect("Database error");
 
@@ -638,9 +638,9 @@ async fn studio_edit_permissions_save(
     let update_result = db
         .query("UPDATE media SET public = $public, visibility = $visibility, restricted_to_group = $restricted_to_group WHERE id = $id;")
         .bind(("public", ispublic))
-        .bind(("visibility", &visibility))
-        .bind(("restricted_to_group", &restricted_to_group))
-        .bind(("id", &mediumid))
+        .bind(("visibility", visibility.clone()))
+        .bind(("restricted_to_group", restricted_to_group.clone()))
+        .bind(("id", mediumid.clone()))
         .await;
 
     if update_result.is_err() {

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -335,40 +335,22 @@ async fn studio_edit_save(
     }
     let user_info = user_info.unwrap();
 
-    let mut resp = db
-        .query("SELECT owner FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
-        .await
-        .expect("Database error");
-
-    let media_owner: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
-
-    match media_owner {
-        Some(record) => {
-            if record.owner != user_info.login {
-                return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
-            }
-        }
-        None => {
-            return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
-        }
-    }
-
     let description: serde_json::Value =
         serde_json::from_str(&form.medium_description).unwrap_or(serde_json::Value::Null);
 
-    let update_result = db
-        .query("UPDATE media SET name = $name, description = $description WHERE id = $id;")
+    // Ownership check + update in one query: returns nothing if id/owner don't match
+    let mut update_resp = db
+        .query("UPDATE media SET name = $name, description = $description WHERE id = $id AND owner = $owner RETURN id")
         .bind(("name", &form.medium_name))
         .bind(("description", &description))
         .bind(("id", &mediumid))
+        .bind(("owner", &user_info.login))
         .await;
 
-    if update_result.is_err() {
-        return Html(format!(
-            "<b class=\"text-danger\">Failed to save changes.</b><script>setTimeout(function(){{window.location.replace(\"/studio/edit/{}\");}},2000);</script>",
-            mediumid
-        ));
+    let updated: Vec<serde_json::Value> = update_resp.as_mut().ok()
+        .and_then(|r| r.take(0).ok()).unwrap_or_default();
+    if updated.is_empty() {
+        return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
     }
 
     Html(format!(
@@ -389,46 +371,24 @@ async fn hx_delete_video(
     }
     let user_info = user_info.unwrap();
 
-    let mut resp = db
-        .query("SELECT owner FROM media WHERE id = $id;")
+    // Ownership check + delete in one query; returns nothing if not owner
+    let mut del_resp = db
+        .query("DELETE FROM media WHERE id = $id AND owner = $owner RETURN id")
         .bind(("id", &mediumid))
+        .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
 
-    let media_owner: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
-
-    match media_owner {
-        Some(record) => {
-            if record.owner != user_info.login {
-                return Redirect::to("/studio");
-            }
-        }
-        None => {
-            return Redirect::to("/studio");
-        }
-    }
-
-    // Delete associated comments first
-    let _ = db
-        .query("DELETE FROM comments WHERE media = $media;")
-        .bind(("media", &mediumid))
-        .await;
-
-    // Delete from any lists
-    let _ = db
-        .query("DELETE FROM list_items WHERE media_id = $media_id;")
-        .bind(("media_id", &mediumid))
-        .await;
-
-    // Delete the video from database
-    let delete_result = db
-        .query("DELETE FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
-        .await;
-
-    if delete_result.is_err() {
+    let deleted: Vec<serde_json::Value> = del_resp.take(0).unwrap_or_default();
+    if deleted.is_empty() {
         return Redirect::to("/studio");
     }
+
+    // Media deleted — clean up related records in a single round-trip
+    let _ = db
+        .query("DELETE FROM comments WHERE media = $id; DELETE FROM list_items WHERE media_id = $id")
+        .bind(("id", &mediumid))
+        .await;
 
     // Delete the source directory
     let source_path = format!("source/{}", mediumid);
@@ -490,16 +450,14 @@ async fn hx_studio_edit_chapters_tab(
     }
     let user_info = user_info.unwrap();
 
-    let mut resp = db
-        .query("SELECT owner FROM media WHERE id = $id;")
+    // Single WHERE clause confirms ownership without a separate read
+    let mut owns_resp = db
+        .query("SELECT id FROM media WHERE id = $id AND owner = $owner")
         .bind(("id", &mediumid))
+        .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
-
-    let owner_record: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
-    let owner = owner_record.map(|r| r.owner);
-
-    if owner.as_deref() != Some(user_info.login.as_str()) {
+    if owns_resp.take::<Vec<serde_json::Value>>(0).unwrap_or_default().is_empty() {
         return Html(minifi_html("".to_owned()));
     }
 
@@ -519,16 +477,14 @@ async fn hx_studio_edit_subtitles_tab(
     }
     let user_info = user_info.unwrap();
 
-    let mut resp = db
-        .query("SELECT owner FROM media WHERE id = $id;")
+    // Single WHERE clause confirms ownership without a separate read
+    let mut owns_resp = db
+        .query("SELECT id FROM media WHERE id = $id AND owner = $owner")
         .bind(("id", &mediumid))
+        .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
-
-    let owner_record: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
-    let owner = owner_record.map(|r| r.owner);
-
-    if owner.as_deref() != Some(user_info.login.as_str()) {
+    if owns_resp.take::<Vec<serde_json::Value>>(0).unwrap_or_default().is_empty() {
         return Html(minifi_html("".to_owned()));
     }
 
@@ -548,16 +504,14 @@ async fn hx_studio_edit_thumbnail_tab(
     }
     let user_info = user_info.unwrap();
 
-    let mut resp = db
-        .query("SELECT owner FROM media WHERE id = $id;")
+    // Single WHERE clause confirms ownership without a separate read
+    let mut owns_resp = db
+        .query("SELECT id FROM media WHERE id = $id AND owner = $owner")
         .bind(("id", &mediumid))
+        .bind(("owner", &user_info.login))
         .await
         .expect("Database error");
-
-    let owner_record: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
-    let owner = owner_record.map(|r| r.owner);
-
-    if owner.as_deref() != Some(user_info.login.as_str()) {
+    if owns_resp.take::<Vec<serde_json::Value>>(0).unwrap_or_default().is_empty() {
         return Html(minifi_html("".to_owned()));
     }
 
@@ -669,25 +623,6 @@ async fn studio_edit_permissions_save(
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
     let user_info = user_info.unwrap();
-
-    let mut resp = db
-        .query("SELECT owner FROM media WHERE id = $id;")
-        .bind(("id", &mediumid))
-        .await
-        .expect("Database error");
-
-    let media_owner: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
-
-    match media_owner {
-        Some(record) => {
-            if record.owner != user_info.login {
-                return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
-            }
-        }
-        None => {
-            return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
-        }
-    }
 
     let visibility = match form.medium_visibility.as_str() {
         "public" | "hidden" | "restricted" => form.medium_visibility.clone(),

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -8,11 +8,11 @@ struct StudioTemplate {
 }
 async fn studio(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -48,31 +48,31 @@ struct HXStudioTemplate {
 }
 async fn hx_studio(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_studio_inner(config, pool, redis, headers, 0).await
+    hx_studio_inner(config, db, redis, headers, 0).await
 }
 
 async fn hx_studio_page(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(page): Path<i64>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_studio_inner(config, pool, redis, headers, page).await
+    hx_studio_inner(config, db, redis, headers, page).await
 }
 
 async fn hx_studio_inner(
     config: Config,
-    pool: PgPool,
+    db: Db,
     redis: RedisConn,
     headers: HeaderMap,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -81,24 +81,14 @@ async fn hx_studio_inner(
     let user_info = user_info.unwrap();
     let offset = page * 40;
 
-    let mut media: Vec<MediumStudio> = sqlx::query(
-        "SELECT id,name,description,views,type FROM media WHERE owner=$1 ORDER BY upload DESC LIMIT 41 OFFSET $2;"
-    )
-    .bind(&user_info.login)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        MediumStudio {
-            id: row.get("id"),
-            name: row.get("name"),
-            description: row.get("description"),
-            views: row.get("views"),
-            r#type: row.get("type"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query("SELECT id, name, description, views, type FROM media WHERE owner = $owner ORDER BY upload DESC LIMIT 41 START $offset;")
+        .bind(("owner", &user_info.login))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
+
+    let mut media: Vec<MediumStudio> = resp.take(0).unwrap_or_default();
 
     let has_more = media.len() == 41;
     if has_more {
@@ -113,11 +103,11 @@ async fn hx_studio_inner(
 
 async fn studio_lists(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -143,29 +133,29 @@ struct HXStudioListsTemplate {
     next_url: String,
 }
 async fn hx_studio_lists(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_studio_lists_inner(pool, redis, headers, 0).await
+    hx_studio_lists_inner(db, redis, headers, 0).await
 }
 
 async fn hx_studio_lists_page(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(page): Path<i64>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_studio_lists_inner(pool, redis, headers, page).await
+    hx_studio_lists_inner(db, redis, headers, page).await
 }
 
 async fn hx_studio_lists_inner(
-    pool: PgPool,
+    db: Db,
     redis: RedisConn,
     headers: HeaderMap,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -174,25 +164,14 @@ async fn hx_studio_lists_inner(
     let user_info = user_info.unwrap();
     let offset = page * 40;
 
-    let mut lists: Vec<ListWithCount> = sqlx::query(
-        "SELECT l.id, l.name, l.owner, l.visibility, l.restricted_to_group, (SELECT COUNT(*) FROM list_items li WHERE li.list_id = l.id) AS item_count FROM lists l WHERE l.owner = $1 ORDER BY l.created DESC LIMIT 41 OFFSET $2;"
-    )
-    .bind(&user_info.login)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        ListWithCount {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            visibility: row.get("visibility"),
-            restricted_to_group: row.get("restricted_to_group"),
-            item_count: row.get("item_count"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    let mut resp = db
+        .query("SELECT id, name, owner, visibility, restricted_to_group, array::len((SELECT id FROM list_items WHERE list_id = $parent.id)) AS item_count FROM lists WHERE owner = $owner ORDER BY created DESC LIMIT 41 START $offset;")
+        .bind(("owner", &user_info.login))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
+
+    let mut lists: Vec<ListWithCount> = resp.take(0).unwrap_or_default();
 
     let has_more = lists.len() == 41;
     if has_more {
@@ -260,14 +239,26 @@ struct HXStudioEditPermissionsTemplate {
     medium: MediumEdit,
     owner_groups: Vec<UserGroup>,
 }
+
+#[derive(Deserialize)]
+struct MediaRecord {
+    id: String,
+    name: String,
+    owner: String,
+    visibility: String,
+    restricted_to_group: Option<String>,
+    #[serde(rename = "type")]
+    r#type: String,
+}
+
 async fn studio_edit(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -275,18 +266,17 @@ async fn studio_edit(
     }
     let user_info = user_info.unwrap();
 
-    let medium = sqlx::query(
-        "SELECT id,name,owner,visibility,restricted_to_group,type FROM media WHERE id=$1;"
-    )
-    .bind(&mediumid)
-    .fetch_one(&pool)
-    .await;
+    let mut resp = db
+        .query("SELECT id, name, owner, visibility, restricted_to_group, type FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
+        .await
+        .expect("Database error");
 
-    match medium {
-        Ok(record) => {
-            use sqlx::Row;
-            let owner: String = record.get("owner");
-            if owner != user_info.login {
+    let record: Option<MediaRecord> = resp.take(0).unwrap_or_default();
+
+    match record {
+        Some(record) => {
+            if record.owner != user_info.login {
                 return Html(minifi_html(
                     "<script>window.location.replace(\"/studio\");</script>".to_owned(),
                 ));
@@ -298,18 +288,18 @@ async fn studio_edit(
                 sidebar,
                 config,
                 medium: MediumEdit {
-                    id: record.get("id"),
-                    name: record.get("name"),
-                    visibility: record.get("visibility"),
-                    restricted_to_group: record.get::<Option<String>, _>("restricted_to_group").unwrap_or_default(),
-                    medium_type: record.get("type"),
+                    id: record.id,
+                    name: record.name,
+                    visibility: record.visibility,
+                    restricted_to_group: record.restricted_to_group.unwrap_or_default(),
+                    medium_type: record.r#type,
                 },
                 common_headers,
                 active_tab: "description".to_owned(),
             };
             Html(minifi_html(template.render().unwrap()))
         }
-        Err(_) => Html(minifi_html(
+        None => Html(minifi_html(
             "<script>window.location.replace(\"/studio\");</script>".to_owned(),
         )),
     }
@@ -326,30 +316,40 @@ struct PermissionsEditForm {
     medium_visibility: String,
     medium_restricted_group: Option<String>,
 }
+
+#[derive(Deserialize)]
+struct OwnerRecord {
+    owner: String,
+}
+
 async fn studio_edit_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<EditForm>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    let mut resp = db
+        .query("SELECT owner FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
+        .await
+        .expect("Database error");
+
+    let media_owner: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
             }
         }
-        Err(_) => {
+        None => {
             return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
         }
     }
@@ -357,14 +357,12 @@ async fn studio_edit_save(
     let description: serde_json::Value =
         serde_json::from_str(&form.medium_description).unwrap_or(serde_json::Value::Null);
 
-    let update_result = sqlx::query(
-        "UPDATE media SET name=$1, description=$2 WHERE id=$3;"
-    )
-    .bind(&form.medium_name)
-    .bind(&description)
-    .bind(&mediumid)
-    .execute(&pool)
-    .await;
+    let update_result = db
+        .query("UPDATE media SET name = $name, description = $description WHERE id = $id;")
+        .bind(("name", &form.medium_name))
+        .bind(("description", &description))
+        .bind(("id", &mediumid))
+        .await;
 
     if update_result.is_err() {
         return Html(format!(
@@ -380,45 +378,52 @@ async fn studio_edit_save(
 }
 
 async fn hx_delete_video(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> impl IntoResponse {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Redirect::to("/login");
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    let mut resp = db
+        .query("SELECT owner FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
+        .await
+        .expect("Database error");
+
+    let media_owner: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Redirect::to("/studio");
             }
         }
-        Err(_) => {
+        None => {
             return Redirect::to("/studio");
         }
     }
 
     // Delete associated comments first
-    let _ = sqlx::query!("DELETE FROM comments WHERE media=$1;", mediumid)
-        .execute(&pool)
+    let _ = db
+        .query("DELETE FROM comments WHERE media = $media;")
+        .bind(("media", &mediumid))
         .await;
 
     // Delete from any lists
-    let _ = sqlx::query!("DELETE FROM list_items WHERE media_id=$1;", mediumid)
-        .execute(&pool)
+    let _ = db
+        .query("DELETE FROM list_items WHERE media_id = $media_id;")
+        .bind(("media_id", &mediumid))
         .await;
 
     // Delete the video from database
-    let delete_result = sqlx::query!("DELETE FROM media WHERE id=$1;", mediumid)
-        .execute(&pool)
+    let delete_result = db
+        .query("DELETE FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
         .await;
 
     if delete_result.is_err() {
@@ -433,64 +438,66 @@ async fn hx_delete_video(
 }
 
 async fn hx_studio_edit_description(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let medium = sqlx::query(
-        "SELECT id,name,owner,visibility,restricted_to_group,type FROM media WHERE id=$1;"
-    )
-    .bind(&mediumid)
-    .fetch_one(&pool)
-    .await;
+    let mut resp = db
+        .query("SELECT id, name, owner, visibility, restricted_to_group, type FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
+        .await
+        .expect("Database error");
 
-    match medium {
-        Ok(record) => {
-            use sqlx::Row;
-            let owner: String = record.get("owner");
-            if owner != user_info.login {
+    let record: Option<MediaRecord> = resp.take(0).unwrap_or_default();
+
+    match record {
+        Some(record) => {
+            if record.owner != user_info.login {
                 return Html(minifi_html("".to_owned()));
             }
 
             let template = HXStudioEditDescriptionTemplate {
                 medium: MediumEdit {
-                    id: record.get("id"),
-                    name: record.get("name"),
-                    visibility: record.get("visibility"),
-                    restricted_to_group: record.get::<Option<String>, _>("restricted_to_group").unwrap_or_default(),
-                    medium_type: record.get("type"),
+                    id: record.id,
+                    name: record.name,
+                    visibility: record.visibility,
+                    restricted_to_group: record.restricted_to_group.unwrap_or_default(),
+                    medium_type: record.r#type,
                 },
             };
             Html(minifi_html(template.render().unwrap()))
         }
-        Err(_) => Html(minifi_html("".to_owned())),
+        None => Html(minifi_html("".to_owned())),
     }
 }
 
 async fn hx_studio_edit_chapters_tab(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let owner: Option<String> = sqlx::query_scalar("SELECT owner FROM media WHERE id=$1;")
-        .bind(&mediumid)
-        .fetch_optional(&pool)
+    let mut resp = db
+        .query("SELECT owner FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
         .await
-        .unwrap_or(None);
+        .expect("Database error");
+
+    let owner_record: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
+    let owner = owner_record.map(|r| r.owner);
 
     if owner.as_deref() != Some(user_info.login.as_str()) {
         return Html(minifi_html("".to_owned()));
@@ -501,22 +508,25 @@ async fn hx_studio_edit_chapters_tab(
 }
 
 async fn hx_studio_edit_subtitles_tab(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let owner: Option<String> = sqlx::query_scalar("SELECT owner FROM media WHERE id=$1;")
-        .bind(&mediumid)
-        .fetch_optional(&pool)
+    let mut resp = db
+        .query("SELECT owner FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
         .await
-        .unwrap_or(None);
+        .expect("Database error");
+
+    let owner_record: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
+    let owner = owner_record.map(|r| r.owner);
 
     if owner.as_deref() != Some(user_info.login.as_str()) {
         return Html(minifi_html("".to_owned()));
@@ -527,22 +537,25 @@ async fn hx_studio_edit_subtitles_tab(
 }
 
 async fn hx_studio_edit_thumbnail_tab(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let owner: Option<String> = sqlx::query_scalar("SELECT owner FROM media WHERE id=$1;")
-        .bind(&mediumid)
-        .fetch_optional(&pool)
+    let mut resp = db
+        .query("SELECT owner FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
         .await
-        .unwrap_or(None);
+        .expect("Database error");
+
+    let owner_record: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
+    let owner = owner_record.map(|r| r.owner);
 
     if owner.as_deref() != Some(user_info.login.as_str()) {
         return Html(minifi_html("".to_owned()));
@@ -553,31 +566,37 @@ async fn hx_studio_edit_thumbnail_tab(
 }
 
 async fn hx_studio_edit_danger_tab(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let row = sqlx::query("SELECT owner, name FROM media WHERE id=$1;")
-        .bind(&mediumid)
-        .fetch_optional(&pool)
+    #[derive(Deserialize)]
+    struct OwnerNameRecord {
+        owner: String,
+        name: String,
+    }
+
+    let mut resp = db
+        .query("SELECT owner, name FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
         .await
-        .unwrap_or(None);
+        .expect("Database error");
+
+    let row: Option<OwnerNameRecord> = resp.take(0).unwrap_or_default();
 
     match row {
         Some(record) => {
-            use sqlx::Row;
-            let owner: String = record.get("owner");
-            if owner != user_info.login {
+            if record.owner != user_info.login {
                 return Html(minifi_html("".to_owned()));
             }
-            let medium_name: String = record.get("name");
+            let medium_name = record.name;
             let template = HXStudioEditDangerTemplate { medium_id: mediumid, medium_name };
             Html(minifi_html(template.render().unwrap()))
         }
@@ -586,87 +605,86 @@ async fn hx_studio_edit_danger_tab(
 }
 
 async fn hx_studio_edit_permissions_tab(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html("".to_owned()));
     }
     let user_info = user_info.unwrap();
 
-    let medium = sqlx::query(
-        "SELECT id,name,owner,visibility,restricted_to_group,type FROM media WHERE id=$1;"
-    )
-    .bind(&mediumid)
-    .fetch_one(&pool)
-    .await;
+    let mut resp = db
+        .query("SELECT id, name, owner, visibility, restricted_to_group, type FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
+        .await
+        .expect("Database error");
 
-    match medium {
-        Ok(record) => {
-            use sqlx::Row;
-            let owner: String = record.get("owner");
-            if owner != user_info.login {
+    let record: Option<MediaRecord> = resp.take(0).unwrap_or_default();
+
+    match record {
+        Some(record) => {
+            if record.owner != user_info.login {
                 return Html(minifi_html("".to_owned()));
             }
 
             let mut owner_groups = system_groups_for_owner(&user_info.login);
-            let user_groups: Vec<UserGroup> = sqlx::query("SELECT id, name, owner FROM user_groups WHERE owner = $1 ORDER BY created DESC;")
-                .bind(&user_info.login)
-                .map(|row: sqlx::postgres::PgRow| {
-                    UserGroup {
-                        id: row.get("id"),
-                        name: row.get("name"),
-                        owner: row.get("owner"),
-                    }
-                })
-                .fetch_all(&pool)
+
+            let mut groups_resp = db
+                .query("SELECT id, name, owner FROM user_groups WHERE owner = $owner ORDER BY created DESC;")
+                .bind(("owner", &user_info.login))
                 .await
-                .unwrap_or_default();
+                .expect("Database error");
+
+            let user_groups: Vec<UserGroup> = groups_resp.take(0).unwrap_or_default();
             owner_groups.extend(user_groups);
 
             let template = HXStudioEditPermissionsTemplate {
                 medium: MediumEdit {
-                    id: record.get("id"),
-                    name: record.get("name"),
-                    visibility: record.get("visibility"),
-                    restricted_to_group: record.get::<Option<String>, _>("restricted_to_group").unwrap_or_default(),
-                    medium_type: record.get("type"),
+                    id: record.id,
+                    name: record.name,
+                    visibility: record.visibility,
+                    restricted_to_group: record.restricted_to_group.unwrap_or_default(),
+                    medium_type: record.r#type,
                 },
                 owner_groups,
             };
             Html(minifi_html(template.render().unwrap()))
         }
-        Err(_) => Html(minifi_html("".to_owned())),
+        None => Html(minifi_html("".to_owned())),
     }
 }
 
 async fn studio_edit_permissions_save(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Form(form): Form<PermissionsEditForm>,
 ) -> axum::response::Html<String> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    let mut resp = db
+        .query("SELECT owner FROM media WHERE id = $id;")
+        .bind(("id", &mediumid))
+        .await
+        .expect("Database error");
+
+    let media_owner: Option<OwnerRecord> = resp.take(0).unwrap_or_default();
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
             }
         }
-        Err(_) => {
+        None => {
             return Html("<script>window.location.replace(\"/studio\");</script>".to_owned());
         }
     }
@@ -682,15 +700,13 @@ async fn studio_edit_permissions_save(
         None
     };
 
-    let update_result = sqlx::query(
-        "UPDATE media SET public=$1, visibility=$2, restricted_to_group=$3 WHERE id=$4;"
-    )
-    .bind(ispublic)
-    .bind(&visibility)
-    .bind(&restricted_to_group)
-    .bind(&mediumid)
-    .execute(&pool)
-    .await;
+    let update_result = db
+        .query("UPDATE media SET public = $public, visibility = $visibility, restricted_to_group = $restricted_to_group WHERE id = $id;")
+        .bind(("public", ispublic))
+        .bind(("visibility", &visibility))
+        .bind(("restricted_to_group", &restricted_to_group))
+        .bind(("id", &mediumid))
+        .await;
 
     if update_result.is_err() {
         return Html(format!(

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -23,30 +23,30 @@ async fn subscriptions(
 async fn hx_subscriptions(
     Extension(config): Extension<Config>,
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_subscriptions_inner(config, headers, pool, redis, 0).await
+    hx_subscriptions_inner(config, headers, db, redis, 0).await
 }
 
 async fn hx_subscriptions_page(
     Extension(config): Extension<Config>,
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(page): Path<i64>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_subscriptions_inner(config, headers, pool, redis, page).await
+    hx_subscriptions_inner(config, headers, db, redis, page).await
 }
 
 async fn hx_subscriptions_inner(
     config: Config,
     headers: HeaderMap,
-    pool: PgPool,
+    db: Db,
     redis: RedisConn,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = match get_user_login(headers, &pool, redis.clone()).await {
+    let user = match get_user_login(headers, &db, redis.clone()).await {
         Some(user) => user,
         None => {
             return Html(
@@ -59,32 +59,45 @@ async fn hx_subscriptions_inner(
 
     let offset = page * 30;
 
-    let mut media: Vec<Medium> = sqlx::query(
-        "SELECT m.id, m.name, m.owner, m.views, m.type
-         FROM media m
-         INNER JOIN subscriptions s ON m.owner = s.target
-         WHERE s.subscriber = $1 AND (m.visibility = 'public' OR (m.visibility = 'restricted' AND (m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1) OR m.restricted_to_group = '__all_registered__' OR (m.restricted_to_group = '__subscribers__' AND m.owner IN (SELECT target FROM subscriptions WHERE subscriber = $1)))))
-         ORDER BY m.upload DESC
-         LIMIT 31 OFFSET $2;"
-    )
-    .bind(&user.login)
-    .bind(offset)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        Medium {
-            id: row.get("id"),
-            name: row.get("name"),
-            owner: row.get("owner"),
-            views: row.get("views"),
-            r#type: row.get("type"),
-            sprite_filename: None,
-            sprite_x: 0,
-            sprite_y: 0,
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .expect("Database error");
+    #[derive(Deserialize)]
+    struct MediumRow {
+        id: surrealdb::RecordId,
+        name: String,
+        owner: String,
+        views: i64,
+        #[serde(rename = "type")]
+        r#type: String,
+    }
+
+    let mut resp = db
+        .query(
+            "SELECT id, name, owner, views, type FROM media \
+             WHERE owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user) \
+             AND (visibility = 'public' OR (visibility = 'restricted' AND ( \
+               restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user) \
+               OR restricted_to_group = '__all_registered__' \
+               OR (restricted_to_group = '__subscribers__' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user)) \
+             ))) \
+             ORDER BY upload DESC LIMIT $limit START $offset"
+        )
+        .bind(("user", &user.login))
+        .bind(("limit", 31i64))
+        .bind(("offset", offset))
+        .await
+        .expect("Database error");
+
+    let rows: Vec<MediumRow> = resp.take(0).unwrap_or_default();
+
+    let mut media: Vec<Medium> = rows.into_iter().map(|row| Medium {
+        id: row.id.key().to_string(),
+        name: row.name,
+        owner: row.owner,
+        views: row.views,
+        r#type: row.r#type,
+        sprite_filename: None,
+        sprite_x: 0,
+        sprite_y: 0,
+    }).collect();
 
     let has_more = media.len() == 31;
     if has_more {
@@ -105,54 +118,46 @@ async fn hx_subscriptions_inner(
 
 async fn hx_subscribe(
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(userid): Path<String>,
 ) -> axum::response::Html<String> {
-    let user = get_user_login(headers, &pool, redis.clone()).await.unwrap();
-    sqlx::query!(
-        "INSERT INTO subscriptions (subscriber, target) VALUES ($1,$2);",
-        user.login,
-        userid
+    let user = get_user_login(headers, &db, redis.clone()).await.unwrap();
+    db.query(
+        "UPSERT subscriptions:[$subscriber, $target] SET subscriber = $subscriber, target = $target"
     )
-    .execute(&pool)
+    .bind(("subscriber", &user.login))
+    .bind(("target", &userid))
     .await
     .expect("Database error");
-    Html(format!("<a hx-get=\"/hx/unsubscribe/{}\" hx-swap=\"outerHTML\" class=\"btn btn-secondary\"><i class=\"fa-solid fa-user-minus\"></i>&nbsp;Unsubscribe</a>",user.login))
+    Html(format!("<a hx-get=\"/hx/unsubscribe/{}\" hx-swap=\"outerHTML\" class=\"btn btn-secondary\"><i class=\"fa-solid fa-user-minus\"></i>&nbsp;Unsubscribe</a>", userid))
 }
+
 async fn hx_unsubscribe(
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(userid): Path<String>,
 ) -> axum::response::Html<String> {
-    let user = get_user_login(headers, &pool, redis.clone()).await.unwrap();
-    sqlx::query!(
-        "DELETE FROM subscriptions WHERE subscriber=$1 AND target=$2;",
-        user.login,
-        userid
+    let user = get_user_login(headers, &db, redis.clone()).await.unwrap();
+    db.query(
+        "DELETE subscriptions WHERE subscriber = $subscriber AND target = $target"
     )
-    .execute(&pool)
+    .bind(("subscriber", &user.login))
+    .bind(("target", &userid))
     .await
     .expect("Database error");
-    Html(format!("<a hx-get=\"/hx/subscribe/{}\" hx-swap=\"outerHTML\" class=\"btn btn-primary\"><i class=\"fa-solid fa-user-plus\"></i>&nbsp;Subscribe</a>",user.login))
+    Html(format!("<a hx-get=\"/hx/subscribe/{}\" hx-swap=\"outerHTML\" class=\"btn btn-primary\"><i class=\"fa-solid fa-user-plus\"></i>&nbsp;Subscribe</a>", userid))
 }
+
 async fn hx_subscribebutton(
     headers: HeaderMap,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Path(userid): Path<String>,
 ) -> axum::response::Html<String> {
-    if let Some(user) = get_user_login(headers, &pool, redis.clone()).await {
-        let issubscribed = sqlx::query!(
-            "SELECT EXISTS(SELECT FROM subscriptions WHERE subscriber=$1 AND target=$2) AS issubscribed;",
-            user.login,
-            userid
-        )
-        .fetch_one(&pool)
-        .await
-        .map(|row| row.issubscribed.unwrap_or(false))
-        .unwrap_or(false);
+    if let Some(user) = get_user_login(headers, &db, redis.clone()).await {
+        let issubscribed = is_subscribed(&db, &user.login, &userid).await;
 
         let button = if issubscribed {
             format!(

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -73,11 +73,7 @@ async fn hx_subscriptions_inner(
         .query(
             "SELECT id, name, owner, views, type FROM media \
              WHERE owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user) \
-             AND (visibility = 'public' OR (visibility = 'restricted' AND ( \
-               restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user) \
-               OR restricted_to_group = '__all_registered__' \
-               OR (restricted_to_group = '__subscribers__' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user)) \
-             ))) \
+             AND fn::visible_to(visibility, restricted_to_group, owner, $user) \
              ORDER BY upload DESC LIMIT $limit START $offset"
         )
         .bind(("user", &user.login))

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -76,7 +76,7 @@ async fn hx_subscriptions_inner(
              AND fn::visible_to(visibility, restricted_to_group, owner, $user) \
              ORDER BY upload DESC LIMIT $limit START $offset"
         )
-        .bind(("user", &user.login))
+        .bind(("user", user.login.clone()))
         .bind(("limit", 31i64))
         .bind(("offset", offset))
         .await
@@ -122,8 +122,8 @@ async fn hx_subscribe(
     db.query(
         "UPSERT subscriptions:[$subscriber, $target] SET subscriber = $subscriber, target = $target"
     )
-    .bind(("subscriber", &user.login))
-    .bind(("target", &userid))
+    .bind(("subscriber", user.login.clone()))
+    .bind(("target", userid.clone()))
     .await
     .expect("Database error");
     Html(format!("<a hx-get=\"/hx/unsubscribe/{}\" hx-swap=\"outerHTML\" class=\"btn btn-secondary\"><i class=\"fa-solid fa-user-minus\"></i>&nbsp;Unsubscribe</a>", userid))
@@ -139,8 +139,8 @@ async fn hx_unsubscribe(
     db.query(
         "DELETE subscriptions WHERE subscriber = $subscriber AND target = $target"
     )
-    .bind(("subscriber", &user.login))
-    .bind(("target", &userid))
+    .bind(("subscriber", user.login.clone()))
+    .bind(("target", userid.clone()))
     .await
     .expect("Database error");
     Html(format!("<a hx-get=\"/hx/subscribe/{}\" hx-swap=\"outerHTML\" class=\"btn btn-primary\"><i class=\"fa-solid fa-user-plus\"></i>&nbsp;Subscribe</a>", userid))

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -27,28 +27,33 @@ async fn convert_subtitle_to_vtt(content: Vec<u8>, input_format: &str) -> Option
 }
 
 async fn studio_subtitles_get(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::Value::Array(vec![]));
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Json(serde_json::Value::Array(vec![]));
             }
         }
-        Err(_) => {
+        None => {
             return Json(serde_json::Value::Array(vec![]));
         }
     }
@@ -76,13 +81,13 @@ async fn studio_subtitles_get(
 }
 
 async fn studio_subtitles_add(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     mut multipart: Multipart,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -92,12 +97,17 @@ async fn studio_subtitles_add(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -106,7 +116,7 @@ async fn studio_subtitles_add(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -246,23 +256,27 @@ async fn studio_subtitles_add(
 }
 
 async fn studio_subtitle_font_get(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::json!({ "exists": false }));
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
-
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
     match media_owner {
-        Ok(record) if record.owner == user_info.login => {}
+        Some(record) if record.owner == user_info.login => {}
         _ => return Json(serde_json::json!({ "exists": false })),
     }
 
@@ -272,13 +286,13 @@ async fn studio_subtitle_font_get(
 }
 
 async fn studio_subtitle_font_upload(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     mut multipart: Multipart,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -288,12 +302,17 @@ async fn studio_subtitle_font_upload(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -302,7 +321,7 @@ async fn studio_subtitle_font_upload(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -414,12 +433,12 @@ async fn studio_subtitle_font_upload(
 }
 
 async fn studio_subtitle_font_delete(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -429,12 +448,17 @@ async fn studio_subtitle_font_delete(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -443,7 +467,7 @@ async fn studio_subtitle_font_delete(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -462,35 +486,40 @@ async fn studio_subtitle_font_delete(
 }
 
 async fn studio_subtitles_translate_status(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::json!({ "in_progress": false }));
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
-
-    match media_owner {
-        Ok(record) if record.owner == user_info.login => {}
+    #[derive(serde::Deserialize)]
+    struct OwnerRow2 { owner: String }
+    let mut _owner_resp2 = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner2: Option<OwnerRow2> = _owner_resp2.take(0).unwrap_or(None);
+    match media_owner2 {
+        Some(record) if record.owner == user_info.login => {}
         _ => return Json(serde_json::json!({ "in_progress": false })),
     }
 
     let concept_id = format!("{}_translate", mediumid);
-    let result = sqlx::query!("SELECT processed FROM media_concepts WHERE id=$1;", concept_id)
-        .fetch_optional(&pool)
-        .await;
-
-    let in_progress = match result {
-        Ok(Some(row)) => !row.processed,
-        _ => false,
-    };
+    #[derive(serde::Deserialize)]
+    struct ProcessedRow { processed: bool }
+    let mut _proc_resp = db
+        .query("SELECT processed FROM media_concepts WHERE id = $id")
+        .bind(("id", &concept_id))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let proc_result: Option<ProcessedRow> = _proc_resp.take(0).unwrap_or(None);
+    let in_progress = proc_result.map(|r| !r.processed).unwrap_or(false);
 
     Json(serde_json::json!({ "in_progress": in_progress }))
 }
@@ -502,13 +531,13 @@ struct SubtitleTranslateForm {
 }
 
 async fn studio_subtitles_translate(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Json(form): Json<SubtitleTranslateForm>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -518,12 +547,17 @@ async fn studio_subtitles_translate(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -532,7 +566,7 @@ async fn studio_subtitles_translate(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -592,20 +626,18 @@ async fn studio_subtitles_translate(
     }
 
     // Upsert concept: delete any existing translation job for this medium, then insert new one
-    let _ = sqlx::query("DELETE FROM media_concepts WHERE id=$1;")
-        .bind(&concept_id)
-        .execute(&pool)
+    let _ = db
+        .query("DELETE FROM media_concepts WHERE id = $id")
+        .bind(("id", &concept_id))
         .await;
 
     let concept_name = format!("Translate {} -> {}", source_label, target_language);
-    if let Err(_) = sqlx::query(
-        "INSERT INTO media_concepts (id, name, owner, type, processed) VALUES ($1, $2, $3, 'vtt_translate', false)"
-    )
-    .bind(&concept_id)
-    .bind(&concept_name)
-    .bind(&user_info.login)
-    .execute(&pool)
-    .await
+    if let Err(_) = db
+        .query("UPSERT type::thing('media_concepts', $id) SET name = $name, owner = $owner, type = 'vtt_translate', processed = false")
+        .bind(("id", &concept_id))
+        .bind(("name", &concept_name))
+        .bind(("owner", &user_info.login))
+        .await
     {
         return Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
@@ -626,13 +658,13 @@ struct SubtitleDeleteForm {
 }
 
 async fn studio_subtitles_delete(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     Json(form): Json<SubtitleDeleteForm>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -642,12 +674,17 @@ async fn studio_subtitles_delete(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -656,7 +693,7 @@ async fn studio_subtitles_delete(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")

--- a/src/subtitles.rs
+++ b/src/subtitles.rs
@@ -42,7 +42,7 @@ async fn studio_subtitles_get(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -101,7 +101,7 @@ async fn studio_subtitles_add(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -271,7 +271,7 @@ async fn studio_subtitle_font_get(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -306,7 +306,7 @@ async fn studio_subtitle_font_upload(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -452,7 +452,7 @@ async fn studio_subtitle_font_delete(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -501,7 +501,7 @@ async fn studio_subtitles_translate_status(
     struct OwnerRow2 { owner: String }
     let mut _owner_resp2 = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner2: Option<OwnerRow2> = _owner_resp2.take(0).unwrap_or(None);
@@ -515,7 +515,7 @@ async fn studio_subtitles_translate_status(
     struct ProcessedRow { processed: bool }
     let mut _proc_resp = db
         .query("SELECT processed FROM media_concepts WHERE id = $id")
-        .bind(("id", &concept_id))
+        .bind(("id", concept_id.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let proc_result: Option<ProcessedRow> = _proc_resp.take(0).unwrap_or(None);
@@ -551,7 +551,7 @@ async fn studio_subtitles_translate(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -628,15 +628,15 @@ async fn studio_subtitles_translate(
     // Upsert concept: delete any existing translation job for this medium, then insert new one
     let _ = db
         .query("DELETE FROM media_concepts WHERE id = $id")
-        .bind(("id", &concept_id))
+        .bind(("id", concept_id.clone()))
         .await;
 
     let concept_name = format!("Translate {} -> {}", source_label, target_language);
     if let Err(_) = db
         .query("UPSERT type::thing('media_concepts', $id) SET name = $name, owner = $owner, type = 'vtt_translate', processed = false")
-        .bind(("id", &concept_id))
-        .bind(("name", &concept_name))
-        .bind(("owner", &user_info.login))
+        .bind(("id", concept_id.clone()))
+        .bind(("name", concept_name.clone()))
+        .bind(("owner", user_info.login.clone()))
         .await
     {
         return Response::builder()
@@ -678,7 +678,7 @@ async fn studio_subtitles_delete(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -49,7 +49,7 @@ async fn studio_thumbnail_upload(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
@@ -219,7 +219,7 @@ async fn studio_thumbnail_delete(
     struct OwnerRow { owner: String }
     let mut _owner_resp = db
         .query("SELECT owner FROM media WHERE id = $id")
-        .bind(("id", &mediumid))
+        .bind(("id", mediumid.clone()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -10,6 +10,13 @@ async fn studio_thumbnail_get(
     }
     let user_info = user_info.unwrap();
 
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", mediumid.clone()))
+        .await
+        .unwrap_or_else(|_| unreachable!());
     let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
     match media_owner {
         Some(record) if record.owner == user_info.login => {}

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -1,21 +1,18 @@
 async fn studio_thumbnail_get(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Json<serde_json::Value> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Json(serde_json::json!({ "exists": false }));
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
-
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
     match media_owner {
-        Ok(record) if record.owner == user_info.login => {}
+        Some(record) if record.owner == user_info.login => {}
         _ => return Json(serde_json::json!({ "exists": false })),
     }
 
@@ -25,13 +22,13 @@ async fn studio_thumbnail_get(
 }
 
 async fn studio_thumbnail_upload(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
     mut multipart: Multipart,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -41,12 +38,17 @@ async fn studio_thumbnail_upload(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -55,7 +57,7 @@ async fn studio_thumbnail_upload(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
@@ -191,12 +193,12 @@ async fn studio_thumbnail_upload(
 }
 
 async fn studio_thumbnail_delete(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Response<Body> {
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Response::builder()
             .status(StatusCode::UNAUTHORIZED)
@@ -206,12 +208,17 @@ async fn studio_thumbnail_delete(
     }
     let user_info = user_info.unwrap();
 
-    let media_owner = sqlx::query!("SELECT owner FROM media WHERE id=$1;", mediumid)
-        .fetch_one(&pool)
-        .await;
+    #[derive(serde::Deserialize)]
+    struct OwnerRow { owner: String }
+    let mut _owner_resp = db
+        .query("SELECT owner FROM media WHERE id = $id")
+        .bind(("id", &mediumid))
+        .await
+        .unwrap_or_else(|_| unreachable!());
+    let media_owner: Option<OwnerRow> = _owner_resp.take(0).unwrap_or(None);
 
     match media_owner {
-        Ok(record) => {
+        Some(record) => {
             if record.owner != user_info.login {
                 return Response::builder()
                     .status(StatusCode::FORBIDDEN)
@@ -220,7 +227,7 @@ async fn studio_thumbnail_delete(
                     .unwrap();
             }
         }
-        Err(_) => {
+        None => {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(axum::http::header::CONTENT_TYPE, "application/json")

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -21,21 +21,21 @@ async fn trending(
 
 async fn hx_trending(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_trending_inner(config, pool, redis, headers, 0).await
+    hx_trending_inner(config, db, redis, headers, 0).await
 }
 
 async fn hx_trending_page(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(page): Path<i64>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_trending_inner(config, pool, redis, headers, page).await
+    hx_trending_inner(config, db, redis, headers, page).await
 }
 
 /// Try to load a page of trending media from the Redis cache.
@@ -97,9 +97,18 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
     Some(media)
 }
 
+#[derive(Deserialize)]
+struct TrendingRow {
+    id: String,
+    name: String,
+    owner: String,
+    views: i64,
+    r#type: String,
+}
+
 async fn hx_trending_inner(
     config: Config,
-    pool: PgPool,
+    db: Db,
     mut redis: RedisConn,
     headers: HeaderMap,
     page: i64,
@@ -111,34 +120,40 @@ async fn hx_trending_inner(
         Some(cached) => cached,
         None => {
             // Cache not available — fall back to direct DB query
-            let user = get_user_login(headers, &pool, redis.clone()).await;
+            let user = get_user_login(headers, &db, redis.clone()).await;
             let user_login = user.map(|u| u.login).unwrap_or_default();
-            sqlx::query(
-                "SELECT m.id, m.name, m.owner, m.views, m.type \
-                 FROM media m \
-                 LEFT JOIN media_likes ml ON m.id = ml.media_id \
-                 WHERE m.visibility = 'public' OR (m.visibility = 'restricted' AND (m.restricted_to_group IN (SELECT group_id FROM user_group_members WHERE user_login = $1) OR (m.restricted_to_group = '__all_registered__' AND $1 != '') OR (m.restricted_to_group = '__subscribers__' AND $1 != '' AND m.owner IN (SELECT target FROM subscriptions WHERE subscriber = $1)))) \
-                 GROUP BY m.id, m.name, m.owner, m.views, m.type \
-                 ORDER BY COUNT(*) FILTER (WHERE ml.reaction = 'like') DESC LIMIT 31 OFFSET $2;"
-            )
-            .bind(&user_login)
-            .bind(offset)
-            .map(|row: sqlx::postgres::PgRow| {
-                use sqlx::Row;
-                Medium {
-                    id: row.get("id"),
-                    name: row.get("name"),
-                    owner: row.get("owner"),
-                    views: row.get("views"),
-                    r#type: row.get("type"),
+            let rows: Vec<TrendingRow> = db
+                .query(
+                    "SELECT id, name, owner, views, type, \
+                     array::len((SELECT id FROM media_likes WHERE media_id = id AND reaction = 'like')) AS like_count \
+                     FROM media AS m \
+                     WHERE visibility = 'public' \
+                     OR (visibility = 'restricted' AND ( \
+                         restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user) \
+                         OR (restricted_to_group = '__all_registered__' AND $user != '') \
+                         OR (restricted_to_group = '__subscribers__' AND $user != '' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user)) \
+                     )) \
+                     ORDER BY like_count DESC \
+                     LIMIT 31 \
+                     START $offset;"
+                )
+                .bind(("user", user_login))
+                .bind(("offset", offset))
+                .await
+                .and_then(|mut r| r.take(0))
+                .expect("Database error");
+            rows.into_iter()
+                .map(|row| Medium {
+                    id: row.id,
+                    name: row.name,
+                    owner: row.owner,
+                    views: row.views,
+                    r#type: row.r#type,
                     sprite_filename: None,
                     sprite_x: 0,
                     sprite_y: 0,
-                }
-            })
-            .fetch_all(&pool)
-            .await
-            .expect("Database error")
+                })
+                .collect()
         }
     };
 

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -124,18 +124,11 @@ async fn hx_trending_inner(
             let user_login = user.map(|u| u.login).unwrap_or_default();
             let rows: Vec<TrendingRow> = db
                 .query(
-                    "SELECT id, name, owner, views, type, \
-                     array::len((SELECT id FROM media_likes WHERE media_id = id AND reaction = 'like')) AS like_count \
-                     FROM media AS m \
-                     WHERE visibility = 'public' \
-                     OR (visibility = 'restricted' AND ( \
-                         restricted_to_group IN (SELECT VALUE group_id FROM user_group_members WHERE user_login = $user) \
-                         OR (restricted_to_group = '__all_registered__' AND $user != '') \
-                         OR (restricted_to_group = '__subscribers__' AND $user != '' AND owner IN (SELECT VALUE target FROM subscriptions WHERE subscriber = $user)) \
-                     )) \
-                     ORDER BY like_count DESC \
-                     LIMIT 31 \
-                     START $offset;"
+                    "SELECT id, name, owner, views, type, likes_count AS like_count \
+                     FROM media \
+                     WHERE fn::visible_to(visibility, restricted_to_group, owner, $user) \
+                     ORDER BY likes_count DESC \
+                     LIMIT 31 START $offset"
                 )
                 .bind(("user", user_login))
                 .bind(("offset", offset))

--- a/src/two_factor.rs
+++ b/src/two_factor.rs
@@ -38,19 +38,20 @@ fn make_totp(
 }
 
 /// Load all Passkey rows for a user from the database.
-async fn load_passkeys(pool: &PgPool, login: &str) -> Vec<(String, Passkey)> {
-    sqlx::query("SELECT id, passkey FROM webauthn_credentials WHERE user_login=$1")
-        .bind(login)
-        .map(|row: sqlx::postgres::PgRow| {
-            use sqlx::Row;
-            let id: String = row.get("id");
-            let val: serde_json::Value = row.get("passkey");
-            let pk: Passkey = serde_json::from_value(val).unwrap();
-            (id, pk)
-        })
-        .fetch_all(pool)
+async fn load_passkeys(db: &Db, login: &str) -> Vec<(String, Passkey)> {
+    #[derive(serde::Deserialize)]
+    struct PasskeyRow { id: surrealdb::RecordId, passkey: serde_json::Value }
+    let mut resp = db
+        .query("SELECT id, passkey FROM webauthn_credentials WHERE user_login = $user")
+        .bind(("user", login))
         .await
-        .unwrap_or_default()
+        .unwrap_or_else(|_| unreachable!());
+    let rows: Vec<PasskeyRow> = resp.take(0).unwrap_or_default();
+    rows.into_iter().filter_map(|row| {
+        let id = row.id.key().to_string();
+        let pk: Passkey = serde_json::from_value(row.passkey).ok()?;
+        Some((id, pk))
+    }).collect()
 }
 
 /// Build a JSON `axum::response::Response` with a given status code.
@@ -69,7 +70,7 @@ struct TotpLoginForm {
 
 async fn hx_login_2fa_totp(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     Form(form): Form<TotpLoginForm>,
 ) -> (StatusCode, HeaderMap, String) {
@@ -94,13 +95,16 @@ async fn hx_login_2fa_totp(
     };
 
     // Fetch TOTP secret
-    let totp_secret: Option<String> = sqlx::query_scalar(
-        "SELECT totp_secret FROM users WHERE login=$1 AND totp_enabled=true",
-    )
-    .bind(&login)
-    .fetch_one(&pool)
-    .await
-    .unwrap_or(None);
+    #[derive(serde::Deserialize)]
+    struct TotpSecretRow { totp_secret: Option<String> }
+    let mut _ts_resp = db
+        .query("SELECT totp_secret FROM users WHERE id = $id AND totp_enabled = true")
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &login)))
+        .await
+        .expect("db error");
+    let totp_secret: Option<String> = _ts_resp.take::<Option<TotpSecretRow>>(0)
+        .unwrap_or(None)
+        .and_then(|r| r.totp_secret);
 
     let totp_secret = match totp_secret {
         Some(s) => s,
@@ -163,11 +167,11 @@ struct HXSettings2FATotpSetupTemplate {
 
 async fn hx_settings_2fa_totp_setup(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers, &pool, redis.clone()).await;
+    let user_info = get_user_login(headers, &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -223,12 +227,12 @@ struct TotpVerifySetupForm {
 
 async fn hx_settings_2fa_totp_verify_setup(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     headers: HeaderMap,
     Form(form): Form<TotpVerifySetupForm>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers, &pool, redis.clone()).await;
+    let user_info = get_user_login(headers, &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -283,13 +287,11 @@ async fn hx_settings_2fa_totp_verify_setup(
         ));
     }
 
-    let result = sqlx::query(
-        "UPDATE users SET totp_secret=$1, totp_enabled=true WHERE login=$2",
-    )
-    .bind(&secret_base32)
-    .bind(&user_info.login)
-    .execute(&pool)
-    .await;
+    let result = db
+        .query("UPDATE users SET totp_secret = $secret, totp_enabled = true WHERE id = $id")
+        .bind(("secret", &secret_base32))
+        .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
+        .await;
 
     if result.is_err() {
         return Html(minifi_html(
@@ -310,11 +312,11 @@ async fn hx_settings_2fa_totp_verify_setup(
 }
 
 async fn hx_settings_2fa_totp_disable(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers, &pool, redis).await;
+    let user_info = get_user_login(headers, &db, redis).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -323,9 +325,9 @@ async fn hx_settings_2fa_totp_disable(
     let user_info = user_info.unwrap();
 
     let result =
-        sqlx::query("UPDATE users SET totp_secret=NULL, totp_enabled=false WHERE login=$1")
-            .bind(&user_info.login)
-            .execute(&pool)
+        db
+            .query("UPDATE users SET totp_secret = NULL, totp_enabled = false WHERE id = $id")
+            .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
             .await;
 
     if result.is_err() {
@@ -358,14 +360,14 @@ struct HXSettings2FATemplate {
 }
 
 async fn hx_settings_2fa(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     Extension(webauthn_lock): Extension<
         std::sync::Arc<std::sync::RwLock<Option<webauthn_rs::Webauthn>>>,
     >,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers, &pool, redis).await;
+    let user_info = get_user_login(headers, &db, redis).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -374,27 +376,30 @@ async fn hx_settings_2fa(
     let user_info = user_info.unwrap();
 
     let totp_enabled: bool =
-        sqlx::query_scalar("SELECT totp_enabled FROM users WHERE login=$1")
-            .bind(&user_info.login)
-            .fetch_one(&pool)
-            .await
-            .unwrap_or(false);
+        {
+            #[derive(serde::Deserialize)] struct TotpEnabledRow2 { totp_enabled: bool }
+            let mut _te_resp = db
+                .query("SELECT totp_enabled FROM users WHERE id = $id")
+                .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
+                .await
+                .unwrap_or_else(|_| unreachable!());
+            let _te_row: Option<TotpEnabledRow2> = _te_resp.take(0).unwrap_or(None);
+            _te_row.map(|r| r.totp_enabled).unwrap_or(false)
+        };
 
-    let webauthn_creds: Vec<WebauthnCredInfo> = sqlx::query(
-        "SELECT id, credential_name, created FROM webauthn_credentials WHERE user_login=$1 ORDER BY created ASC",
-    )
-    .bind(&user_info.login)
-    .map(|row: sqlx::postgres::PgRow| {
-        use sqlx::Row;
-        WebauthnCredInfo {
-            id: row.get("id"),
-            name: row.get("credential_name"),
-            created: row.get("created"),
-        }
-    })
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
+    #[derive(serde::Deserialize)]
+    struct WebauthnCredRow { id: String, credential_name: String, created: i64 }
+    let mut _wc_resp = db
+        .query("SELECT id, credential_name, created FROM webauthn_credentials WHERE user_login = $user ORDER BY created ASC")
+        .bind(("user", &user_info.login))
+        .await
+        .expect("db error");
+    let webauthn_creds: Vec<WebauthnCredInfo> = _wc_resp
+        .take::<Vec<WebauthnCredRow>>(0)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|r| WebauthnCredInfo { id: r.id, name: r.credential_name, created: r.created })
+        .collect();
 
     let webauthn_available = webauthn_lock.read().map(|g| g.is_some()).unwrap_or(false);
 
@@ -414,7 +419,7 @@ struct StartRegisterRequest {
 }
 
 async fn hx_webauthn_register_start(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     Extension(webauthn_lock): Extension<
         std::sync::Arc<std::sync::RwLock<Option<webauthn_rs::Webauthn>>>,
@@ -422,14 +427,14 @@ async fn hx_webauthn_register_start(
     headers: HeaderMap,
     Json(req): Json<StartRegisterRequest>,
 ) -> axum::response::Response {
-    let user_info = get_user_login(headers, &pool, redis.clone()).await;
+    let user_info = get_user_login(headers, &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return json_resp(StatusCode::UNAUTHORIZED, serde_json::json!({"error": "Not logged in"}));
     }
     let user_info = user_info.unwrap();
 
     // Load existing passkeys BEFORE acquiring the RwLock (await before lock)
-    let existing = load_passkeys(&pool, &user_info.login).await;
+    let existing = load_passkeys(&db, &user_info.login).await;
     let exclude_creds: Option<Vec<_>> = if existing.is_empty() {
         None
     } else {
@@ -489,7 +494,7 @@ async fn hx_webauthn_register_start(
 }
 
 async fn hx_webauthn_register_finish(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     Extension(webauthn_lock): Extension<
         std::sync::Arc<std::sync::RwLock<Option<webauthn_rs::Webauthn>>>,
@@ -498,7 +503,7 @@ async fn hx_webauthn_register_finish(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     Json(reg_response): Json<RegisterPublicKeyCredential>,
 ) -> axum::response::Response {
-    let user_info = get_user_login(headers, &pool, redis.clone()).await;
+    let user_info = get_user_login(headers, &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return json_resp(StatusCode::UNAUTHORIZED, serde_json::json!({"error": "Not logged in"}));
     }
@@ -570,15 +575,13 @@ async fn hx_webauthn_register_finish(
 
     let record_id = generate_secure_string();
     let passkey_json = serde_json::to_value(&passkey).unwrap_or_default();
-    let result = sqlx::query(
-        "INSERT INTO webauthn_credentials (id, user_login, credential_name, passkey) VALUES ($1, $2, $3, $4)",
-    )
-    .bind(&record_id)
-    .bind(&user_info.login)
-    .bind(&cred_name)
-    .bind(&passkey_json)
-    .execute(&pool)
-    .await;
+    let result = db
+        .query("CREATE type::thing('webauthn_credentials', $id) SET user_login = $user, credential_name = $cname, passkey = $passkey, created = time::unix(time::now())")
+        .bind(("id", &record_id))
+        .bind(("user", &user_info.login))
+        .bind(("cname", &cred_name))
+        .bind(("passkey", &passkey_json))
+        .await;
 
     let _: () = redis
         .del(format!("webauthn_reg:{}", token))
@@ -596,12 +599,12 @@ async fn hx_webauthn_register_finish(
 }
 
 async fn hx_settings_2fa_webauthn_delete(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     Path(cred_id): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user_info = get_user_login(headers, &pool, redis).await;
+    let user_info = get_user_login(headers, &db, redis).await;
     if !is_logged(user_info.clone()).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
@@ -609,17 +612,14 @@ async fn hx_settings_2fa_webauthn_delete(
     }
     let user_info = user_info.unwrap();
 
-    let rows = sqlx::query(
-        "DELETE FROM webauthn_credentials WHERE id=$1 AND user_login=$2",
-    )
-    .bind(&cred_id)
-    .bind(&user_info.login)
-    .execute(&pool)
-    .await
-    .map(|r| r.rows_affected())
-    .unwrap_or(0);
-
-    if rows == 0 {
+    let mut _del_resp = db
+        .query("DELETE FROM webauthn_credentials WHERE id = $cid AND user_login = $user RETURN id")
+        .bind(("cid", &cred_id))
+        .bind(("user", &user_info.login))
+        .await
+        .expect("db error");
+    let deleted: Vec<serde_json::Value> = _del_resp.take(0).unwrap_or_default();
+    if deleted.is_empty() {
         return Html(minifi_html(
             "<b class=\"text-danger\">Credential not found or not yours.</b>".to_owned(),
         ));
@@ -640,14 +640,14 @@ struct StartAuthRequest {
 }
 
 async fn hx_webauthn_auth_start(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     Extension(webauthn_lock): Extension<
         std::sync::Arc<std::sync::RwLock<Option<webauthn_rs::Webauthn>>>,
     >,
     Json(req): Json<StartAuthRequest>,
 ) -> axum::response::Response {
-    let passkeys_with_ids = load_passkeys(&pool, &req.username).await;
+    let passkeys_with_ids = load_passkeys(&db, &req.username).await;
     if passkeys_with_ids.is_empty() {
         return json_resp(
             StatusCode::NOT_FOUND,
@@ -692,7 +692,7 @@ async fn hx_webauthn_auth_start(
 
 async fn hx_webauthn_auth_finish(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(mut redis): Extension<RedisConn>,
     Extension(webauthn_lock): Extension<
         std::sync::Arc<std::sync::RwLock<Option<webauthn_rs::Webauthn>>>,
@@ -748,16 +748,15 @@ async fn hx_webauthn_auth_finish(
     };
 
     // Update passkey counter
-    let passkeys_with_ids = load_passkeys(&pool, &login).await;
+    let passkeys_with_ids = load_passkeys(&db, &login).await;
     for (record_id, mut pk) in passkeys_with_ids {
         if pk.update_credential(&auth_result) == Some(true) {
             let passkey_json = serde_json::to_value(&pk).unwrap_or_default();
-            let _ =
-                sqlx::query("UPDATE webauthn_credentials SET passkey=$1 WHERE id=$2")
-                    .bind(&passkey_json)
-                    .bind(&record_id)
-                    .execute(&pool)
-                    .await;
+            let _ = db
+                .query("UPDATE webauthn_credentials SET passkey = $passkey WHERE id = $id")
+                .bind(("passkey", &passkey_json))
+                .bind(("id", &record_id))
+                .await;
         }
     }
 

--- a/src/two_factor.rs
+++ b/src/two_factor.rs
@@ -43,7 +43,7 @@ async fn load_passkeys(db: &Db, login: &str) -> Vec<(String, Passkey)> {
     struct PasskeyRow { id: surrealdb::RecordId, passkey: serde_json::Value }
     let mut resp = db
         .query("SELECT id, passkey FROM webauthn_credentials WHERE user_login = $user")
-        .bind(("user", login))
+        .bind(("user", login.to_string()))
         .await
         .unwrap_or_else(|_| unreachable!());
     let rows: Vec<PasskeyRow> = resp.take(0).unwrap_or_default();
@@ -289,7 +289,7 @@ async fn hx_settings_2fa_totp_verify_setup(
 
     let result = db
         .query("UPDATE users SET totp_secret = $secret, totp_enabled = true WHERE id = $id")
-        .bind(("secret", &secret_base32))
+        .bind(("secret", secret_base32.clone()))
         .bind(("id", surrealdb::RecordId::from_table_key("users", &user_info.login)))
         .await;
 
@@ -391,7 +391,7 @@ async fn hx_settings_2fa(
     struct WebauthnCredRow { id: String, credential_name: String, created: i64 }
     let mut _wc_resp = db
         .query("SELECT id, credential_name, created FROM webauthn_credentials WHERE user_login = $user ORDER BY created ASC")
-        .bind(("user", &user_info.login))
+        .bind(("user", user_info.login.clone()))
         .await
         .expect("db error");
     let webauthn_creds: Vec<WebauthnCredInfo> = _wc_resp
@@ -577,10 +577,10 @@ async fn hx_webauthn_register_finish(
     let passkey_json = serde_json::to_value(&passkey).unwrap_or_default();
     let result = db
         .query("CREATE type::thing('webauthn_credentials', $id) SET user_login = $user, credential_name = $cname, passkey = $passkey, created = time::unix(time::now())")
-        .bind(("id", &record_id))
-        .bind(("user", &user_info.login))
-        .bind(("cname", &cred_name))
-        .bind(("passkey", &passkey_json))
+        .bind(("id", record_id.clone()))
+        .bind(("user", user_info.login.clone()))
+        .bind(("cname", cred_name.clone()))
+        .bind(("passkey", passkey_json.clone()))
         .await;
 
     let _: () = redis
@@ -614,8 +614,8 @@ async fn hx_settings_2fa_webauthn_delete(
 
     let mut _del_resp = db
         .query("DELETE FROM webauthn_credentials WHERE id = $cid AND user_login = $user RETURN id")
-        .bind(("cid", &cred_id))
-        .bind(("user", &user_info.login))
+        .bind(("cid", cred_id.clone()))
+        .bind(("user", user_info.login.clone()))
         .await
         .expect("db error");
     let deleted: Vec<serde_json::Value> = _del_resp.take(0).unwrap_or_default();
@@ -754,8 +754,8 @@ async fn hx_webauthn_auth_finish(
             let passkey_json = serde_json::to_value(&pk).unwrap_or_default();
             let _ = db
                 .query("UPDATE webauthn_credentials SET passkey = $passkey WHERE id = $id")
-                .bind(("passkey", &passkey_json))
-                .bind(("id", &record_id))
+                .bind(("passkey", passkey_json.clone()))
+                .bind(("id", record_id.clone()))
                 .await;
         }
     }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,12 +1,13 @@
 #[derive(Template)]
 #[template(path = "pages/hx-studio-upload.html", escape = "none")]
 struct HXStudioUploadTemplate {}
+
 async fn hx_studio_upload(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -17,11 +18,11 @@ async fn hx_studio_upload(
 
 async fn upload(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    if !is_logged(get_user_login(headers.clone(), &pool, redis.clone()).await).await {
+    if !is_logged(get_user_login(headers.clone(), &db, redis.clone()).await).await {
         return Html(minifi_html(
             "<script>window.location.replace(\"/login\");</script>".to_owned(),
         ));
@@ -39,13 +40,13 @@ async fn upload(
 }
 
 async fn hx_upload(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
     mut multipart: Multipart,
 ) -> Html<String> {
     // Step 1: Authenticate User
-    let user_info = get_user_login(headers.clone(), &pool, redis.clone()).await;
+    let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
     if !is_logged(user_info.clone()).await {
         return Html("<script>window.location.replace(\"/login\");</script>".to_owned());
     }
@@ -103,14 +104,14 @@ async fn hx_upload(
         response_html.push_str("</table><br>");
 
         // Step 7: Save metadata to the database
-        sqlx::query!(
-            "INSERT INTO media_concepts (id, name, owner, type) VALUES ($1, $2, $3, $4)",
-            medium_id,
-            file_name,
-            user_info.clone().unwrap().login,
-            detect_medium_type_mime(file_type)
+        let concept_id = surrealdb::RecordId::from_table_key("media_concepts", &medium_id);
+        db.query(
+            "CREATE $id SET name = $name, owner = $owner, type = $type, processed = false;",
         )
-        .execute(&pool)
+        .bind(("id", concept_id))
+        .bind(("name", &file_name))
+        .bind(("owner", user_info.clone().unwrap().login))
+        .bind(("type", detect_medium_type_mime(file_type)))
         .await
         .expect("Database error");
     }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -109,7 +109,7 @@ async fn hx_upload(
             "CREATE $id SET name = $name, owner = $owner, type = $type, processed = false;",
         )
         .bind(("id", concept_id))
-        .bind(("name", &file_name))
+        .bind(("name", file_name.clone()))
         .bind(("owner", user_info.clone().unwrap().login))
         .bind(("type", detect_medium_type_mime(file_type)))
         .await

--- a/src/usernav.rs
+++ b/src/usernav.rs
@@ -6,11 +6,11 @@ struct HXUsernavTemplate {
 }
 async fn hx_usernav(
     Extension(config): Extension<Config>,
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Extension(redis): Extension<RedisConn>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    let try_user = get_user_login(headers, &pool, redis.clone()).await;
+    let try_user = get_user_login(headers, &db, redis.clone()).await;
     if try_user.is_some() {
         let user = try_user.unwrap();
         let template = HXUsernavTemplate { user, config };

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,13 +1,18 @@
+#[derive(Deserialize)]
+struct ViewsRow {
+    views: i64,
+}
+
 async fn hx_new_view(
-    Extension(pool): Extension<PgPool>,
+    Extension(db): Extension<Db>,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
-    let update_views = sqlx::query!(
-        "UPDATE media SET views = views + 1 WHERE id=$1 RETURNING views;",
-        mediumid
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("Database error");
-    Html(update_views.views.to_string())
+    let mut resp = db
+        .query("UPDATE media SET views += 1 WHERE id = $id RETURN views")
+        .bind(("id", surrealdb::RecordId::from_table_key("media", &mediumid)))
+        .await
+        .expect("Database error");
+    let rows: Vec<ViewsRow> = resp.take(0).unwrap_or_default();
+    let views = rows.first().map(|r| r.views).unwrap_or(0);
+    Html(views.to_string())
 }


### PR DESCRIPTION
## Summary
This PR migrates the entire application from PostgreSQL (via sqlx) to SurrealDB as the primary database backend. All database queries have been rewritten to use SurrealDB's query language and API, with corresponding schema changes.

## Key Changes

### Database Layer Migration
- Replaced `sqlx::PgPool` with `surrealdb::Surreal<WsClient>` throughout the codebase
- Updated all SQL queries to SurrealDB query syntax (using `$parameter` binding style)
- Implemented proper deserialization of SurrealDB responses using `serde` with custom struct definitions
- Added `schema.surql` file containing complete SurrealDB schema definition with tables, fields, and indexes

### Query Pattern Changes
- Converted raw SQL queries to SurrealDB's query builder pattern
- Replaced `sqlx::Row` trait usage with `serde::Deserialize` for type-safe result mapping
- Updated pagination queries to use `LIMIT` and `START` syntax instead of `OFFSET`
- Modified aggregate queries to use SurrealDB's array functions (e.g., `array::len()`)
- Changed record ID handling to use `surrealdb::RecordId` for proper type safety

### Configuration Updates
- Updated `config.json` to use SurrealDB connection parameters (`surrealdb_url`, `surrealdb_ns`, `surrealdb_db`, `surrealdb_user`, `surrealdb_pass`)
- Modified `docker-compose.yml` to replace PostgreSQL service with SurrealDB and updated service dependencies

### Affected Modules
- `main.rs`: Core database type definition and initialization
- `lists.rs`: List page queries and media-in-list queries
- `studio.rs`: Studio media and lists queries
- `groups.rs`: User group queries and creation
- `settings.rs`: Settings page queries
- `two_factor.rs`: Passkey and TOTP secret queries
- `subtitles.rs`: Media owner verification queries
- `likes_dislikes.rs`: Reaction count and user reaction queries
- `concept.rs`: Media concept queries
- `channel.rs`: User channel and subscription count queries
- `comments.rs`: Comment fetching with author information
- `subscriptions.rs`: Subscription-based media queries
- `helper_functions.rs`: User login and profile queries
- `medium.rs`: Media detail queries with owner information
- `search.rs`: Visibility filter building for search
- `login_handler.rs`: User authentication queries
- `trending.rs`, `recommendations.rs`, `thumbnail.rs`, `chapters.rs`, `views.rs`: Various query updates

### Implementation Details
- All database operations now use async/await with SurrealDB's WebSocket client
- Record IDs are properly constructed using `surrealdb::RecordId::from_table_key()` where needed
- Response handling uses `.take(0)` to extract query results and `.unwrap_or_default()` for safe fallbacks
- Struct definitions for database rows use `#[derive(Deserialize)]` with `#[serde(rename)]` for field mapping
- Maintained backward compatibility with existing API responses and data structures

https://claude.ai/code/session_012a18KgXgwn9rTxzb6Fbhsb