### PR TITLE
Migrate Three.js renderer to WebGPU and add 3D object icon support

### DIFF
--- a/templates/pages/hx-listitems.html
+++ b/templates/pages/hx-listitems.html
@@ -24,6 +24,8 @@
                             <i class="fa-solid fa-file-excel"></i>
                             {% else if item.type == "document_presentation" %}
                             <i class="fa-solid fa-file-powerpoint"></i>
+                            {% else if item.type == "object_3d" %}
+                            <i class="fa-solid fa-cubes"></i>
                             {% else %}
                             <i class="fa-solid fa-file"></i>
                             {% endif %}

--- a/templates/pages/hx-mediumcard.html
+++ b/templates/pages/hx-mediumcard.html
@@ -41,6 +41,8 @@
                             <i class="fa-solid fa-file-excel"></i>
                             {% else if item.type == "document_presentation" %}
                             <i class="fa-solid fa-file-powerpoint"></i>
+                            {% else if item.type == "object_3d" %}
+                            <i class="fa-solid fa-cubes"></i>
                             {% else %}
                             <i class="fa-solid fa-file"></i>
                             {% endif %}

--- a/templates/pages/hx-mediumlist.html
+++ b/templates/pages/hx-mediumlist.html
@@ -46,6 +46,8 @@
                         <i class="fa-solid fa-file-excel"></i>
                         {% else if item.type == "document_presentation" %}
                         <i class="fa-solid fa-file-powerpoint"></i>
+                        {% else if item.type == "object_3d" %}
+                        <i class="fa-solid fa-cubes"></i>
                         {% else %}
                         <i class="fa-solid fa-file"></i>
                         {% endif %}

--- a/templates/pages/hx-studio.html
+++ b/templates/pages/hx-studio.html
@@ -33,6 +33,8 @@
                             <i class="fa-solid fa-file-excel"></i>
                             {% else if medium.type == "document_presentation" %}
                             <i class="fa-solid fa-file-powerpoint"></i>
+                            {% else if medium.type == "object_3d" %}
+                            <i class="fa-solid fa-cubes"></i>
                             {% else %}
                             <i class="fa-solid fa-file"></i>
                             {% endif %}

--- a/templates/pages/medium.html
+++ b/templates/pages/medium.html
@@ -338,14 +338,17 @@
                         import * as THREE from 'three';
                         import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
                         import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+                        import WebGPURenderer from 'three/addons/renderers/WebGPURenderer.js';
 
+                        (async () => {
                         const container = document.getElementById('threejs-container');
                         const canvas = document.getElementById('threejs-canvas');
 
-                        const renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: true });
+                        const renderer = new WebGPURenderer({ canvas: canvas, antialias: true });
                         renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
                         renderer.outputColorSpace = THREE.SRGBColorSpace;
                         renderer.shadowMap.enabled = true;
+                        await renderer.init();
 
                         const scene = new THREE.Scene();
                         scene.background = new THREE.Color(0x0f0f1a);
@@ -419,15 +422,14 @@
                             }
                         );
 
-                        function animate() {
-                            requestAnimationFrame(animate);
+                        renderer.setAnimationLoop(() => {
                             controls.update();
                             renderer.render(scene, camera);
-                        }
-                        animate();
+                        });
 
                         const resizeObserver = new ResizeObserver(resizeRenderer);
                         resizeObserver.observe(container);
+                        })();
                         </script>
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Summary
This PR upgrades the Three.js 3D rendering implementation to use WebGPU instead of WebGL, and adds support for displaying 3D object file type icons across the UI.

## Key Changes
- **Renderer Migration**: Replaced `THREE.WebGLRenderer` with `WebGPURenderer` in the medium.html template
  - Added async initialization with `await renderer.init()` to properly set up the WebGPU renderer
  - Wrapped the initialization code in an async IIFE to support the async renderer setup
  - Replaced the custom `animate()` function with `renderer.setAnimationLoop()` for better WebGPU compatibility

- **3D Object Icon Support**: Added icon display for 3D object file types across all medium/item templates
  - Added `object_3d` type check in `hx-listitems.html`, `hx-mediumcard.html`, `hx-mediumlist.html`, and `hx-studio.html`
  - Uses Font Awesome `fa-cubes` icon to represent 3D objects

## Implementation Details
- The WebGPU renderer requires asynchronous initialization, necessitating the async IIFE wrapper
- The `setAnimationLoop()` method is the recommended approach for WebGPU renderer animation loops
- Icon additions follow the existing pattern used for other file types (spreadsheet, presentation, etc.)

https://claude.ai/code/session_016n1jYbqQm97AbrzFpF8PLB