### PR TITLE
Fix timestamp conversion from milliseconds to seconds in history

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -103,8 +103,8 @@ async fn hx_history_inner(
                     _ => 0,
                 }).unwrap_or(0);
 
-            let visit_time = DateTime::from_timestamp_millis(*viewed_at)
-                .map(|dt| dt.with_timezone(&Local).format("%Y-%m-%d %H:%M").to_string());
+            let visit_time = DateTime::from_timestamp_secs(*viewed_at)
+                .map(|dt: DateTime<chrono::Utc>| dt.with_timezone(&Local).format("%Y-%m-%d %H:%M").to_string());
 
             media.push(Medium {
                 id,


### PR DESCRIPTION
## Summary
Fixed a timestamp conversion bug in the history module where milliseconds were being incorrectly interpreted as seconds.

## Key Changes
- Changed `DateTime::from_timestamp_millis()` to `DateTime::from_timestamp_secs()` to correctly interpret the `viewed_at` timestamp as seconds rather than milliseconds
- Added explicit type annotation `dt: DateTime<chrono::Utc>` to the closure parameter for clarity

## Details
The `viewed_at` value is stored in seconds, but the code was using `from_timestamp_millis()` which expects milliseconds. This would cause timestamps to be interpreted as approximately 1000x larger than their actual values, resulting in dates far in the future. The fix ensures the timestamp is correctly converted to a `DateTime` object before formatting it for display.

https://claude.ai/code/session_01CmgRJiwUXbsXzcXKBqgrVY