### PR TITLE
Add visit time display to history view

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -123,6 +123,7 @@ async fn hx_usermedia_inner(
                 sprite_filename: None,
                 sprite_x: 0,
                 sprite_y: 0,
+                visit_time: None,
             });
         }
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -86,7 +86,7 @@ async fn hx_history_inner(
 
     // Fetch media details for each history entry
     let mut media: Vec<Medium> = Vec::new();
-    for (media_id, _viewed_at) in page_rows.iter().take(per_page as usize) {
+    for (media_id, viewed_at) in page_rows.iter().take(per_page as usize) {
         let media_row = db.session.execute_unpaged(&db.get_media_basic, (media_id,))
             .await
             .ok()
@@ -103,6 +103,9 @@ async fn hx_history_inner(
                     _ => 0,
                 }).unwrap_or(0);
 
+            let visit_time = DateTime::from_timestamp_millis(*viewed_at)
+                .map(|dt| dt.with_timezone(&Local).format("%Y-%m-%d %H:%M").to_string());
+
             media.push(Medium {
                 id,
                 name,
@@ -112,6 +115,7 @@ async fn hx_history_inner(
                 sprite_filename: None,
                 sprite_x: 0,
                 sprite_y: 0,
+                visit_time,
             });
         }
     }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -307,6 +307,7 @@ async fn hx_list_items_inner(
                 sprite_filename: None,
                 sprite_x: 0,
                 sprite_y: 0,
+                visit_time: None,
             });
         }
     }
@@ -353,6 +354,7 @@ async fn hx_list_sidebar(
                 sprite_filename: None,
                 sprite_x: 0,
                 sprite_y: 0,
+                visit_time: None,
             });
         }
     }

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -58,6 +58,7 @@ struct Medium {
     sprite_filename: Option<String>,
     sprite_x: i32,
     sprite_y: i32,
+    visit_time: Option<String>,
 }
 
 async fn medium(

--- a/src/search.rs
+++ b/src/search.rs
@@ -29,6 +29,7 @@ impl From<MeiliMedia> for Medium {
             sprite_filename: None,
             sprite_x: 0,
             sprite_y: 0,
+            visit_time: None,
         }
     }
 }

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -136,6 +136,7 @@ async fn hx_subscriptions_inner(
             sprite_filename: None,
             sprite_x: 0,
             sprite_y: 0,
+            visit_time: None,
         });
         taken += 1;
     }

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -87,6 +87,7 @@ async fn try_trending_from_cache(redis: &mut RedisConn, offset: i64) -> Option<V
             sprite_filename: if has_sprite { sprite_filename.clone() } else { None },
             sprite_x: info.get("sprite_x").and_then(|v| v.parse().ok()).unwrap_or(0),
             sprite_y: info.get("sprite_y").and_then(|v| v.parse().ok()).unwrap_or(0),
+            visit_time: None,
         });
     }
 

--- a/templates/pages/hx-mediumlist.html
+++ b/templates/pages/hx-mediumlist.html
@@ -66,7 +66,12 @@
                     >{{ item.name }}</b
                 >
                 <p class="text-secondary m-0">
-                    {{ item.owner }}<br />{{ item.views }} views
+                    {{ item.owner }}<br />
+                    {% if let Some(vt) = item.visit_time %}
+                    <i class="fa-solid fa-clock me-1"></i>{{ vt }}
+                    {% else %}
+                    <i class="fa-solid fa-eye me-1"></i>{{ item.views }} views
+                    {% endif %}
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
This PR adds the ability to display the last visit time for media items in the history view, replacing the generic view count display with a timestamp when available.

## Key Changes
- **New field**: Added `visit_time: Option<String>` to the `Medium` struct to store formatted visit timestamps
- **History view enhancement**: Modified `hx_history_inner()` to capture and format the `viewed_at` timestamp from history entries as "YYYY-MM-DD HH:MM" in the local timezone
- **Template update**: Updated the medium list template to conditionally display either:
  - A clock icon with the visit time (when available in history view)
  - An eye icon with view count (for other views)
- **Initialization**: Added `visit_time: None` initialization across all other `Medium` struct instantiations (lists, channels, search, subscriptions, trending) to maintain compatibility

## Implementation Details
- The visit time is only populated in the history view where `viewed_at` data is available
- Uses `DateTime::from_timestamp_millis()` to convert the timestamp and `Local` timezone for user-friendly display
- The template uses Rust's `if let Some()` pattern to gracefully handle cases where visit time is not available
- All other views continue to display the view count as before, with no functional changes

https://claude.ai/code/session_01URvg26HHqYucR6ApEmEL8H