### PR TITLE
Enable rustls ring crypto provider for TLS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ axum = { version = "0.8", features = ["multipart", "json"] }
 tower = "*"
 tower-http = { version = "*", features = ["fs", "compression-br", "compression-zstd"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-rustls = "0.23"
+rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2"
 memory-serve = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ struct Config {
 }
 #[tokio::main]
 async fn main() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install rustls crypto provider");
+
     let config: Config =
         serde_json::from_str(&fs::read_to_string("config.json").await.unwrap()).unwrap();
 


### PR DESCRIPTION
## Summary
This PR enables the rustls ring cryptographic provider to ensure TLS functionality is properly initialized at application startup.

## Key Changes
- Added rustls crypto provider initialization in `main()` that installs the default ring-based crypto provider before any TLS operations occur
- Updated the rustls dependency to include the `ring` feature, which provides the cryptographic primitives needed for TLS operations

## Implementation Details
The rustls crypto provider must be explicitly installed before the application can perform any TLS-related operations. This is done at the very beginning of the `main()` function to ensure it's available throughout the application's lifetime. The initialization includes error handling to panic if the provider installation fails, which is appropriate since TLS functionality is critical for this application.

https://claude.ai/code/session_01GTFEA2TjeA9Qztye84pjQ1