### PR TITLE
Add Schema.org structured data to improve SEO

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -13,6 +13,7 @@ struct ChannelTemplate {
     config: Config,
     common_headers: CommonHeaders,
     user: UserChannel,
+    schema_org_json: String,
 }
 async fn channel(
     Extension(db): Extension<ScyllaDb>,
@@ -58,11 +59,38 @@ async fn channel(
 
     let sidebar = generate_sidebar(&config, "channel".to_owned());
     let common_headers = extract_common_headers(&headers);
+    let schema_org_json = {
+        let profile_url = format!("{}/u/{}", config.site_url, user.login);
+        let mut main_entity = serde_json::json!({
+            "@type": "Person",
+            "name": &user.name,
+            "identifier": &user.login,
+            "url": &profile_url,
+            "interactionStatistic": {
+                "@type": "InteractionCounter",
+                "interactionType": "https://schema.org/FollowAction",
+                "userInteractionCount": user.subscribed.unwrap_or(0)
+            }
+        });
+        if let Some(ref pic) = user.channel_picture {
+            main_entity["image"] = serde_json::Value::String(
+                format!("{}/source/{}/picture.avif", config.source_server_url, pic)
+            );
+        }
+        serde_json::to_string(&serde_json::json!({
+            "@context": "https://schema.org",
+            "@type": "ProfilePage",
+            "name": format!("{} - {}", user.name, config.instancename),
+            "url": &profile_url,
+            "mainEntity": main_entity
+        })).unwrap_or_default()
+    };
     let template = ChannelTemplate {
         sidebar,
         config,
         common_headers,
         user,
+        schema_org_json,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/home.rs
+++ b/src/home.rs
@@ -4,17 +4,34 @@ struct HomeTemplate {
     sidebar: String,
     config: Config,
     common_headers: CommonHeaders,
+    schema_org_json: String,
 }
 async fn home(
     Extension(config): Extension<Config>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
+    let schema_org_json = serde_json::to_string(&serde_json::json!({
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": &config.instancename,
+        "description": &config.description,
+        "url": &config.site_url,
+        "potentialAction": {
+            "@type": "SearchAction",
+            "target": {
+                "@type": "EntryPoint",
+                "urlTemplate": format!("{}/search?q={{search_term_string}}", config.site_url)
+            },
+            "query-input": "required name=search_term_string"
+        }
+    })).unwrap_or_default();
     let sidebar = generate_sidebar(&config, "home".to_owned());
     let common_headers = extract_common_headers(&headers);
     let template = HomeTemplate {
         config,
         sidebar,
         common_headers,
+        schema_org_json,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -227,6 +227,67 @@ async fn medium_in_list(
         is_cmaf = false;
     }
 
+    let upload_iso = chrono::DateTime::from_timestamp(m_upload, 0)
+        .map(|dt: chrono::DateTime<chrono::Utc>| dt.to_rfc3339())
+        .unwrap_or_default();
+    let schema_org_json = {
+        let v = match m_type.as_str() {
+            "video" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "VideoObject",
+                "name": m_name.clone(),
+                "thumbnailUrl": format!("{}/source/{}/thumbnail.jpg", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "contentUrl": format!("{}/m/{}/video-sm.mp4", config.site_url, medium_id),
+                "embedUrl": format!("{}/m/{}", config.site_url, medium_id),
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, m_owner)
+                }
+            }),
+            "audio" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "AudioObject",
+                "name": m_name.clone(),
+                "thumbnailUrl": format!("{}/source/{}/thumbnail.jpg", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "contentUrl": format!("{}/source/{}/audio.ogg", config.source_server_url, medium_id),
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, m_owner)
+                }
+            }),
+            "picture" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "ImageObject",
+                "name": m_name.clone(),
+                "contentUrl": format!("{}/source/{}/picture.avif", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, m_owner)
+                }
+            }),
+            "document_pdf" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "DigitalDocument",
+                "name": m_name.clone(),
+                "thumbnailUrl": format!("{}/source/{}/thumbnail.jpg", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, m_owner)
+                }
+            }),
+            _ => serde_json::json!({}),
+        };
+        serde_json::to_string(&v).unwrap_or_default()
+    };
+
     let sidebar = generate_sidebar(&config, "medium".to_owned());
     let template = MediumTemplate {
         sidebar,
@@ -245,6 +306,7 @@ async fn medium_in_list(
         medium_chapters_exist,
         medium_previews_exist,
         is_cmaf,
+        schema_org_json,
         config,
         common_headers,
         is_logged_in,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -39,6 +39,7 @@ struct ListPageTemplate {
     list: List,
     is_owner: bool,
     common_headers: CommonHeaders,
+    schema_org_json: String,
 }
 
 #[derive(Template)]
@@ -111,6 +112,17 @@ async fn list_page(
     }
 
     let common_headers = extract_common_headers(&headers);
+    let schema_org_json = serde_json::to_string(&serde_json::json!({
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        "name": &list.name,
+        "url": format!("{}/l/{}", config.site_url, list.id),
+        "author": {
+            "@type": "Person",
+            "identifier": &list.owner,
+            "url": format!("{}/u/{}", config.site_url, list.owner)
+        }
+    })).unwrap_or_default();
     let sidebar = generate_sidebar(&config, "list".to_owned());
     let template = ListPageTemplate {
         sidebar,
@@ -118,6 +130,7 @@ async fn list_page(
         list,
         is_owner,
         common_headers,
+        schema_org_json,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,7 @@ async fn main() {
 
     let has_tls = tls_cert.is_some();
     let app = Router::new()
+        .route("/robots.txt", get(robots_txt))
         .route("/sitemap.xml", get(sitemap_xml))
         .route("/", get(home))
         .route("/login", get(login))

--- a/src/medium.rs
+++ b/src/medium.rs
@@ -41,6 +41,7 @@ struct MediumTemplate {
     medium_chapters_exist: bool,
     medium_previews_exist: bool,
     is_cmaf: bool,
+    schema_org_json: String,
     config: Config,
     common_headers: CommonHeaders,
     is_logged_in: bool,
@@ -140,6 +141,67 @@ async fn medium(
         is_cmaf = false;
     }
 
+    let upload_iso = chrono::DateTime::from_timestamp(upload, 0)
+        .map(|dt: chrono::DateTime<chrono::Utc>| dt.to_rfc3339())
+        .unwrap_or_default();
+    let schema_org_json = {
+        let v = match media_type.as_str() {
+            "video" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "VideoObject",
+                "name": name.clone(),
+                "thumbnailUrl": format!("{}/source/{}/thumbnail.jpg", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "contentUrl": format!("{}/m/{}/video-sm.mp4", config.site_url, medium_id),
+                "embedUrl": format!("{}/m/{}", config.site_url, medium_id),
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, owner)
+                }
+            }),
+            "audio" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "AudioObject",
+                "name": name.clone(),
+                "thumbnailUrl": format!("{}/source/{}/thumbnail.jpg", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "contentUrl": format!("{}/source/{}/audio.ogg", config.source_server_url, medium_id),
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, owner)
+                }
+            }),
+            "picture" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "ImageObject",
+                "name": name.clone(),
+                "contentUrl": format!("{}/source/{}/picture.avif", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, owner)
+                }
+            }),
+            "document_pdf" => serde_json::json!({
+                "@context": "https://schema.org",
+                "@type": "DigitalDocument",
+                "name": name.clone(),
+                "thumbnailUrl": format!("{}/source/{}/thumbnail.jpg", config.source_server_url, medium_id),
+                "uploadDate": upload_iso,
+                "author": {
+                    "@type": "Person",
+                    "name": owner_name.clone(),
+                    "url": format!("{}/u/{}", config.site_url, owner)
+                }
+            }),
+            _ => serde_json::json!({}),
+        };
+        serde_json::to_string(&v).unwrap_or_default()
+    };
+
     let sidebar = generate_sidebar(&config, "medium".to_owned());
     let template = MediumTemplate {
         sidebar,
@@ -158,6 +220,7 @@ async fn medium(
         medium_chapters_exist,
         medium_previews_exist,
         is_cmaf,
+        schema_org_json,
         config,
         common_headers,
         is_logged_in,

--- a/src/search.rs
+++ b/src/search.rs
@@ -900,6 +900,7 @@ struct SearchTemplate {
     config: Config,
     common_headers: CommonHeaders,
     initial_query: String,
+    schema_org_json: String,
 }
 
 #[derive(Deserialize)]
@@ -913,6 +914,18 @@ async fn search(
     headers: HeaderMap,
     axum::extract::Query(params): axum::extract::Query<SearchQuery>,
 ) -> axum::response::Html<Vec<u8>> {
+    let schema_org_json = serde_json::to_string(&serde_json::json!({
+        "@context": "https://schema.org",
+        "@type": "SearchResultsPage",
+        "name": format!("Search - {}", config.instancename),
+        "description": &config.description,
+        "url": format!("{}/search", config.site_url),
+        "isPartOf": {
+            "@type": "WebSite",
+            "name": &config.instancename,
+            "url": &config.site_url
+        }
+    })).unwrap_or_default();
     let sidebar = generate_sidebar(&config, "search".to_owned());
     let common_headers = extract_common_headers(&headers);
     let initial_query = params.q.unwrap_or_default();
@@ -921,6 +934,7 @@ async fn search(
         config,
         common_headers,
         initial_query,
+        schema_org_json,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -1,3 +1,16 @@
+async fn robots_txt(Extension(config): Extension<Config>) -> Response {
+    let body = format!(
+        "User-agent: *\nAllow: /\n\nSitemap: {}/sitemap.xml\n",
+        config.site_url
+    );
+    (
+        axum::http::StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        body,
+    )
+        .into_response()
+}
+
 async fn sitemap_xml(Extension(mut redis): Extension<RedisConn>) -> Response {
     let cached: Option<String> = redis.get("cache:sitemap").await.unwrap_or(None);
 

--- a/src/trending.rs
+++ b/src/trending.rs
@@ -4,17 +4,31 @@ struct TrendingTemplate {
     sidebar: String,
     config: Config,
     common_headers: CommonHeaders,
+    schema_org_json: String,
 }
 async fn trending(
     Extension(config): Extension<Config>,
     headers: HeaderMap,
 ) -> axum::response::Html<Vec<u8>> {
+    let schema_org_json = serde_json::to_string(&serde_json::json!({
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": format!("Trending - {}", config.instancename),
+        "description": &config.description,
+        "url": format!("{}/trending", config.site_url),
+        "isPartOf": {
+            "@type": "WebSite",
+            "name": &config.instancename,
+            "url": &config.site_url
+        }
+    })).unwrap_or_default();
     let sidebar = generate_sidebar(&config, "trending".to_owned());
     let common_headers = extract_common_headers(&headers);
     let template = TrendingTemplate {
         sidebar,
         config,
         common_headers,
+        schema_org_json,
     };
     Html(minifi_html(template.render().unwrap()))
 }

--- a/templates/pages/channel.html
+++ b/templates/pages/channel.html
@@ -16,6 +16,7 @@
     <meta property="og:description" content="{{ config.description }}" />
     <meta property="og:image" content="{{ config.source_server_url }}/source/favicon.svg" />
     <meta property="og:site_name" content="{{ config.instancename }}" />
+    <script type="application/ld+json">{{ schema_org_json }}</script>
 </head>
 
 <body hx-ext="preload">

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -14,6 +14,7 @@
     <meta property="og:description" content="{{ config.description }}" />
     <meta property="og:image" content="{{ config.source_server_url }}/source/favicon.svg" />
     <meta property="og:site_name" content="{{ config.instancename }}" />
+    <script type="application/ld+json">{{ schema_org_json }}</script>
 </head>
 
 <body hx-ext="preload">

--- a/templates/pages/list.html
+++ b/templates/pages/list.html
@@ -11,6 +11,7 @@
         <meta property="og:description" content="{{ config.description }}" />
         <meta property="og:image" content="{{ config.source_server_url }}/source/favicon.svg" />
         <meta property="og:site_name" content="{{ config.instancename }}" />
+        <script type="application/ld+json">{{ schema_org_json }}</script>
     </head>
     <body hx-ext="preload">
         {{ sidebar }}

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -64,6 +64,8 @@
 
         <title>{{ medium_name }}</title>
 
+        <script type="application/ld+json">{{ schema_org_json }}</script>
+
         {% include "component-dependencies.html" %}
         {% include "component-dependencies-quill.html" %}
         {% include "component-dependencies-tomselect.html" %}

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -14,6 +14,7 @@
     <meta property="og:description" content="{{ config.description }}" />
     <meta property="og:image" content="{{ config.source_server_url }}/source/favicon.svg" />
     <meta property="og:site_name" content="{{ config.instancename }}" />
+    <script type="application/ld+json">{{ schema_org_json }}</script>
 </head>
 
 <body hx-ext="preload">

--- a/templates/pages/trending.html
+++ b/templates/pages/trending.html
@@ -14,6 +14,7 @@
     <meta property="og:description" content="{{ config.description }}" />
     <meta property="og:image" content="{{ config.source_server_url }}/source/favicon.svg" />
     <meta property="og:site_name" content="{{ config.instancename }}" />
+    <script type="application/ld+json">{{ schema_org_json }}</script>
 </head>
 
 <body hx-ext="preload">


### PR DESCRIPTION
## Summary
This PR adds Schema.org structured data (JSON-LD format) to multiple pages throughout the application to improve search engine optimization and rich snippet support. Each page now includes appropriate schema markup that describes its content to search engines.

## Key Changes

- **Added Schema.org JSON-LD markup** to the following pages:
  - Home page: `WebSite` schema with search action support
  - Search results: `SearchResultsPage` schema
  - Trending page: `CollectionPage` schema
  - User profiles/channels: `ProfilePage` schema with person details and follower count
  - Lists: `ItemList` schema with owner information
  - Media items (videos, audio, pictures, documents): Type-specific schemas (`VideoObject`, `AudioObject`, `ImageObject`, `DigitalDocument`) with upload dates, thumbnails, and author information

- **Added robots.txt endpoint** (`/robots.txt`) to provide search engine crawling directives and sitemap location

- **Updated templates** to include `<script type="application/ld+json">` tags containing the structured data (visible in medium.html template)

- **Added `schema_org_json` field** to all relevant template structs to pass the generated JSON-LD data to the rendering layer

## Implementation Details

- Schema generation uses `serde_json` to construct and serialize JSON objects
- Upload timestamps are converted to ISO 8601 format using `chrono::DateTime`
- Media schemas are generated based on media type (video, audio, picture, document_pdf) with appropriate Schema.org types
- All schema generation includes fallback to empty string on serialization errors using `.unwrap_or_default()`
- Author/owner information is included in schemas where applicable with proper URL formatting
- The robots.txt endpoint directs crawlers to the sitemap.xml location

https://claude.ai/code/session_01BMT2SEx6chpjzX5dnEP1g6