### PR TITLE
Reduce HTMX lazy-load flicker with fade-in transitions

### DIFF
--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -75,7 +75,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (t && t.classList && (
             t.classList.contains('hx-placeholder') ||
             t.classList.contains('sidebar-hx-placeholder') ||
-            t.classList.contains('subscribe-placeholder')
+            t.classList.contains('subscribe-placeholder') ||
+            t.classList.contains('usernav-placeholder')
         )) {
             t.style.opacity = '0';
         }

--- a/assets/static/script.js
+++ b/assets/static/script.js
@@ -69,6 +69,25 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // Fade-in lazy-loaded HTMX content to reduce flicker
+    document.body.addEventListener('htmx:beforeSwap', (event) => {
+        const t = event.detail.target;
+        if (t && t.classList && (
+            t.classList.contains('hx-placeholder') ||
+            t.classList.contains('sidebar-hx-placeholder') ||
+            t.classList.contains('subscribe-placeholder')
+        )) {
+            t.style.opacity = '0';
+        }
+    });
+
+    document.body.addEventListener('htmx:afterSettle', (event) => {
+        const t = event.detail.target;
+        if (t && t.style && t.style.opacity === '0') {
+            requestAnimationFrame(() => { t.style.opacity = '1'; });
+        }
+    });
+
     fitMediumTitle();
 });
 

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -15772,12 +15772,18 @@ body.sidebar-collapsed .sidebarbackground {
     min-width: 110px;
 }
 
+/* User nav placeholder in navbar */
+.usernav-placeholder {
+    min-height: 40px;
+}
+
 /* ── Lazy-load fade-in ── */
 
 /* Smooth fade-in when HTMX swaps content into lazy-load placeholders */
 .hx-placeholder,
 .sidebar-hx-placeholder,
-.subscribe-placeholder {
+.subscribe-placeholder,
+.usernav-placeholder {
     transition: opacity 0.2s ease-in;
 }
 

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -15772,6 +15772,25 @@ body.sidebar-collapsed .sidebarbackground {
     min-width: 110px;
 }
 
+/* ── Lazy-load fade-in ── */
+
+/* Smooth fade-in when HTMX swaps content into lazy-load placeholders */
+.hx-placeholder,
+.sidebar-hx-placeholder,
+.subscribe-placeholder {
+    transition: opacity 0.2s ease-in;
+}
+
+/* Fade-in for outerHTML swaps (e.g. sidebar items replacing placeholder) */
+@keyframes hxOuterFadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.hx-outer-fade-in {
+    animation: hxOuterFadeIn 0.2s ease;
+}
+
 /* Channel profile image container — prevent shift before image loads */
 .channel-picture-container {
     height: 20vh;

--- a/templates/pages/component-navbar.html
+++ b/templates/pages/component-navbar.html
@@ -28,7 +28,7 @@
             </ul>
         </form>
         <div class="my-1 text-white d-flex align-items-center gap-5">
-            <div hx-get="/hx/usernav" hx-trigger="load" style="width:120px;height:40px;" class="mx-3" preload="always">
+            <div hx-get="/hx/usernav" hx-trigger="load" style="width:120px;height:40px;" class="mx-3 usernav-placeholder" preload="always">
                 <a href="/login" preload="mouseover" style="visibility:hidden;"><button class="btn text-white"><i class="fa-solid fa-user mx-2" aria-hidden="true"></i>Log in</button></a>
             </div>
             <button class="btn btn-primary ms-3" onclick="toggleSidebar()" aria-label="Toggle sidebar" aria-expanded="true" aria-controls="sidebar"><i class="fa-solid fa-bars fa-xl" aria-hidden="true"></i></button>

--- a/templates/pages/hx-sidebar.html
+++ b/templates/pages/hx-sidebar.html
@@ -1,11 +1,11 @@
-<li class="nav-item">
+<li class="nav-item hx-outer-fade-in">
     <a href="/subscriptions" class="nav-link {% if active_item == "subscribed" %}active{% endif %} text-white
         text-decoration-none my-2 fs-6 mx-3 bg-hover" preload="mouseover">
         <i class="fa-solid fa-bell"></i>
         Subscribed
     </a>
 </li>
-<li class="nav-item">
+<li class="nav-item hx-outer-fade-in">
     <a href="/studio" class="nav-link {% if active_item == "studio" %}active{% endif %} text-white
         text-decoration-none my-2 fs-6 mx-3 bg-hover" preload="mouseover">
         <i class="fa-solid fa-photo-film"></i>


### PR DESCRIPTION
## Summary

- Add smooth 0.2s opacity fade-in for content loaded via `hx-trigger="load"` placeholders (`.hx-placeholder`, `.sidebar-hx-placeholder`, `.subscribe-placeholder`), replacing the instant pop-in that caused visual flicker
- Use `htmx:beforeSwap` to set opacity to 0 on the target, then `htmx:afterSettle` with a CSS transition to smoothly reveal the swapped-in content (handles innerHTML swaps)
- Add a CSS animation class (`hx-outer-fade-in`) for outerHTML swap cases like the sidebar nav items

## Test plan

- [ ] Navigate between pages (home, trending, channel, settings, studio) and verify lazy-loaded content fades in smoothly instead of popping in
- [ ] Check sidebar items fade in on page load
- [ ] Verify search suggestions still appear/disappear instantly (not affected by the fade-in)
- [ ] Verify infinite scroll items still use their existing `infScrollFadeIn` animation
- [ ] Test like/dislike button clicks respond instantly (outerHTML swap on click should not be delayed)
- [ ] Test on mobile viewport sizes

https://claude.ai/code/session_01ATNH7XyfemWz5yg53bXqBE