### PR TITLE
Add service version detection to diagnostics page

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,24 @@ fn main() {
     };
 
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
+
+    // --- Git branch ---
+    let branch_output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output();
+
+    let git_branch = match branch_output {
+        Ok(o) if o.status.success() => {
+            let branch = String::from_utf8(o.stdout)
+                .unwrap_or_default()
+                .trim()
+                .to_owned();
+            if branch.is_empty() { "unknown".to_owned() } else { branch }
+        }
+        _ => "unknown".to_owned(),
+    };
+
+    println!("cargo:rustc-env=GIT_BRANCH={}", git_branch);
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/");
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -460,18 +460,60 @@ fn get_kernel_version() -> String {
     }
 }
 
+async fn get_scylla_version(db: &ScyllaDb) -> String {
+    db.session
+        .query_unpaged("SELECT release_version FROM system.local", ())
+        .await
+        .ok()
+        .and_then(|r| r.into_rows_result().ok())
+        .and_then(|rows| rows.maybe_first_row::<(String,)>().ok().flatten())
+        .map(|(v,)| v)
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+async fn get_meilisearch_version(meili: &MeilisearchClient) -> String {
+    meili.get_version()
+        .await
+        .map(|v| v.pkg_version)
+        .unwrap_or_else(|_| "unknown".to_owned())
+}
+
+async fn get_redis_version(mut redis: RedisConn) -> String {
+    let info: redis::RedisResult<String> = redis::cmd("INFO")
+        .arg("server")
+        .query_async(&mut redis)
+        .await;
+    match info {
+        Ok(info_str) => {
+            for line in info_str.lines() {
+                if line.starts_with("redis_version:") {
+                    return line["redis_version:".len()..].trim().to_owned();
+                }
+            }
+            "unknown".to_owned()
+        }
+        Err(_) => "unknown".to_owned(),
+    }
+}
+
 #[derive(Template)]
 #[template(path = "pages/hx-settings-diagnostics.html", escape = "none")]
 struct HXSettingsDiagnosticsTemplate {
     git_commit: String,
+    git_branch: String,
     version: String,
     os_distro: String,
     os_kernel: String,
     os_arch: String,
+    scylla_version: String,
+    meilisearch_version: String,
+    redis_version: String,
 }
+
 async fn hx_settings_diagnostics(
     Extension(db): Extension<ScyllaDb>,
     Extension(redis): Extension<RedisConn>,
+    Extension(meili): Extension<Arc<MeilisearchClient>>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
     let user_info = get_user_login(headers.clone(), &db, redis.clone()).await;
@@ -480,17 +522,25 @@ async fn hx_settings_diagnostics(
     }
 
     let git_commit = env!("GIT_COMMIT_HASH").to_owned();
+    let git_branch = env!("GIT_BRANCH").to_owned();
     let version = env!("CARGO_PKG_VERSION").to_owned();
     let os_distro = get_os_distro();
     let os_kernel = get_kernel_version();
     let os_arch = std::env::consts::ARCH.to_owned();
+    let scylla_version = get_scylla_version(&db).await;
+    let meilisearch_version = get_meilisearch_version(&meili).await;
+    let redis_version = get_redis_version(redis).await;
 
     let template = HXSettingsDiagnosticsTemplate {
         git_commit,
+        git_branch,
         version,
         os_distro,
         os_kernel,
         os_arch,
+        scylla_version,
+        meilisearch_version,
+        redis_version,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/templates/pages/hx-settings-diagnostics.html
+++ b/templates/pages/hx-settings-diagnostics.html
@@ -1,4 +1,5 @@
 <div class="col-12 col-md-8 col-lg-6">
+    <h5 class="mb-3">Build Info</h5>
     <table class="table table-hover table-bordered text-white">
         <tbody>
             <tr>
@@ -10,6 +11,16 @@
                 <td><code>{{ git_commit }}</code></td>
             </tr>
             <tr>
+                <td>Branch</td>
+                <td><code>{{ git_branch }}</code></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h5 class="mb-3 mt-4">Server</h5>
+    <table class="table table-hover table-bordered text-white">
+        <tbody>
+            <tr>
                 <td>OS Distro</td>
                 <td><code>{{ os_distro }}</code></td>
             </tr>
@@ -20,6 +31,24 @@
             <tr>
                 <td>Architecture</td>
                 <td><code>{{ os_arch }}</code></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h5 class="mb-3 mt-4">Services</h5>
+    <table class="table table-hover table-bordered text-white">
+        <tbody>
+            <tr>
+                <td>ScyllaDB / Cassandra</td>
+                <td><code>{{ scylla_version }}</code></td>
+            </tr>
+            <tr>
+                <td>Meilisearch</td>
+                <td><code>{{ meilisearch_version }}</code></td>
+            </tr>
+            <tr>
+                <td>Redis / DragonflyDB</td>
+                <td><code>{{ redis_version }}</code></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
Enhanced the diagnostics page to display version information for all major backend services (ScyllaDB, Meilisearch, and Redis) alongside existing build and system information. Also added git branch information to the build details.

## Key Changes
- **New version detection functions**: Added async functions to query version information from:
  - ScyllaDB via `system.local` table query
  - Meilisearch via client API
  - Redis via INFO server command
  
- **Build script enhancement**: Extended `build.rs` to capture the current git branch name at compile time using `git rev-parse --abbrev-ref HEAD`

- **Template restructuring**: Reorganized the diagnostics page into three logical sections:
  - Build Info (version, git commit, git branch)
  - Server (OS distro, kernel, architecture)
  - Services (ScyllaDB, Meilisearch, Redis versions)

- **Handler updates**: Modified `hx_settings_diagnostics` to:
  - Accept `MeilisearchClient` extension
  - Call new version detection functions
  - Pass all version data to template

## Implementation Details
- Version detection functions gracefully handle failures by returning "unknown" as fallback
- Redis version parsing extracts the version from the INFO server output by searching for the `redis_version:` line
- All service version queries are async and awaited before template rendering
- Git branch defaults to "unknown" if git command fails or returns empty string

https://claude.ai/code/session_017yc4hmBiuPAjYDJ6Q4dFeo