### PR TITLE
Fix type mismatch in media owner query parameter

### DIFF
--- a/src/reccomendations.rs
+++ b/src/reccomendations.rs
@@ -17,7 +17,7 @@ async fn hx_recommended(
 
     let media: Vec<Medium> = if let Some(ref owner) = owner {
         db.session
-            .execute_unpaged(&db.get_media_by_owner, (owner, 21i64))
+            .execute_unpaged(&db.get_media_by_owner, (owner, 21i32))
             .await
             .ok()
             .and_then(|r| r.into_rows_result().ok())


### PR DESCRIPTION
## Summary
Fixed a type mismatch in the database query for fetching media by owner. The limit parameter was changed from `i64` to `i32` to match the expected parameter type.

## Changes
- Changed the limit parameter type from `21i64` to `21i32` in the `get_media_by_owner` database query call

## Details
The `execute_unpaged` method expects an `i32` for the limit parameter, but the code was passing an `i64` literal. This change ensures type consistency and prevents potential type conversion issues at runtime.

https://claude.ai/code/session_01Uzz5swf2HPCQ5bimizw2oJ