### PR TITLE
Add "upload" field to search suggestions retrieval

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -183,7 +183,7 @@ async fn hx_search_suggestions(
                 .with_highlight_pre_tag("<mark>")
                 .with_highlight_post_tag("</mark>")
                 .with_attributes_to_retrieve(meilisearch_sdk::search::Selectors::Some(&[
-                    "id", "name", "owner", "views", "type",
+                    "id", "name", "owner", "views", "type", "upload",
                 ]))
                 .execute::<MeiliMedia>()
                 .await


### PR DESCRIPTION
## Summary
Updated the Meilisearch query in the search suggestions endpoint to include the "upload" field in the retrieved attributes.

## Changes
- Added "upload" to the list of attributes retrieved from Meilisearch in the `hx_search_suggestions` function
- This allows the search suggestions response to include upload-related information for each media result

## Implementation Details
The "upload" field is now included alongside existing attributes (id, name, owner, views, type) when executing the Meilisearch query for search suggestions. This enables clients to access upload metadata without requiring a separate request.

https://claude.ai/code/session_01CPfByTRhhWzfNajvSK3rGX