### PR TITLE
Support Git metadata injection in Docker builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: panmourovaty/rustvideoplatform:dev
+          build-args: |
+            GIT_COMMIT_HASH=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
 
   build-primary:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
@@ -59,6 +62,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            GIT_COMMIT_HASH=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
 
       - name: Export digest
         run: |
@@ -109,6 +115,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=panmourovaty/rustvideoplatform,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            GIT_COMMIT_HASH=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
 
       - name: Export digest
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM alpine:edge AS builder
 RUN apk add --no-cache cargo musl-dev pkgconfig nodejs npm woff2 openssl-dev perl make build-base
 
 ARG TARGETARCH
+ARG GIT_COMMIT_HASH=unknown
+ARG GIT_BRANCH=unknown
+ENV GIT_COMMIT_HASH=$GIT_COMMIT_HASH
+ENV GIT_BRANCH=$GIT_BRANCH
 
 # Pre-build dependencies (cached layer - only invalidated when Cargo.toml changes)
 COPY Cargo.toml /src/rustvideoplatform/

--- a/build.rs
+++ b/build.rs
@@ -18,38 +18,48 @@ fn command_exists(program: &str) -> bool {
 
 fn main() {
     // --- Git commit hash ---
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output();
-
-    let git_hash = match output {
-        Ok(o) if o.status.success() => {
-            let hash = String::from_utf8(o.stdout)
-                .unwrap_or_default()
-                .trim()
-                .to_owned();
-            if hash.is_empty() { "unknown".to_owned() } else { hash }
-        }
-        _ => "unknown".to_owned(),
-    };
+    // Prefer value injected via Docker build-arg / environment variable (set during CI builds
+    // where git is not available inside the container).
+    let git_hash = std::env::var("GIT_COMMIT_HASH")
+        .ok()
+        .filter(|v| !v.is_empty() && v != "unknown")
+        .unwrap_or_else(|| {
+            let output = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output();
+            match output {
+                Ok(o) if o.status.success() => {
+                    let hash = String::from_utf8(o.stdout)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_owned();
+                    if hash.is_empty() { "unknown".to_owned() } else { hash }
+                }
+                _ => "unknown".to_owned(),
+            }
+        });
 
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
 
     // --- Git branch ---
-    let branch_output = Command::new("git")
-        .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output();
-
-    let git_branch = match branch_output {
-        Ok(o) if o.status.success() => {
-            let branch = String::from_utf8(o.stdout)
-                .unwrap_or_default()
-                .trim()
-                .to_owned();
-            if branch.is_empty() { "unknown".to_owned() } else { branch }
-        }
-        _ => "unknown".to_owned(),
-    };
+    let git_branch = std::env::var("GIT_BRANCH")
+        .ok()
+        .filter(|v| !v.is_empty() && v != "unknown")
+        .unwrap_or_else(|| {
+            let branch_output = Command::new("git")
+                .args(["rev-parse", "--abbrev-ref", "HEAD"])
+                .output();
+            match branch_output {
+                Ok(o) if o.status.success() => {
+                    let branch = String::from_utf8(o.stdout)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_owned();
+                    if branch.is_empty() { "unknown".to_owned() } else { branch }
+                }
+                _ => "unknown".to_owned(),
+            }
+        });
 
     println!("cargo:rustc-env=GIT_BRANCH={}", git_branch);
     println!("cargo:rerun-if-changed=.git/HEAD");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -462,7 +462,7 @@ fn get_kernel_version() -> String {
 
 async fn get_scylla_version(db: &ScyllaDb) -> String {
     db.session
-        .query_unpaged("SELECT release_version FROM system.local", ())
+        .query_unpaged("SHOW VERSION", ())
         .await
         .ok()
         .and_then(|r| r.into_rows_result().ok())

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -461,8 +461,18 @@ fn get_kernel_version() -> String {
 }
 
 async fn get_scylla_version(db: &ScyllaDb) -> String {
-    db.session
+    if let Some(v) = db.session
         .query_unpaged("SHOW VERSION", ())
+        .await
+        .ok()
+        .and_then(|r| r.into_rows_result().ok())
+        .and_then(|rows| rows.maybe_first_row::<(String,)>().ok().flatten())
+        .map(|(v,)| v)
+    {
+        return v;
+    }
+    db.session
+        .query_unpaged("SELECT release_version FROM system.local", ())
         .await
         .ok()
         .and_then(|r| r.into_rows_result().ok())


### PR DESCRIPTION
## Summary
This PR enables Git commit hash and branch information to be injected during Docker builds via environment variables, allowing proper version metadata in containerized environments where Git is not available.

## Key Changes
- **build.rs**: Modified Git metadata collection to prefer environment variables (`GIT_COMMIT_HASH` and `GIT_BRANCH`) over shell commands, with fallback to git commands for local builds
- **Dockerfile**: Added build arguments and environment variables to pass Git metadata into the build process
- **.github/workflows/docker-image.yml**: Updated all Docker build steps to inject `GIT_COMMIT_HASH` and `GIT_BRANCH` from GitHub Actions context (`github.sha` and `github.ref_name`)
- **src/settings.rs**: Added fallback to `SHOW VERSION` command before querying `system.local` table for Scylla version detection

## Implementation Details
- The build script now checks for environment variables first before executing git commands, enabling CI/CD pipelines to provide metadata without requiring git inside containers
- The Docker build arguments are set to sensible defaults (`unknown`) if not provided
- The Scylla version detection now attempts a more direct query first, improving compatibility with different Scylla versions

https://claude.ai/code/session_01DwUv6jdhhG64kHD6sgYKs5