### PR TITLE
Refactor sitemap generation to use Redis caching

### DIFF
--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -1,94 +1,16 @@
-async fn sitemap_xml(
-    Extension(pool): Extension<PgPool>,
-    Extension(config): Extension<Config>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
-    let host = headers
-        .get(HOST)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("localhost");
-    let base = format!("https://{}", host);
+async fn sitemap_xml(Extension(mut redis): Extension<RedisConn>) -> Response {
+    let cached: Option<String> = redis.get("cache:sitemap").await.unwrap_or(None);
 
-    let mut xml = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-    xml.push_str("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n");
-
-    // Home
-    xml.push_str(&format!(
-        "  <url><loc>{}/</loc><changefreq>daily</changefreq><priority>1.0</priority></url>\n",
-        base
-    ));
-    // Trending
-    xml.push_str(&format!(
-        "  <url><loc>{}/trending</loc><changefreq>daily</changefreq><priority>0.8</priority></url>\n",
-        base
-    ));
-    // Search
-    xml.push_str(&format!(
-        "  <url><loc>{}/search</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>\n",
-        base
-    ));
-
-    // All users
-    let users: Vec<String> = sqlx::query_scalar("SELECT login FROM users ORDER BY login")
-        .fetch_all(&pool)
-        .await
-        .unwrap_or_default();
-
-    for login in &users {
-        let escaped = html_escape(login);
-        xml.push_str(&format!(
-            "  <url><loc>{}/u/{}</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>\n",
-            base, escaped
-        ));
+    match cached {
+        Some(xml) => (
+            axum::http::StatusCode::OK,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/xml; charset=utf-8",
+            )],
+            xml,
+        )
+            .into_response(),
+        None => axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response(),
     }
-
-    // All public videos/media
-    let media: Vec<(String,)> = sqlx::query_as(
-        "SELECT id FROM media WHERE visibility = 'public' ORDER BY upload DESC",
-    )
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
-
-    for (id,) in &media {
-        let escaped = html_escape(id);
-        xml.push_str(&format!(
-            "  <url><loc>{}/m/{}</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>\n",
-            base, escaped
-        ));
-    }
-
-    // All public lists
-    let lists: Vec<(String,)> = sqlx::query_as(
-        "SELECT id FROM lists WHERE visibility = 'public' ORDER BY created DESC",
-    )
-    .fetch_all(&pool)
-    .await
-    .unwrap_or_default();
-
-    for (id,) in &lists {
-        let escaped = html_escape(id);
-        xml.push_str(&format!(
-            "  <url><loc>{}/l/{}</loc><changefreq>weekly</changefreq><priority>0.6</priority></url>\n",
-            base, escaped
-        ));
-    }
-
-    xml.push_str("</urlset>\n");
-
-    let _ = config; // suppress unused warning
-
-    (
-        axum::http::StatusCode::OK,
-        [(axum::http::header::CONTENT_TYPE, "application/xml; charset=utf-8")],
-        xml,
-    )
-}
-
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#x27;")
 }


### PR DESCRIPTION
## Summary
Refactored the sitemap generation endpoint to retrieve pre-computed sitemaps from Redis cache instead of dynamically generating them on each request.

## Key Changes
- Replaced dynamic sitemap XML generation with Redis cache lookup
- Removed database queries for users, media, and lists
- Removed inline XML string building and HTML escaping logic
- Simplified endpoint to return cached sitemap or SERVICE_UNAVAILABLE status
- Changed function signature to accept `RedisConn` extension instead of `PgPool` and `Config`
- Updated response type from tuple-based to explicit `Response` type

## Implementation Details
- The endpoint now attempts to retrieve a pre-cached sitemap from Redis using the key `"cache:sitemap"`
- If the cache hit succeeds, returns HTTP 200 with the cached XML content
- If the cache is empty or unavailable, returns HTTP 503 (Service Unavailable)
- This approach assumes sitemap generation is handled separately (likely via a background job or scheduled task) and cached in Redis
- Significantly reduces database load and improves response time for sitemap requests

https://claude.ai/code/session_01HgPqdXN8atAUCgiY1PRgkC