### PR TITLE
Allow Meilisearch to reach embedder on Docker network

### DIFF
--- a/example-deployment/config.json
+++ b/example-deployment/config.json
@@ -8,7 +8,13 @@
     "custom_session_domain": ".vids.cz",
     "meilisearch_url": "http://meilisearch:7700",
     "meilisearch_key": "SECRET_PASSWORD_HERE",
+    "meilisearch_embedder": {
+        "name": "default"
+    },
+    "site_url": "https://vids.cz",
     "source_server_url": "https://source.vids.cz",
+    "description": "An experimental open-source multimedia sharing platform.",
+    "locale": "en",
 
     "tls_cert": null,
     "tls_key": null,

--- a/example-deployment/docker-compose.yml
+++ b/example-deployment/docker-compose.yml
@@ -65,6 +65,7 @@ services:
      - MEILI_ENV=production
      - MEILI_LOG_LEVEL
      - MEILI_DB_PATH=/data.ms
+     - MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS=any
  whisper:
    image: ghcr.io/ggml-org/whisper.cpp:main-vulkan
    container_name: whisper

--- a/example-deployment/docker-compose.yml
+++ b/example-deployment/docker-compose.yml
@@ -65,6 +65,7 @@ services:
      - MEILI_ENV=production
      - MEILI_LOG_LEVEL
      - MEILI_DB_PATH=/data.ms
+     # Required for Meilisearch >=1.34.1: allows REST embedder to reach Docker-internal services
      - MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS=any
  whisper:
    image: ghcr.io/ggml-org/whisper.cpp:main-vulkan
@@ -89,6 +90,8 @@ services:
      - /dev/dri:/dev/dri
    stdin_open: true
    tty: true
+ # Option A: llama.cpp embedding server (OpenAI-compatible API on port 8084)
+ # Use with indexer config: source=rest, url=http://embedllama:8084/v1/embeddings
  embedllama:
    image: ghcr.io/ggml-org/llama.cpp:server-vulkan
    container_name: embedllama
@@ -101,3 +104,17 @@ services:
      - /dev/dri:/dev/dri
    stdin_open: true
    tty: true
+ # Option B: Ollama (uncomment below and comment out Option A)
+ # Use with indexer config: source=ollama, url=http://embedllama:11434, model=YOUR_MODEL
+ # embedllama:
+ #   image: ollama/ollama
+ #   container_name: embedllama
+ #   environment:
+ #     - OLLAMA_VULKAN=1
+ #   ports:
+ #     - "11434:11434"
+ #   volumes:
+ #     - ./ollama_data:/root/.ollama
+ #   devices:
+ #     - /dev/dri:/dev/dri
+ #   restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS=any` to Meilisearch in docker-compose
- This disables SSRF protection that blocks requests to private/Docker network IPs

## Root cause
Meilisearch has built-in SSRF protection that rejects HTTP requests to private network IPs. Docker container hostnames resolve to private IPs (172.x.x.x), causing "bad uri: Rejected URI" when Meilisearch tries to call the embedllama service for generating embeddings.

## Test plan
- [ ] Verify Meilisearch can reach embedllama after restart
- [ ] Verify "Rejected URI" error no longer appears

https://claude.ai/code/session_01AD5uLYYWaJbvjjVAwxcTps