### PR TITLE
Handle invalid JSON in medium_description gracefully

### DIFF
--- a/src/concept.rs
+++ b/src/concept.rs
@@ -158,7 +158,7 @@ async fn publish(
             None
         };
         let description: serde_json::Value =
-            serde_json::from_str(&form.medium_description).unwrap();
+            serde_json::from_str(&form.medium_description).unwrap_or(serde_json::Value::Null);
         let _ = sqlx::query(
             "INSERT INTO media (id,name,description,owner,public,visibility,restricted_to_group,type) VALUES ($1,$2,$3,$4,$5,$6,$7,$8);"
         )


### PR DESCRIPTION
## Summary
Changed the JSON parsing of `form.medium_description` to handle invalid JSON gracefully by returning a null value instead of panicking.

## Key Changes
- Replaced `.unwrap()` with `.unwrap_or(serde_json::Value::Null)` when parsing the `medium_description` field
- This prevents the application from crashing when the description contains invalid JSON, instead defaulting to a null value

## Implementation Details
The change allows the media insertion to proceed even when the description field contains malformed JSON, improving the robustness of the publish endpoint. Invalid descriptions will be stored as null values in the database rather than causing a panic.

https://claude.ai/code/session_01SfLFZCADJBmNmdc9bQS9At