### PR TITLE
Split llama.cpp services into separate translation and embedding containers

### DIFF
--- a/example-deployment/config.json
+++ b/example-deployment/config.json
@@ -30,13 +30,13 @@
 
     "translation": {
         "languages": ["en", "cs"],
-        "llama_url": "http://llamacpp:8083",
+        "llama_url": "http://translatellama:8083",
         "source_language": "en",
         "timeout_secs": 500
     },
 
     "embedding": {
-        "url": "http://llamacpp:8083/v1/embeddings",
+        "url": "http://embedllama:8084/v1/embeddings",
         "model": "YOUR_QWEN3_EMBEDDING_MODEL",
         "timeout_secs": 30
     },

--- a/example-deployment/docker-compose.yml
+++ b/example-deployment/docker-compose.yml
@@ -31,7 +31,7 @@ services:
    depends_on:
      - scylladb
      - whisper
-     - llamacpp
+     - translatellama
  indexer:
    image: panmourovaty/rustvideoplatform-indexer
    volumes:
@@ -76,14 +76,26 @@ services:
      - /dev/dri:/dev/dri
    stdin_open: true
    tty: true
- llamacpp:
+ translatellama:
    image: ghcr.io/ggml-org/llama.cpp:server-vulkan
-   container_name: llamacpp
+   container_name: translatellama
    volumes:
      - ./models:/models
-   command: ["--host", "0.0.0.0", "--port", "8083", "-m", "/models/YOUR_TRANSLATION_MODEL", "--alias", "translation", "-m", "/models/YOUR_QWEN3_EMBEDDING_MODEL", "--alias", "embedding", "--embedding", "--pooling", "cls", "--no-webui"]
+   command: ["--host", "0.0.0.0", "--port", "8083", "-m", "/models/YOUR_TRANSLATION_MODEL", "--alias", "translation", "--no-webui"]
    ports:
      - "8083:8083"
+   devices:
+     - /dev/dri:/dev/dri
+   stdin_open: true
+   tty: true
+ embedllama:
+   image: ghcr.io/ggml-org/llama.cpp:server-vulkan
+   container_name: embedllama
+   volumes:
+     - ./models:/models
+   command: ["--host", "0.0.0.0", "--port", "8084", "-m", "/models/YOUR_QWEN3_EMBEDDING_MODEL", "--alias", "embedding", "--embedding", "--pooling", "cls", "--no-webui"]
+   ports:
+     - "8084:8084"
    devices:
      - /dev/dri:/dev/dri
    stdin_open: true


### PR DESCRIPTION
## Summary
Refactored the llama.cpp service architecture to separate translation and embedding workloads into two independent containers, improving modularity and allowing independent scaling of each service.

## Key Changes
- Renamed `llamacpp` service to `translatellama` running on port 8083
  - Removed embedding model and embedding-related flags from the translation service
  - Simplified command to focus solely on translation tasks
- Created new `embedllama` service running on port 8084
  - Dedicated container for embedding operations using Qwen3 embedding model
  - Includes embedding-specific flags (`--embedding`, `--pooling cls`)
- Updated service dependencies in the main application to reference `translatellama`
- Updated configuration URLs:
  - Translation service now points to `http://translatellama:8083`
  - Embedding service now points to `http://embedllama:8084/v1/embeddings`

## Implementation Details
- Both services use the same base image (`ghcr.io/ggml-org/llama.cpp:server-vulkan`)
- Both services maintain GPU access via `/dev/dri` device mapping
- Shared model volume allows both containers to access the same model files
- Clear separation of concerns enables independent configuration and resource allocation for each workload

https://claude.ai/code/session_01KWTsSEsrHeictieq8byGpj