### PR TITLE
Refactor subtitle translation selects to use TomSelect

### DIFF
--- a/templates/pages/hx-studio-edit-subtitles.html
+++ b/templates/pages/hx-studio-edit-subtitles.html
@@ -122,6 +122,8 @@
 <script>
 (function() {
     var subtitles = [];
+    var tsSource = new TomSelect('#translate-source-select', { create: false, allowEmptyOption: true });
+    var tsTarget = new TomSelect('#translate-target-select', { create: false, allowEmptyOption: true });
 
     function renderSubtitles() {
         var tbody = document.getElementById('subtitles-tbody');
@@ -202,17 +204,15 @@
         .catch(function(err) { console.error('Failed to load subtitles:', err); });
 
     function updateTranslateSourceSelect() {
-        var sel = document.getElementById('translate-source-select');
-        var currentVal = sel.value;
-        sel.innerHTML = '<option value="">-- Select source --</option>';
+        var currentVal = tsSource.getValue();
+        tsSource.clearOptions();
+        tsSource.addOption({ value: '', text: '-- Select source --' });
         subtitles.forEach(function(sub) {
             if (sub.format === 'ass') return; // ASS subtitles cannot be used as translation source
-            var opt = document.createElement('option');
-            opt.value = sub.label;
-            opt.textContent = sub.label;
-            sel.appendChild(opt);
+            tsSource.addOption({ value: sub.label, text: sub.label });
         });
-        if (currentVal) sel.value = currentVal;
+        tsSource.refreshOptions(false);
+        if (currentVal) tsSource.setValue(currentVal, true);
     }
 
     function showTranslateStatus(type, msg) {
@@ -237,8 +237,8 @@
 
     document.getElementById('translate-subtitle-btn').addEventListener('click', function() {
         var btn = this;
-        var sourceLabel = document.getElementById('translate-source-select').value;
-        var targetLang = document.getElementById('translate-target-select').value;
+        var sourceLabel = tsSource.getValue();
+        var targetLang = tsTarget.getValue();
 
         if (!sourceLabel) {
             showTranslateStatus('danger', 'Please select a source subtitle.');


### PR DESCRIPTION
## Summary
Refactored the subtitle translation source and target language selectors to use TomSelect instead of vanilla HTML select elements, improving the user experience with better select functionality.

## Key Changes
- Initialized TomSelect instances for both `#translate-source-select` and `#translate-target-select` with `create: false` and `allowEmptyOption: true` options
- Updated `updateTranslateSourceSelect()` function to use TomSelect API methods:
  - Replaced direct DOM manipulation (`innerHTML`, `createElement`) with `clearOptions()` and `addOption()`
  - Changed value retrieval from `sel.value` to `tsSource.getValue()`
  - Added `refreshOptions(false)` to update the select after adding options
  - Updated value setting to use `tsSource.setValue()` with silent flag
- Updated translation button click handler to use `getValue()` method instead of direct `.value` property access for both source and target selects

## Implementation Details
- TomSelect instances are initialized at the module level to maintain state across function calls
- The `allowEmptyOption: true` configuration preserves the ability to have an empty default option
- The `create: false` setting prevents users from creating custom options, maintaining data integrity
- All value operations now go through TomSelect's API for consistency and proper state management

https://claude.ai/code/session_01ERzZtf2ramD9zoLsycV3sA