### PR TITLE
Remove view transition animations for media player

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -137,14 +137,3 @@ function fitMediumTitle() {
 
 window.addEventListener('resize', fitMediumTitle);
 
-// Cross-document view transition: mark the clicked thumbnail so it morphs into the player.
-// Uses event delegation so it works for HTMX-loaded cards too.
-document.addEventListener('click', function (e) {
-    const link = e.target.closest('a[href^="/m/"]');
-    if (!link || e.defaultPrevented) return;
-    // hx-mediumcard cards use .thumbnail-container; search cards use .search-card-thumbnail
-    const thumb = link.querySelector('.thumbnail-container, .search-card-thumbnail');
-    if (thumb) {
-        thumb.style.viewTransitionName = 'medium-player';
-    }
-});

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -16569,44 +16569,6 @@ body.sidebar-collapsed .sidebarbackground {
     align-self: center;
 }
 
-/* Cross-document view transitions: thumbnail card → media player */
-@view-transition {
-    navigation: auto;
-}
-
-/* The group handles geometry (position + size) morphing automatically.
-   We just tune the duration and easing. */
-::view-transition-group(medium-player) {
-    animation-duration: 560ms;
-    animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-/* Fade out the thumbnail snapshot */
-::view-transition-old(medium-player) {
-    animation: 280ms ease-out both fade-out-vt;
-}
-
-/* Fade in the player snapshot, slightly delayed so the morph leads */
-::view-transition-new(medium-player) {
-    animation: 300ms 240ms ease-in both fade-in-vt;
-}
-
-@keyframes fade-out-vt {
-    to { opacity: 0; }
-}
-
-@keyframes fade-in-vt {
-    from { opacity: 0; }
-}
-
-/* Respect reduced-motion preference */
-@media (prefers-reduced-motion: reduce) {
-    ::view-transition-group(medium-player),
-    ::view-transition-old(medium-player),
-    ::view-transition-new(medium-player) {
-        animation-duration: 0.01ms !important;
-    }
-}
 
 /* User display name - always single line, max 150px, responsive font size */
 .user-name-clamp {

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -112,7 +112,6 @@
                 <div class="card py-3 px-3 text-white" style="min-height: 85vh">
                     <div
                         class="d-flex justify-content-center player-container"
-                        style="view-transition-name: medium-player"
                     >
                         {% if medium_type == "video" %}
                         <media-player


### PR DESCRIPTION
This PR removes the View Transitions API implementation that was used to animate the morphing of thumbnail cards into the media player during cross-document navigation.

## Summary
The view transition feature that provided a smooth animation when navigating from a thumbnail card to the media player has been completely removed from the codebase.

## Changes Made
- **CSS**: Removed all view transition-related styles including:
  - `@view-transition` rule for automatic navigation transitions
  - `::view-transition-group(medium-player)` animation configuration
  - `::view-transition-old(medium-player)` and `::view-transition-new(medium-player)` fade animations
  - Associated `@keyframes` definitions (`fade-out-vt`, `fade-in-vt`)
  - Media query for `prefers-reduced-motion` accessibility handling

- **JavaScript**: Removed the click event delegation handler that:
  - Detected clicks on media links (`/m/` URLs)
  - Applied the `medium-player` view transition name to thumbnail elements
  - Supported both HTMX-loaded cards and search result cards

- **HTML**: Removed the `style="view-transition-name: medium-player"` inline style from the player container div in the media player template

## Implementation Details
The removal is complete and clean—all three layers (CSS animations, JavaScript event handling, and HTML markup) have been removed, ensuring no orphaned code or unused styles remain.

https://claude.ai/code/session_01R7gQcoWLb5EqcEbMd2Eiud