### PR TITLE
Remove unused parameters from handler functions

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -23,10 +23,10 @@ async fn channel(
     // Get user name + profile_picture from users table
     let user_info = db.session.execute_unpaged(&db.get_user_by_login, (&userid,)).await
         .ok().and_then(|r| r.into_rows_result().ok())
-        .and_then(|rows| rows.maybe_first_row::<(String, Option<String>)>().ok().flatten());
+        .and_then(|rows| rows.maybe_first_row::<(Option<String>, Option<String>)>().ok().flatten());
 
     let (name, profile_picture) = match user_info {
-        Some(row) => row,
+        Some((name_opt, pic)) => (name_opt.unwrap_or_default(), pic),
         None => {
             return Html(minifi_html(
                 "<script>window.location.replace(\"/\");</script>".to_owned(),

--- a/src/helper_functions.rs
+++ b/src/helper_functions.rs
@@ -105,11 +105,11 @@ async fn get_user_login(
         .ok()?;
 
     let result = db.session.execute_unpaged(&db.get_user_by_login, (&login,)).await.ok()?;
-    let row = result.into_rows_result().ok()?.maybe_first_row::<(String, Option<String>)>().ok()??;
+    let row = result.into_rows_result().ok()?.maybe_first_row::<(Option<String>, Option<String>)>().ok()??;
 
     Some(User {
         login,
-        name: row.0,
+        name: row.0.unwrap_or_default(),
         profile_picture: row.1,
     })
 }

--- a/src/likes_dislikes.rs
+++ b/src/likes_dislikes.rs
@@ -6,7 +6,7 @@ fn like_dislike_html(mediumid: &str, likes: i64, dislikes: i64, user_reaction: O
     )
 }
 
-fn like_dislike_html_unauth(_mediumid: &str, likes: i64, dislikes: i64) -> String {
+fn like_dislike_html_unauth(likes: i64, dislikes: i64) -> String {
     format!(
         r#"<li class="d-flex align-items-center mx-2"><a class="text-decoration-none" href="/login"><i class="fa-solid fa-thumbs-up fa-xl"></i>&nbsp;<b>{likes}</b></a><span class="text-white mx-2">|</span><a class="text-decoration-none" href="/login"><i class="fa-solid fa-thumbs-down fa-xl"></i>&nbsp;<b>{dislikes}</b></a></li>"#
     )
@@ -85,7 +85,7 @@ async fn hx_likedislikebutton(
         Html(like_dislike_html(&mediumid, likes, dislikes, user_reaction.as_deref()))
     } else {
         let (likes, dislikes, _) = get_reaction_state_cached(&db, &mediumid, None, redis.clone()).await;
-        Html(like_dislike_html_unauth(&mediumid, likes, dislikes))
+        Html(like_dislike_html_unauth(likes, dislikes))
     }
 }
 
@@ -112,7 +112,7 @@ async fn hx_like(
         Html(like_dislike_html(&mediumid, likes, dislikes, user_reaction.as_deref()))
     } else {
         let (likes, dislikes, _) = get_reaction_state_cached(&db, &mediumid, None, redis.clone()).await;
-        Html(like_dislike_html_unauth(&mediumid, likes, dislikes))
+        Html(like_dislike_html_unauth(likes, dislikes))
     }
 }
 
@@ -139,6 +139,6 @@ async fn hx_dislike(
         Html(like_dislike_html(&mediumid, likes, dislikes, user_reaction.as_deref()))
     } else {
         let (likes, dislikes, _) = get_reaction_state_cached(&db, &mediumid, None, redis.clone()).await;
-        Html(like_dislike_html_unauth(&mediumid, likes, dislikes))
+        Html(like_dislike_html_unauth(likes, dislikes))
     }
 }

--- a/src/likes_dislikes.rs
+++ b/src/likes_dislikes.rs
@@ -6,7 +6,7 @@ fn like_dislike_html(mediumid: &str, likes: i64, dislikes: i64, user_reaction: O
     )
 }
 
-fn like_dislike_html_unauth(mediumid: &str, likes: i64, dislikes: i64) -> String {
+fn like_dislike_html_unauth(_mediumid: &str, likes: i64, dislikes: i64) -> String {
     format!(
         r#"<li class="d-flex align-items-center mx-2"><a class="text-decoration-none" href="/login"><i class="fa-solid fa-thumbs-up fa-xl"></i>&nbsp;<b>{likes}</b></a><span class="text-white mx-2">|</span><a class="text-decoration-none" href="/login"><i class="fa-solid fa-thumbs-down fa-xl"></i>&nbsp;<b>{dislikes}</b></a></li>"#
     )

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -653,7 +653,7 @@ async fn hx_user_lists_inner(
     // Filter visibility at app level
     let mut visible_lists: Vec<(String, String, String, Option<String>, i64)> = Vec::new();
     for list_row in all_lists {
-        let (ref id, ref name, ref visibility, ref restricted_to_group, _created) = list_row;
+        let (ref _id, ref _name, ref visibility, ref restricted_to_group, _created) = list_row;
         let is_owner = userid == user_login;
         if is_owner || visibility == "public" || can_access_restricted(&db, visibility, restricted_to_group.as_deref(), &userid, &user, redis.clone()).await {
             visible_lists.push(list_row);

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -653,7 +653,7 @@ async fn hx_user_lists_inner(
     // Filter visibility at app level
     let mut visible_lists: Vec<(String, String, String, Option<String>, i64)> = Vec::new();
     for list_row in all_lists {
-        let (ref _id, ref _name, ref visibility, ref restricted_to_group, _created) = list_row;
+        let (_, _, ref visibility, ref restricted_to_group, _created) = list_row;
         let is_owner = userid == user_login;
         if is_owner || visibility == "public" || can_access_restricted(&db, visibility, restricted_to_group.as_deref(), &userid, &user, redis.clone()).await {
             visible_lists.push(list_row);

--- a/src/login_handler.rs
+++ b/src/login_handler.rs
@@ -106,7 +106,7 @@ async fn hx_login(
         }
         let session_cookie_set = format!("session={}; {}", session_cookie_value, session_restriction);
         if redis
-            .set(format!("session:{}", session_cookie_value), &form.login)
+            .set::<_, _, ()>(format!("session:{}", session_cookie_value), &form.login)
             .await
             .is_err()
         {

--- a/src/mp4_compose.rs
+++ b/src/mp4_compose.rs
@@ -92,7 +92,7 @@ async fn stream_video_as_mp4(
         .and_then(|r| r.into_rows_result().ok())
         .and_then(|rows| rows.maybe_first_row::<(String, String, String, String, Option<String>, String)>().ok().flatten());
 
-    let (id, name, owner, visibility, restricted_to_group, medium_type) = match medium_row {
+    let (_id, name, owner, visibility, restricted_to_group, medium_type) = match medium_row {
         Some(row) => row,
         None => {
             return Response::builder()

--- a/src/mp4_compose.rs
+++ b/src/mp4_compose.rs
@@ -92,7 +92,7 @@ async fn stream_video_as_mp4(
         .and_then(|r| r.into_rows_result().ok())
         .and_then(|rows| rows.maybe_first_row::<(String, String, String, String, Option<String>, String)>().ok().flatten());
 
-    let (_id, name, owner, visibility, restricted_to_group, medium_type) = match medium_row {
+    let (_, name, owner, visibility, restricted_to_group, medium_type) = match medium_row {
         Some(row) => row,
         None => {
             return Response::builder()

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -1,8 +1,6 @@
 async fn hx_recommended(
     Extension(config): Extension<Config>,
     Extension(db): Extension<ScyllaDb>,
-    Extension(_redis): Extension<RedisConn>,
-    _headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Result<Html<Vec<u8>>, axum::response::Response> {
     let mediumid = mediumid.to_ascii_lowercase();

--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -1,8 +1,8 @@
 async fn hx_recommended(
     Extension(config): Extension<Config>,
     Extension(db): Extension<ScyllaDb>,
-    Extension(redis): Extension<RedisConn>,
-    headers: HeaderMap,
+    Extension(_redis): Extension<RedisConn>,
+    _headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> Result<Html<Vec<u8>>, axum::response::Response> {
     let mediumid = mediumid.to_ascii_lowercase();

--- a/src/studio.rs
+++ b/src/studio.rs
@@ -94,7 +94,7 @@ async fn hx_studio_inner(
     // App-level pagination: skip and take
     let remaining: Vec<_> = all_rows.into_iter().skip(skip).collect();
     let has_more = remaining.len() > 40;
-    let mut media: Vec<MediumStudio> = remaining.into_iter().take(40).map(|(id, name, description, views, media_type, _upload, _visibility, _restricted_to_group)| {
+    let media: Vec<MediumStudio> = remaining.into_iter().take(40).map(|(id, name, description, views, media_type, _upload, _visibility, _restricted_to_group)| {
         MediumStudio {
             id,
             name,

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -21,21 +21,17 @@ async fn trending(
 
 async fn hx_trending(
     Extension(config): Extension<Config>,
-    Extension(db): Extension<ScyllaDb>,
     Extension(redis): Extension<RedisConn>,
-    headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_trending_inner(config, db, redis, headers, 0).await
+    hx_trending_inner(config, redis, 0).await
 }
 
 async fn hx_trending_page(
     Extension(config): Extension<Config>,
-    Extension(db): Extension<ScyllaDb>,
     Extension(redis): Extension<RedisConn>,
-    headers: HeaderMap,
     Path(page): Path<i64>,
 ) -> axum::response::Html<Vec<u8>> {
-    hx_trending_inner(config, db, redis, headers, page).await
+    hx_trending_inner(config, redis, page).await
 }
 
 /// Try to load a page of trending media from the Redis cache.
@@ -99,9 +95,7 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
 
 async fn hx_trending_inner(
     config: Config,
-    _db: ScyllaDb,
     mut redis: RedisConn,
-    _headers: HeaderMap,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
     let offset = page * 30;

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -99,9 +99,9 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
 
 async fn hx_trending_inner(
     config: Config,
-    db: ScyllaDb,
+    _db: ScyllaDb,
     mut redis: RedisConn,
-    headers: HeaderMap,
+    _headers: HeaderMap,
     page: i64,
 ) -> axum::response::Html<Vec<u8>> {
     let offset = page * 30;

--- a/src/two_factor.rs
+++ b/src/two_factor.rs
@@ -145,11 +145,8 @@ async fn hx_login_2fa_totp(
             .parse()
             .unwrap(),
     );
-    (
-        StatusCode::OK,
-        headers,
-        "<b class=\"text-success\">Login successful!</b><script>window.location.replace('/');</script>".to_owned(),
-    )
+    headers.insert("HX-Redirect", "/".parse().unwrap());
+    (StatusCode::OK, headers, String::new())
 }
 
 // ── TOTP settings ────────────────────────────────────────────────────────────

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,6 +1,6 @@
 async fn hx_new_view(
     Extension(db): Extension<ScyllaDb>,
-    Extension(mut redis): Extension<RedisConn>,
+    Extension(_redis): Extension<RedisConn>,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
     // Increment counter in ScyllaDB

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,6 +1,5 @@
 async fn hx_new_view(
     Extension(db): Extension<ScyllaDb>,
-    Extension(_redis): Extension<RedisConn>,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
     // Increment counter in ScyllaDB


### PR DESCRIPTION
## Summary
This PR removes unused parameters from various handler functions throughout the codebase to improve code clarity and reduce unnecessary dependencies being passed around.

## Key Changes

- **trending.rs**: Removed unused `ScyllaDb`, `HeaderMap` parameters from `hx_trending`, `hx_trending_page`, and `hx_trending_inner` functions
- **likes_dislikes.rs**: Removed unused `mediumid` parameter from `like_dislike_html_unauth` function and updated all call sites
- **two_factor.rs**: Simplified 2FA login response to use `HX-Redirect` header instead of inline script
- **channel.rs**: Changed user name type from `String` to `Option<String>` to match database schema, with proper unwrapping to default empty string
- **helper_functions.rs**: Updated `get_user_login` to handle optional user name from database
- **lists.rs**: Removed unused `id` and `name` bindings in list filtering loop
- **login_handler.rs**: Added explicit type annotation to Redis `set` call for clarity
- **mp4_compose.rs**: Removed unused `id` binding in video streaming function
- **recommendations.rs**: Removed unused `RedisConn` and `HeaderMap` parameters from `hx_recommended`
- **studio.rs**: Changed `mut media` to `media` since the vector is not mutated after creation
- **views.rs**: Removed unused `RedisConn` parameter from `hx_new_view`

## Implementation Details

These changes follow the principle of not passing parameters that aren't used by the function, reducing cognitive load and making the actual dependencies clearer. The database schema adjustments (particularly around optional user names) ensure type safety and proper null handling.

https://claude.ai/code/session_01V5VkzAkz7LnQYoP6N8QRt2