### PR TITLE
Remove serde default functions from Config struct

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,13 +43,9 @@ type Db = Surreal<WsClient>;
 #[derive(Deserialize, Clone)]
 struct Config {
     surrealdb_url: String,
-    #[serde(default = "default_surreal_ns")]
     surrealdb_ns: String,
-    #[serde(default = "default_surreal_db")]
     surrealdb_db: String,
-    #[serde(default = "default_surreal_user")]
     surrealdb_user: String,
-    #[serde(default = "default_surreal_pass")]
     surrealdb_pass: String,
     redis_url: String,
     instancename: String,
@@ -66,10 +62,6 @@ struct Config {
     webauthn_rp_origin: Option<String>,
 }
 
-fn default_surreal_ns() -> String { "platform".to_string() }
-fn default_surreal_db() -> String { "platform".to_string() }
-fn default_surreal_user() -> String { "root".to_string() }
-fn default_surreal_pass() -> String { "root".to_string() }
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
## Summary
Removed the `#[serde(default = "...")]` attributes and their corresponding default value functions from the Config struct. This makes all SurrealDB configuration fields required rather than optional.

## Changes
- Removed `#[serde(default)]` attributes from `surrealdb_ns`, `surrealdb_db`, `surrealdb_user`, and `surrealdb_pass` fields
- Deleted the four default value functions:
  - `default_surreal_ns()` → was "platform"
  - `default_surreal_db()` → was "platform"
  - `default_surreal_user()` → was "root"
  - `default_surreal_pass()` → was "root"

## Impact
Configuration files must now explicitly provide values for all SurrealDB connection parameters. This enforces explicit configuration and removes implicit defaults, which may improve clarity and reduce unexpected behavior from missing configuration values.

https://claude.ai/code/session_01KuG8mBUqH4FACg7xZFQTtB