### PR TITLE
Rename type field to medium_type in search results

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -867,7 +867,7 @@ async fn hx_search_all_inner(
                     owner: hit.result.owner,
                     views: hit.result.views,
                     likes: hit.result.likes,
-                    r#type: hit.result.r#type,
+                    medium_type: hit.result.medium_type,
                     upload: hit.result.upload,
                 }
             }).collect();


### PR DESCRIPTION
## Summary
Renamed the `r#type` field to `medium_type` in the search results mapping to improve code clarity and avoid the raw identifier syntax.

## Changes
- Changed field name from `r#type` to `medium_type` in the `hx_search_all_inner` function's result mapping
- This simplifies the code by eliminating the need for the raw identifier prefix (`r#`), making the field name more readable and idiomatic

## Details
The `r#type` syntax is a Rust raw identifier used to reference keywords or reserved words as identifiers. By renaming to `medium_type`, the code becomes cleaner and more maintainable without requiring special syntax.

https://claude.ai/code/session_01KZUqFu4t6NV7XGJCwdiRQM