### PR TITLE
Replace deprecated type::thing with type::record in media likes event

### DIFF
--- a/schema.surql
+++ b/schema.surql
@@ -88,7 +88,7 @@ DEFINE EVENT media_likes_changed ON TABLE media_likes
   WHEN $event = "CREATE" OR $event = "UPDATE" OR $event = "DELETE"
   THEN {
     LET $mid = IF $event = "DELETE" THEN $before.media_id ELSE $after.media_id END;
-    UPDATE type::thing('media', $mid) SET
+    UPDATE type::record('media', $mid) SET
       likes_count    = array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'like')),
       dislikes_count = array::len((SELECT id FROM media_likes WHERE media_id = $mid AND reaction = 'dislike'));
   };


### PR DESCRIPTION
## Summary
Updated the SurrealDB schema to use the current `type::record()` function instead of the deprecated `type::thing()` function in the media likes change event handler.

## Changes
- Replaced `type::thing('media', $mid)` with `type::record('media', $mid)` in the `media_likes_changed` event trigger
- This change ensures compatibility with current SurrealDB API standards and removes usage of deprecated functions

## Details
The `media_likes_changed` event updates the likes and dislikes count on media records whenever a media_likes entry is created, updated, or deleted. The function used to construct the record reference has been updated to reflect SurrealDB's current naming conventions.

https://claude.ai/code/session_016L8iWZGfftbhCTXjQxkv3n