### PR TITLE
Add view history feature with database schema and API routes

### DIFF
--- a/database_schema.cql
+++ b/database_schema.cql
@@ -221,6 +221,17 @@ CREATE TABLE IF NOT EXISTS user_groups_by_member (
 );
 
 -- ══════════════════════════════════════════════════════════════════════
+-- VIEW HISTORY (per-user watch history)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS view_history (
+    user_login text,
+    viewed_at  bigint,
+    media_id   text,
+    PRIMARY KEY (user_login, viewed_at, media_id)
+) WITH CLUSTERING ORDER BY (viewed_at DESC, media_id ASC);
+
+-- ══════════════════════════════════════════════════════════════════════
 -- WEBAUTHN CREDENTIALS
 -- ══════════════════════════════════════════════════════════════════════
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -121,6 +121,10 @@ pub struct ScyllaDb {
     pub update_webauthn_passkey: PreparedStatement,
     pub get_webauthn_cred_by_id: PreparedStatement,
 
+    // --- View History ---
+    pub insert_view_history: PreparedStatement,
+    pub get_view_history: PreparedStatement,
+
     // --- Batch update helpers for groups ---
     pub get_media_by_group: PreparedStatement,
     pub get_lists_by_group: PreparedStatement,
@@ -248,6 +252,10 @@ impl ScyllaDb {
             delete_webauthn_cred_by_user: session.prepare("DELETE FROM webauthn_credentials_by_user WHERE user_login = ? AND created = ? AND id = ?").await?,
             update_webauthn_passkey: session.prepare("UPDATE webauthn_credentials SET passkey = ? WHERE id = ?").await?,
             get_webauthn_cred_by_id: session.prepare("SELECT id, user_login, credential_name, passkey, created FROM webauthn_credentials WHERE id = ?").await?,
+
+            // --- View History ---
+            insert_view_history: session.prepare("INSERT INTO view_history (user_login, viewed_at, media_id) VALUES (?, ?, ?)").await?,
+            get_view_history: session.prepare("SELECT media_id, viewed_at FROM view_history WHERE user_login = ? LIMIT ?").await?,
 
             // --- Batch update helpers for groups ---
             get_media_by_group: session.prepare("SELECT id, owner, upload FROM media WHERE restricted_to_group = ? ALLOW FILTERING").await?,

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,135 @@
+#[derive(Template)]
+#[template(path = "pages/history.html", escape = "none")]
+struct HistoryTemplate {
+    sidebar: String,
+    config: Config,
+    common_headers: CommonHeaders,
+}
+
+async fn history(
+    Extension(config): Extension<Config>,
+    headers: HeaderMap,
+) -> axum::response::Html<Vec<u8>> {
+    let sidebar = generate_sidebar(&config, "history".to_owned());
+    let common_headers = extract_common_headers(&headers);
+    let template = HistoryTemplate {
+        sidebar,
+        config,
+        common_headers,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}
+
+struct HistoryItem {
+    id: String,
+    name: String,
+    owner: String,
+    owner_name: String,
+    media_type: String,
+    viewed_at: String,
+}
+
+#[derive(Template)]
+#[template(path = "pages/hx-history-items.html", escape = "none")]
+struct HXHistoryItemsTemplate {
+    items: Vec<HistoryItem>,
+    config: Config,
+    page: i64,
+    has_more: bool,
+    next_url: String,
+}
+
+async fn hx_history(
+    Extension(config): Extension<Config>,
+    headers: HeaderMap,
+    Extension(db): Extension<ScyllaDb>,
+    Extension(redis): Extension<RedisConn>,
+) -> axum::response::Html<Vec<u8>> {
+    hx_history_inner(config, headers, db, redis, 0).await
+}
+
+async fn hx_history_page(
+    Extension(config): Extension<Config>,
+    headers: HeaderMap,
+    Extension(db): Extension<ScyllaDb>,
+    Extension(redis): Extension<RedisConn>,
+    Path(page): Path<i64>,
+) -> axum::response::Html<Vec<u8>> {
+    hx_history_inner(config, headers, db, redis, page).await
+}
+
+async fn hx_history_inner(
+    config: Config,
+    headers: HeaderMap,
+    db: ScyllaDb,
+    redis: RedisConn,
+    page: i64,
+) -> axum::response::Html<Vec<u8>> {
+    let user = match get_user_login(headers, &db, redis.clone()).await {
+        Some(user) => user,
+        None => {
+            return Html(
+                "Please log in to see your history"
+                    .as_bytes()
+                    .to_vec(),
+            )
+        }
+    };
+
+    let per_page: i64 = 30;
+    // Fetch enough rows to cover offset + page + 1 (to detect has_more)
+    let fetch_limit = ((page + 1) * per_page + 1) as i32;
+    let offset = (page * per_page) as usize;
+
+    let history_rows: Vec<(String, i64)> = db.session.execute_unpaged(&db.get_view_history, (&user.login, &fetch_limit))
+        .await
+        .ok()
+        .and_then(|r| r.into_rows_result().ok())
+        .map(|rows| rows.rows::<(String, i64)>().unwrap().filter_map(|r| r.ok()).collect())
+        .unwrap_or_default();
+
+    // Skip to the right page offset
+    let page_rows: Vec<(String, i64)> = history_rows.into_iter().skip(offset).take(per_page as usize + 1).collect();
+    let has_more = page_rows.len() > per_page as usize;
+
+    // Fetch media details for each history entry
+    let mut items: Vec<HistoryItem> = Vec::new();
+    for (media_id, viewed_at) in page_rows.iter().take(per_page as usize) {
+        let media_row = db.session.execute_unpaged(&db.get_media_basic, (media_id,))
+            .await
+            .ok()
+            .and_then(|r| r.into_rows_result().ok())
+            .and_then(|rows| rows.maybe_first_row::<(String, String, String, String, Option<String>, String)>().ok().flatten());
+
+        if let Some((id, name, owner, _visibility, _restricted_to_group, media_type)) = media_row {
+            // Get owner display name
+            let owner_name = db.session.execute_unpaged(&db.get_user_by_login, (&owner,))
+                .await
+                .ok()
+                .and_then(|r| r.into_rows_result().ok())
+                .and_then(|rows| rows.maybe_first_row::<(Option<String>, Option<String>)>().ok().flatten())
+                .and_then(|r| r.0)
+                .unwrap_or_else(|| owner.clone());
+
+            items.push(HistoryItem {
+                id,
+                name,
+                owner: owner.clone(),
+                owner_name,
+                media_type,
+                viewed_at: prettyunixtime(*viewed_at).await,
+            });
+        }
+    }
+
+    let next_url = format!("/hx/history/{}", page + 1);
+
+    let template = HXHistoryItemsTemplate {
+        items,
+        config,
+        page,
+        has_more,
+        next_url,
+    };
+    Html(minifi_html(template.render().unwrap()))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,9 @@ async fn main() {
         .route("/subscriptions", get(subscriptions))
         .route("/hx/subscriptions", get(hx_subscriptions))
         .route("/hx/subscriptions/{page}", get(hx_subscriptions_page))
+        .route("/history", get(history))
+        .route("/hx/history", get(hx_history))
+        .route("/hx/history/{page}", get(hx_history_page))
         .route("/m/{mediumid}", get(medium))
         .route("/m/{mediumid}/previews.vtt", get(medium_previews_prepare))
         .route(
@@ -610,3 +613,4 @@ include!("groups.rs");
 include!("settings.rs");
 include!("two_factor.rs");
 include!("sitemap.rs");
+include!("history.rs");

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,9 +1,25 @@
 async fn hx_new_view(
     Extension(db): Extension<ScyllaDb>,
+    Extension(mut redis): Extension<RedisConn>,
+    headers: HeaderMap,
     Path(mediumid): Path<String>,
 ) -> axum::response::Html<String> {
     // Increment counter in ScyllaDB
     let _ = db.session.execute_unpaged(&db.increment_view_count, (&mediumid,)).await;
+
+    // Record per-user view history (deduplicated with 1-hour Redis key)
+    if let Some(user) = get_user_login(headers, &db, redis.clone()).await {
+        let dedup_key = format!("viewhist:{}:{}", user.login, mediumid);
+        let already: bool = redis.exists(&dedup_key).await.unwrap_or(false);
+        if !already {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+            let _ = db.session.execute_unpaged(&db.insert_view_history, (&user.login, &now, &mediumid)).await;
+            let _: Result<(), _> = redis.set_ex(&dedup_key, 1i32, 3600).await;
+        }
+    }
 
     // Also update the main media table views (read counter, update main)
     let views: i64 = db.session.execute_unpaged(&db.get_view_count, (&mediumid,))

--- a/templates/pages/history.html
+++ b/templates/pages/history.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="{{ config.locale }}">
+    <head>
+        {% include "component-dependencies.html" %}
+
+        <title>History - {{ config.instancename }}</title>
+
+        <meta name="description" content="{{ config.description }}" />
+        <meta
+            property="og:title"
+            content="{{ config.instancename }} History"
+        />
+        <meta property="og:type" content="website" />
+        <meta
+            property="og:url"
+            content="{{ config.site_url }}/history"
+        />
+        <meta property="og:locale" content="{{ config.locale }}" />
+        <meta property="og:description" content="{{ config.description }}" />
+        <meta property="og:image" content="{{ config.source_server_url }}/source/favicon.svg" />
+        <meta property="og:site_name" content="{{ config.instancename }}" />
+    </head>
+
+    <body hx-ext="preload">
+        {% set page_title = "History" %}
+        {{ sidebar }} {% include "component-navbar.html" %}
+        <div class="row maincontentrow g-3 py-2 ps-2 w-100" role="main">
+            <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+                <div
+                    class="card py-3 px-3 text-white"
+                    style="min-height: 100vh"
+                >
+                    <div
+                        hx-get="/hx/history"
+                        hx-trigger="load"
+                        class="row mb-3 hx-placeholder"
+                        preload="always"
+                    ></div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/templates/pages/hx-history-items.html
+++ b/templates/pages/hx-history-items.html
@@ -1,0 +1,58 @@
+{% for item in items %}
+<div class="d-flex align-items-start gap-3 py-2 {% if !loop.first %}border-top border-secondary{% endif %} inf-scroll-reveal">
+    <a
+        href="/m/{{ item.id }}"
+        class="flex-shrink-0"
+        preload="mouseover"
+    >
+        <div class="thumbnail-container rounded" style="width:176px;height:99px;">
+            <img
+                src="{{ config.source_server_url }}/source/{{ item.id }}/thumbnail-sm.avif"
+                width="176"
+                height="99"
+                class="rounded"
+                alt="thumb-{{ item.id }}"
+                loading="lazy"
+            />
+            <div class="search-card-type-badge">
+                {% if item.media_type == "video" %}
+                <i class="fa-solid fa-video"></i>
+                {% else if item.media_type == "audio" %}
+                <i class="fa-solid fa-music"></i>
+                {% else if item.media_type == "picture" %}
+                <i class="fa-solid fa-image"></i>
+                {% else if item.media_type == "document_pdf" %}
+                <i class="fa-solid fa-file-pdf"></i>
+                {% else %}
+                <i class="fa-solid fa-file"></i>
+                {% endif %}
+            </div>
+        </div>
+    </a>
+    <div class="d-flex flex-column justify-content-center min-w-0">
+        <a href="/m/{{ item.id }}" class="text-white text-decoration-none" preload="mouseover">
+            <b class="d-block text-truncate">{{ item.name }}</b>
+        </a>
+        <a href="/u/{{ item.owner }}" class="text-secondary text-decoration-none small" preload="mouseover">
+            {{ item.owner_name }}
+        </a>
+        <span class="text-secondary small">
+            <i class="fa-solid fa-clock-rotate-left me-1"></i>{{ item.viewed_at }}
+        </span>
+    </div>
+</div>
+{% if loop.index == 15 && has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-hist-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
+{% endif %}
+{% endfor %}
+{% if has_more %}
+<div id="inf-scroll-hist-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
+{% else %}
+<div class="col-12 text-center my-4">
+    {% if items.is_empty() && page == 0 %}
+    <p class="text-secondary">No history yet. Start watching to see your history here.</p>
+    {% else %}
+    <p class="text-secondary"><i class="fa-solid fa-circle-check me-2"></i>You have reached the end.</p>
+    {% endif %}
+</div>
+{% endif %}

--- a/templates/pages/hx-sidebar.html
+++ b/templates/pages/hx-sidebar.html
@@ -6,6 +6,13 @@
     </a>
 </li>
 <li class="nav-item hx-outer-fade-in">
+    <a href="/history" class="nav-link {% if active_item == "history" %}active{% endif %} text-white
+        text-decoration-none my-2 fs-6 mx-3 bg-hover" preload="mouseover">
+        <i class="fa-solid fa-clock-rotate-left"></i>
+        History
+    </a>
+</li>
+<li class="nav-item hx-outer-fade-in">
     <a href="/studio" class="nav-link {% if active_item == "studio" %}active{% endif %} text-white
         text-decoration-none my-2 fs-6 mx-3 bg-hover" preload="mouseover">
         <i class="fa-solid fa-photo-film"></i>


### PR DESCRIPTION
- Introduced a new table `view_history` in the database schema to track user view history.
- Added prepared statements for inserting and retrieving view history in the database.
- Implemented API routes for accessing view history.
- Updated the sidebar template to include a link to the history page.