### PR TITLE
Simplify private key loading using rustls_pemfile::private_key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,25 +123,9 @@ fn load_certs_from_pem(cert_pem: &[u8]) -> Vec<CertificateDer<'static>> {
 
 fn load_private_key_from_pem(key_pem: &[u8]) -> PrivateKeyDer<'static> {
     let mut reader = std::io::BufReader::new(key_pem);
-
-    let pkcs8_keys = rustls_pemfile::pkcs8_private_keys(&mut reader)
-        .collect::<Result<Vec<_>, _>>()
-        .expect("Failed to parse PKCS#8 private key");
-
-    if let Some(key) = pkcs8_keys.into_iter().next() {
-        return PrivateKeyDer::Pkcs8(key);
-    }
-
-    let mut reader = std::io::BufReader::new(key_pem);
-    let rsa_keys = rustls_pemfile::rsa_private_keys(&mut reader)
-        .collect::<Result<Vec<_>, _>>()
-        .expect("Failed to parse RSA private key");
-
-    if let Some(key) = rsa_keys.into_iter().next() {
-        return PrivateKeyDer::Pkcs1(key);
-    }
-
-    panic!("No supported private key found in PEM");
+    rustls_pemfile::private_key(&mut reader)
+        .expect("Failed to parse private key PEM")
+        .expect("No supported private key found in PEM")
 }
 
 fn build_quinn_server_config(cert_pem: &[u8], key_pem: &[u8]) -> QuinnServerConfig {


### PR DESCRIPTION
## Summary
Refactored the private key loading logic to use the unified `rustls_pemfile::private_key()` function instead of manually trying multiple key formats sequentially.

## Key Changes
- Replaced manual PKCS#8 and RSA key parsing with a single call to `rustls_pemfile::private_key()`
- Removed redundant code that attempted to parse keys in multiple formats with separate reader instances
- Simplified error handling by relying on the unified function's built-in format detection
- Reduced function from 18 lines to 6 lines while maintaining the same functionality

## Implementation Details
The `rustls_pemfile::private_key()` function automatically detects and handles multiple private key formats (PKCS#8, RSA, etc.), eliminating the need for manual format-specific parsing attempts. This approach is cleaner, more maintainable, and reduces the chance of missing supported key formats in the future.

https://claude.ai/code/session_01WtvXgDA5ij9ZpnTpM4yJeM