### PR TITLE
Refactor history handling to use Medium struct  

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -20,19 +20,11 @@ async fn history(
     Html(minifi_html(template.render().unwrap()))
 }
 
-struct HistoryItem {
-    id: String,
-    name: String,
-    owner: String,
-    owner_name: String,
-    media_type: String,
-    viewed_at: String,
-}
-
 #[derive(Template)]
 #[template(path = "pages/hx-history-items.html", escape = "none")]
 struct HXHistoryItemsTemplate {
-    items: Vec<HistoryItem>,
+    media: Vec<Medium>,
+    current_medium_id: String,
     config: Config,
     page: i64,
     has_more: bool,
@@ -93,8 +85,8 @@ async fn hx_history_inner(
     let has_more = page_rows.len() > per_page as usize;
 
     // Fetch media details for each history entry
-    let mut items: Vec<HistoryItem> = Vec::new();
-    for (media_id, viewed_at) in page_rows.iter().take(per_page as usize) {
+    let mut media: Vec<Medium> = Vec::new();
+    for (media_id, _viewed_at) in page_rows.iter().take(per_page as usize) {
         let media_row = db.session.execute_unpaged(&db.get_media_basic, (media_id,))
             .await
             .ok()
@@ -102,22 +94,24 @@ async fn hx_history_inner(
             .and_then(|rows| rows.maybe_first_row::<(String, String, String, String, Option<String>, String)>().ok().flatten());
 
         if let Some((id, name, owner, _visibility, _restricted_to_group, media_type)) = media_row {
-            // Get owner display name
-            let owner_name = db.session.execute_unpaged(&db.get_user_by_login, (&owner,))
-                .await
-                .ok()
-                .and_then(|r| r.into_rows_result().ok())
-                .and_then(|rows| rows.maybe_first_row::<(Option<String>, Option<String>)>().ok().flatten())
-                .and_then(|r| r.0)
-                .unwrap_or_else(|| owner.clone());
+            // Get view count
+            let views: i64 = db.session.execute_unpaged(&db.get_view_count, (&id,))
+                .await.ok().and_then(|r| r.into_rows_result().ok())
+                .and_then(|rows| rows.maybe_first_row::<(scylla::value::CqlValue,)>().ok().flatten())
+                .map(|r| match r.0 {
+                    scylla::value::CqlValue::Counter(c) => c.0,
+                    _ => 0,
+                }).unwrap_or(0);
 
-            items.push(HistoryItem {
+            media.push(Medium {
                 id,
                 name,
-                owner: owner.clone(),
-                owner_name,
-                media_type,
-                viewed_at: prettyunixtime(*viewed_at).await,
+                owner,
+                views,
+                r#type: media_type,
+                sprite_filename: None,
+                sprite_x: 0,
+                sprite_y: 0,
             });
         }
     }
@@ -125,7 +119,8 @@ async fn hx_history_inner(
     let next_url = format!("/hx/history/{}", page + 1);
 
     let template = HXHistoryItemsTemplate {
-        items,
+        media,
+        current_medium_id: String::new(),
         config,
         page,
         has_more,

--- a/templates/pages/hx-history-items.html
+++ b/templates/pages/hx-history-items.html
@@ -1,55 +1,10 @@
-{% for item in items %}
-<div class="d-flex align-items-start gap-3 py-2 {% if !loop.first %}border-top border-secondary{% endif %} inf-scroll-reveal">
-    <a
-        href="/m/{{ item.id }}"
-        class="flex-shrink-0"
-        preload="mouseover"
-    >
-        <div class="thumbnail-container rounded" style="width:176px;height:99px;">
-            <img
-                src="{{ config.source_server_url }}/source/{{ item.id }}/thumbnail-sm.avif"
-                width="176"
-                height="99"
-                class="rounded"
-                alt="thumb-{{ item.id }}"
-                loading="lazy"
-            />
-            <div class="search-card-type-badge">
-                {% if item.media_type == "video" %}
-                <i class="fa-solid fa-video"></i>
-                {% else if item.media_type == "audio" %}
-                <i class="fa-solid fa-music"></i>
-                {% else if item.media_type == "picture" %}
-                <i class="fa-solid fa-image"></i>
-                {% else if item.media_type == "document_pdf" %}
-                <i class="fa-solid fa-file-pdf"></i>
-                {% else %}
-                <i class="fa-solid fa-file"></i>
-                {% endif %}
-            </div>
-        </div>
-    </a>
-    <div class="d-flex flex-column justify-content-center min-w-0">
-        <a href="/m/{{ item.id }}" class="text-white text-decoration-none" preload="mouseover">
-            <b class="d-block text-truncate">{{ item.name }}</b>
-        </a>
-        <a href="/u/{{ item.owner }}" class="text-secondary text-decoration-none small" preload="mouseover">
-            {{ item.owner_name }}
-        </a>
-        <span class="text-secondary small">
-            <i class="fa-solid fa-clock-rotate-left me-1"></i>{{ item.viewed_at }}
-        </span>
-    </div>
-</div>
-{% if loop.index == 15 && has_more %}
-<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-hist-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
-{% endif %}
-{% endfor %}
+{% include "pages/hx-mediumlist.html" %}
 {% if has_more %}
+<div style="position:absolute;height:0;width:0;overflow:hidden;visibility:hidden;" hx-get="{{ next_url }}" hx-trigger="revealed" hx-target="#inf-scroll-hist-{{ page }}" hx-swap="outerHTML" hx-on::after-request="this.remove()"></div>
 <div id="inf-scroll-hist-{{ page }}" class="col-12 my-4 inf-scroll-placeholder"></div>
 {% else %}
 <div class="col-12 text-center my-4">
-    {% if items.is_empty() && page == 0 %}
+    {% if media.is_empty() && page == 0 %}
     <p class="text-secondary">No history yet. Start watching to see your history here.</p>
     {% else %}
     <p class="text-secondary"><i class="fa-solid fa-circle-check me-2"></i>You have reached the end.</p>


### PR DESCRIPTION
update template rendering

- Replaced HistoryItem struct with Medium struct to streamline media data handling.
- Updated hx_history_inner function to fetch media details and view counts.
- Modified HXHistoryItemsTemplate to use media instead of items, and included a new template for media list rendering.
- Adjusted HTML template to reflect changes in data structure and ensure proper display of media history.