### PR TITLE
Simplify TLS configuration using RustlsConfig::from_pem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ tower = "*"
 tower-http = { version = "*", features = ["fs", "compression-br", "compression-zstd"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 rustls = { version = "0.23", features = ["ring"] }
-rustls-pemfile = "2"
 memory-serve = "1"
 serde = { version = "1.0", features = ["derive"] }
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "json"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use serde::Serialize;
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use axum_server::tls_rustls::RustlsConfig;
-use std::io::{BufRead, BufReader};
+use std::io::BufRead;
 use std::sync::Arc;
 use tokio::{fs, io, io::AsyncWriteExt};
 use tower_http::compression::CompressionLayer;
@@ -369,32 +369,18 @@ async fn main() {
             .await
             .expect("Failed to read TLS private key file");
 
-        let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-            rustls_pemfile::certs(&mut BufReader::new(cert_bytes.as_slice()))
-                .collect::<Result<Vec<_>, _>>()
-                .expect("Failed to parse TLS certificate")
-                .into_iter()
-                .map(|c| c.into_owned())
-                .collect();
+        // Load TLS configuration from PEM data.
+        // RustlsConfig::from_pem sets ALPN to ["h2", "http/1.1"] by default.
+        let rustls_config = RustlsConfig::from_pem(cert_bytes, key_bytes)
+            .await
+            .expect("Failed to configure TLS: ensure cert and key are valid PEM files");
 
-        let key: rustls::pki_types::PrivateKeyDer<'static> =
-            rustls_pemfile::private_key(&mut BufReader::new(key_bytes.as_slice()))
-                .expect("Failed to parse TLS private key")
-                .expect("No private key found in TLS key file");
-
-        let mut tls_server_config = rustls::ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
-            .expect("Invalid TLS certificate or key");
-
-        // Advertise HTTP/2 via ALPN when enable_http2 is true (default).
-        tls_server_config.alpn_protocols = if enable_http2 {
-            vec![b"h2".to_vec(), b"http/1.1".to_vec()]
-        } else {
-            vec![b"http/1.1".to_vec()]
-        };
-
-        let rustls_config = RustlsConfig::from_config(Arc::new(tls_server_config));
+        // When HTTP/2 is disabled, override ALPN to advertise http/1.1 only.
+        if !enable_http2 {
+            let mut server_cfg = (*rustls_config.get_inner()).clone();
+            server_cfg.alpn_protocols = vec![b"http/1.1".to_vec()];
+            rustls_config.reload_from_config(Arc::new(server_cfg));
+        }
 
         let https_addr: std::net::SocketAddr = "0.0.0.0:8443".parse().unwrap();
         let http_addr: std::net::SocketAddr = "0.0.0.0:8080".parse().unwrap();


### PR DESCRIPTION
## Summary
Refactored TLS certificate and key loading to use `RustlsConfig::from_pem()` instead of manually parsing PEM files with `rustls_pemfile`. This simplifies the code and reduces manual certificate handling.

## Key Changes
- Replaced manual PEM parsing logic with `RustlsConfig::from_pem(cert_bytes, key_bytes)` which handles certificate and key loading in a single call
- Removed `BufReader` import and manual certificate/key parsing code (~15 lines)
- Simplified ALPN protocol configuration: now conditionally overrides ALPN only when HTTP/2 is disabled, rather than building the entire config conditionally
- Removed `rustls-pemfile` dependency as it's no longer directly used

## Implementation Details
- `RustlsConfig::from_pem()` defaults to advertising both HTTP/2 ("h2") and HTTP/1.1 protocols via ALPN
- When `enable_http2` is false, the code now clones the inner server config and updates only the ALPN protocols to ["http/1.1"], then reloads the configuration
- Error handling remains consistent with clear error messages for TLS configuration failures

https://claude.ai/code/session_01HeSpwnmtikHTFGGmEuhKu3