### PR TITLE
Handle missing channel data gracefully with redirects

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -20,7 +20,7 @@ async fn channel(
     headers: HeaderMap,
     Path(userid): Path<String>,
 ) -> axum::response::Html<Vec<u8>> {
-    let user = sqlx::query_as!(
+    let user = match sqlx::query_as!(
         UserChannel,
         "SELECT
     u.login,
@@ -48,7 +48,14 @@ WHERE
     )
     .fetch_one(&pool)
     .await
-    .unwrap();
+    {
+        Ok(u) => u,
+        Err(_) => {
+            return Html(minifi_html(
+                "<script>window.location.replace(\"/\");</script>".to_owned(),
+            ));
+        }
+    };
     let sidebar = generate_sidebar(&config, "channel".to_owned());
     let common_headers = extract_common_headers(&headers).unwrap();
     let template = ChannelTemplate {

--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -27,7 +27,9 @@
                     <tr>
                         <td class="text-center">
                             <div class="channel-picture-container d-inline-block">
-                                <img src="{{ config.source_server_url }}/source/{{ user.channel_picture.clone().unwrap() }}/picture.avif">
+                                {% if let Some(pic) = user.channel_picture %}
+                                <img src="{{ config.source_server_url }}/source/{{ pic }}/picture.avif">
+                                {% endif %}
                             </div>
                         </td>
                     </tr>


### PR DESCRIPTION
## Summary
Improved error handling for channel page requests by gracefully handling database query failures and missing optional data instead of panicking.

## Key Changes
- **Error handling in channel endpoint**: Replaced `.unwrap()` with a `match` statement that redirects to home page when the channel query fails, preventing server panics on invalid user IDs
- **Template safety**: Updated channel picture rendering to use Tera's `if let` pattern matching instead of calling `.unwrap()` on optional values, preventing template errors when picture data is missing

## Implementation Details
- When a channel lookup fails (e.g., user not found), the endpoint now returns an HTML response with a JavaScript redirect to "/" instead of panicking
- The channel picture is now conditionally rendered only when present, improving robustness for users without profile pictures

https://claude.ai/code/session_014C33p96UYt7ibcbTNZYKqx